### PR TITLE
feat: add pnpm to engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "build": "nx run-many --target=build",
     "storybook": "nx run @fiscozen/storybook:storybook"
   },
+  "engines": {
+    "pnpm": "^9.3.0"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
The lock (pnpm-lock.yaml) is version controlled, as it should.
Each of us handles the pnpm package installation independently on their machine, which is why it's missing from the root project's package. This is also a standard approach.
The problem is there's no trace of which pnpm version we should be using. Each pnpm version could generate a different lock, resulting in difficulty working with a common lock and issues like broken lock files.
This change "locks" the pnpm version at project level and in case of version mismatch, pnpm will fail.
More on that here: https://pnpm.io/package_json