### PR TITLE
LIB-728 fix(typeahead): v-model

### DIFF
--- a/apps/storybook/src/stories/Typeahead.stories.ts
+++ b/apps/storybook/src/stories/Typeahead.stories.ts
@@ -55,8 +55,70 @@ const Default: Story = {
     inputProps: {
       label: 'This is a label',
       placeholder: 'This is a placeholder'
-    }
+    },
   }
+}
+
+const Precompiled: Story = {
+  ...Template,
+  args: {
+    selectProps: {
+      options,
+      isOpen: false
+    },
+    inputProps: {
+      label: 'This is a label',
+      placeholder: 'This is a placeholder'
+    },
+  },
+  render: (args) => ({
+    components: {FzTypeahead},
+    setup() {
+      const model = ref("1");
+      return { model, args }
+    },
+    methods: {
+      onInputChange() {
+        console.log("Input changed");
+      }
+    },
+    template: `
+      <div class="h-[100vh] w-[100-vw] p-16">
+        <FzTypeahead v-bind="args" v-model="model" @fztypeahead:input="onInputChange"/>
+      </div>
+    `
+  }),
+}
+
+const PrecompiledObject: Story = {
+  ...Template,
+  args: {
+    selectProps: {
+      options,
+      isOpen: false
+    },
+    inputProps: {
+      label: 'This is a label',
+      placeholder: 'This is a placeholder'
+    },
+  },
+  render: (args) => ({
+    components: {FzTypeahead},
+    setup() {
+      const model = ref(options[0]);
+      return { model, args }
+    },
+    methods: {
+      onInputChange() {
+        console.log("Input changed");
+      }
+    },
+    template: `
+      <div class="h-[100vh] w-[100-vw] p-16">
+        <FzTypeahead v-bind="args" v-model.object="model" @fztypeahead:input="onInputChange"/>
+      </div>
+    `
+  }),
 }
 
 const NoDelayTime: Story = {
@@ -132,6 +194,6 @@ const RemoteLoading: Story = {
   }
 }
 
-export { Default, NoDelayTime, HundredOptions, RemoteLoading }
+export { Default, Precompiled, PrecompiledObject, NoDelayTime, HundredOptions, RemoteLoading }
 
 export default meta

--- a/packages/typeahead/package.json
+++ b/packages/typeahead/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/typeahead",
-  "version": "0.1.2-beta.3",
+  "version": "0.1.2",
   "description": "Design System Typeahead component",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/typeahead/package.json
+++ b/packages/typeahead/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/typeahead",
-  "version": "0.1.1",
+  "version": "0.1.2-beta.3",
   "description": "Design System Typeahead component",
   "scripts": {
     "coverage": "vitest run --coverage",


### PR DESCRIPTION
Jira: [LIB-728](https://fiscozen.atlassian.net/browse/LIB-728)

The v-model prop was not working because of an incorrect implementation. 
This was not immediately noticeable, but a hint was that any initial v-model state was not working.
Also, the selected option was not being highlighted hinting that FzSelect was not actually receiving the model. 
While I was at it, I've added the `object` modifier. 
This means that `v-model="..."` now works with the string value of an option by default.
If one wants to work with the entire object `{value,label}`, all they have to do is use `v-model.object="..."` instead.
Examples are provided in newly added stories Precompiled and PrecompiledObject.