### PR TITLE
feat: Infinite scrolling and minor fix

### DIFF
--- a/apps/storybook/src/stories/Select.stories.ts
+++ b/apps/storybook/src/stories/Select.stories.ts
@@ -115,3 +115,14 @@ export const SelectWithHundredsOfOptionsAndMaxHeight: SelectStory = {
     floatingPanelMaxHeight: '200px'
   }
 }
+
+export const OpenOnTop: SelectStory = {
+  ...Template,
+  args: {
+    ...Template.args,
+    position: 'top'
+  },
+  decorators: [() => ({
+    template: "<div style='padding-top:200px'><story/></div>"
+    })]
+}

--- a/apps/storybook/src/stories/Typeahead.stories.ts
+++ b/apps/storybook/src/stories/Typeahead.stories.ts
@@ -54,7 +54,21 @@ const Default: Story = {
   }
 }
 
+const hundredOptionsRepeated = Array.from({length: 100}, (_, i) => ({label: `option ${i % 3}`, value: `${i}`}))
+const HundredOptions: Story = {
+  ...Template,
+  args: {
+    selectProps: {
+      options: hundredOptionsRepeated,
+      isOpen:false
+    },
+    inputProps: {
+      label: 'This is a label',
+      placeholder: 'This is a placeholder'
+    }
+  }
+}
 
-export { Default }
+export { Default, HundredOptions }
 
 export default meta

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/composables",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Design System utility composables",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/composables/src/FzFloating.vue
+++ b/packages/composables/src/FzFloating.vue
@@ -77,7 +77,7 @@ const contentClass = computed(() => {
       <div
         ref="content"
         v-show="$slots.default && (!$slots.opener || ($slots.opener && isOpen))"
-        class="fz__floating__content bg-core-white fixed p-4 z-10"
+        class="fz__floating__content bg-core-white absolute p-4 z-10"
         :class="contentClass"
       >
         <slot :isOpen :floating></slot>

--- a/packages/composables/src/FzFloating.vue
+++ b/packages/composables/src/FzFloating.vue
@@ -59,6 +59,7 @@ const contentClass = computed(() => {
 
 <template>
   <div>
+    <slot name="opener-start"></slot>
     <div ref="opener" class="inline-flex">
       <slot name="opener" :isOpen :floating></slot>
     </div>

--- a/packages/composables/src/composables/useFloating.ts
+++ b/packages/composables/src/composables/useFloating.ts
@@ -254,7 +254,7 @@ export const useFloating = (
 
       safeElementDomRef.value.style.top = `${float.position.y}px`
       safeElementDomRef.value.style.left = `${float.position.x}px`
-      safeElementDomRef.value.style.position = 'fixed'
+      // safeElementDomRef.value.style.position = 'fixed'
       safeElementDomRef.value.style.display = 'flex'
 
       rect.value = safeElementDomRef.value.getBoundingClientRect()

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/select",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Design System Select component",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/select/src/FzSelect.vue
+++ b/packages/select/src/FzSelect.vue
@@ -3,6 +3,7 @@
     :position="position ?? 'bottom-start'"
     :isOpen
     class="flex flex-col gap-8 overflow-visible"
+    :teleport="teleport"
   >
     <template #opener-start>
       <label :class="['text-sm', computedLabelClass]">
@@ -85,6 +86,7 @@ import FzSelectOption from "./components/FzSelectOption.vue";
 const props = withDefaults(defineProps<FzSelectProps>(), {
   size: "md",
   optionsToShow: 25,
+  teleport: true
 });
 const model = defineModel({
   required: true,

--- a/packages/select/src/FzSelect.vue
+++ b/packages/select/src/FzSelect.vue
@@ -1,15 +1,17 @@
 <template>
   <FzFloating
-    position="bottom-start"
+    :position="position ?? 'bottom-start'"
     :isOpen
     class="flex flex-col gap-8 overflow-visible"
   >
+    <template #opener-start>
+      <label :class="['text-sm', computedLabelClass]">
+        {{ label }}{{ required ? " *" : "" }}
+      </label>
+    </template>
     <template #opener class="flex">
       <div class="w-full flex flex-col gap-8" ref="openerContainer">
         <slot name="opener" :handlePickerClick :isOpen>
-          <label :class="['text-sm', computedLabelClass]">
-            {{ label }}{{ required ? " *" : "" }}</label
-          >
           <button
             @click="handlePickerClick"
             test-id="fzselect-opener"
@@ -75,7 +77,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, nextTick, onMounted } from "vue";
-import { FzSelectProps } from "./types";
+import { FzSelectProps, FzSelectOptionsProps } from "./types";
 import { FzIcon } from "@fiscozen/icons";
 import { FzFloating, useClickOutside } from "@fiscozen/composables";
 import FzSelectOption from "./components/FzSelectOption.vue";
@@ -94,7 +96,7 @@ const containerRef = ref<HTMLElement>();
 const containerWidth = ref<string>("auto");
 const openerContainer = ref<HTMLElement>();
 const containerTopPosition = ref<number>(0);
-const visibleOptions = ref(props.options.slice(0, props.optionsToShow));
+const visibleOptions = ref<FzSelectOptionsProps[]>([]);
 const OPTIONS_HEIGHT = 20;
 const OPTIONS_BUFFER = 5;
 

--- a/packages/select/src/__test__/FzSelect.spec.ts
+++ b/packages/select/src/__test__/FzSelect.spec.ts
@@ -20,6 +20,7 @@ describe("FzSelect", () => {
         label: "Test Select",
         required: true,
         modelValue: "",
+        isOpen: false,
         size: "md",
         placeholder: "Select an option",
         options: [
@@ -38,6 +39,7 @@ describe("FzSelect", () => {
         label: "Test Select",
         required: true,
         modelValue: "",
+        isOpen: false,
         size: "md",
         placeholder: "Select an option",
         options: [
@@ -58,6 +60,7 @@ describe("FzSelect", () => {
         size: "md",
         placeholder: "Select an option",
         modelValue: "",
+        isOpen: false,
         options: [
           { value: "option1", label: "Option 1" },
           { value: "option2", label: "Option 2" },
@@ -81,6 +84,7 @@ describe("FzSelect", () => {
         size: "md",
         placeholder: "Select an option",
         modelValue: "",
+        isOpen: false,
         options: [
           { value: "option1", label: "Option 1" },
           { value: "option2", label: "Option 2" },
@@ -104,6 +108,7 @@ describe("FzSelect", () => {
         size: "md",
         placeholder: "Select an option",
         modelValue: "",
+        isOpen: false,
         options: [
           { value: "option1", label: "Option 1" },
           { value: "option2", label: "Option 2" },
@@ -126,6 +131,7 @@ describe("FzSelect", () => {
       props: {
         label: "Test Select",
         required: true,
+        isOpen: false,
         size: "md",
         placeholder: "Select an option",
         modelValue: "",
@@ -147,6 +153,7 @@ describe("FzSelect", () => {
         label: "Test Select",
         required: true,
         size: "md",
+        isOpen: false,
         placeholder: "Select an option",
         modelValue: "",
         options: [
@@ -160,5 +167,61 @@ describe("FzSelect", () => {
 
     await wrapper.vm.$nextTick();
     expect(wrapper.find("svg").classes()).toContain("fa-bell");
+  });
+
+  it("should render only the first 25 options", async () => {
+    const wrapper = mount(FzSelect, {
+      props: {
+        size: "md",
+        isOpen: false,
+        placeholder: "Select an option",
+        modelValue: "",
+        options: Array.from({ length: 100 }, (_, i) => ({
+          label: `option ${i % 3}`,
+          value: `${i}`,
+        })),
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+    wrapper.find('button[test-id="fzselect-opener"]').trigger("click");
+    expect(wrapper.findAll('button[test-id="fzselect-option"]').length).toBe(
+      25,
+    );
+  });
+
+  it("should render another 25 options when scrolling down", async () => {
+    const wrapper = mount(FzSelect, {
+      props: {
+        size: "md",
+        isOpen: false,
+        placeholder: "Select an option",
+        modelValue: "",
+        options: Array.from({ length: 100 }, (_, i) => ({
+          label: `option ${i % 3}`,
+          value: `${i}`,
+        })),
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+    wrapper.find('button[test-id="fzselect-opener"]').trigger("click");
+    expect(wrapper.findAll('button[test-id="fzselect-option"]').length).toBe(
+      25,
+    );
+
+    const container = wrapper.find(
+      '[test-id="fzselect-options-container"]',
+    ).element;
+    container.scrollTop = container.scrollHeight;
+    await wrapper
+      .find('[test-id="fzselect-options-container"]')
+      .trigger("scroll");
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findAll('button[test-id="fzselect-option"]').length).toBe(
+      50,
+    );
   });
 });

--- a/packages/select/src/components/FzSelectOption.vue
+++ b/packages/select/src/components/FzSelectOption.vue
@@ -1,6 +1,7 @@
 <template>
   <button
     :class="[staticClass, computedClass]"
+    test-id="fzselect-option"
     type="button"
     :title="option.label"
     @click="

--- a/packages/select/src/components/FzSelectOption.vue
+++ b/packages/select/src/components/FzSelectOption.vue
@@ -10,10 +10,9 @@
       }
     "
   >
-    <span
-      class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm"
-      >{{ option.label }}</span
-    >
+    <span class="flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{{
+      option.label
+    }}</span>
   </button>
 </template>
 
@@ -28,10 +27,17 @@ const props = defineProps<{
 }>();
 
 const staticClass =
-  "flex items-center text-left h-40 font-medium cursor-pointer py-6 px-12 rounded text-md";
+  "flex items-center text-left h-40 font-medium cursor-pointer py-6 px-12 rounded";
+
+const mappedClass = {
+  sm: "text-sm",
+  md: "text-md",
+  lg: "text-lg",
+};
 const computedClass = computed(() => [
   props.selectedValue === props.option.value
     ? "bg-background-alice-blue text-blue-500"
     : "bg-white hover:!bg-background-alice-blue text-core-black hover:text-blue-500",
+  mappedClass[props.size],
 ]);
 </script>

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -49,7 +49,11 @@ export interface FzSelectProps extends FzFloatingProps {
    * Set the max height of the floating panel
    */
   floatingPanelMaxHeight?: string;
-};
+  /**
+   * Size of the options to render each time in the floating panel
+   */
+  optionsToShow?: number;
+}
 
 export type FzSelectOptionsProps = {
   /**


### PR DESCRIPTION
I have made some improvements to problems that arose during one of our calls. 

Now FzSelect shows 25 options by default (but can be incremented via a specific prop), adding the other options as the user scrolls. Also, FzSelect should calculate the right width for the floating panel, even when passing an external opener

Added some style fixes and the ability to choose where to open the floating panel via position props.

Changed to `absolute` from `fixed` when `teleport=true` in `FzFloating`