### PR TITLE
LIB-597 fix(storybook): add missing medium font

### DIFF
--- a/apps/storybook/src/assets/main.css
+++ b/apps/storybook/src/assets/main.css
@@ -8,25 +8,30 @@ body {
 
 @font-face {
   font-family: Inter;
-  src: url('/fonts/Inter-Regular.ttf') format('truetype');
+  src: url('/fonts/Inter-Light.ttf') format('truetype');
+  font-weight: 300;
 }
+
 @font-face {
   font-family: Inter;
-  src: url('/fonts/Inter-Bold.ttf') format('truetype');
-  font-weight: bold;
+  src: url('/fonts/Inter-Regular.ttf') format('truetype');
+  font-weight: 400;
 }
+
+@font-face {
+  font-family: Inter;
+  src: url('/fonts/Inter-Medium.ttf') format('truetype');
+  font-weight: 500;
+}
+
 @font-face {
   font-family: Inter;
   src: url('/fonts/Inter-SemiBold.ttf') format('truetype');
   font-weight: 600;
 }
+
 @font-face {
   font-family: Inter;
   src: url('/fonts/Inter-Bold.ttf') format('truetype');
   font-weight: 700;
-}
-@font-face {
-  font-family: Inter;
-  src: url('/fonts/Inter-Light.ttf') format('truetype');
-  font-weight: 300;
 }


### PR DESCRIPTION
Jira: [LIB-597](https://fiscozen.atlassian.net/browse/LIB-597)

Adds missing medium font (`font-weight: 500)` to storybook.
Also removes redundant bold font, as `font-weight: bold` and `font-weight: 700` are equal.