### PR TITLE
LIB-794 feat(select): render label only if it exists

### DIFF
--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/select",
-  "version": "0.1.7",
+  "version": "0.1.8-conditional-label.1",
   "description": "Design System Select component",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/select",
-  "version": "0.1.8-conditional-label.1",
+  "version": "0.1.8",
   "description": "Design System Select component",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/select/src/FzSelect.vue
+++ b/packages/select/src/FzSelect.vue
@@ -8,7 +8,7 @@
     @fzfloating:setPosition="calculateMaxHeight"
   >
     <template #opener-start>
-      <label :class="['text-sm', computedLabelClass]">
+      <label v-if="label" :class="['text-sm', computedLabelClass]">
         {{ label }}{{ required ? " *" : "" }}
       </label>
     </template>


### PR DESCRIPTION
Jira: [LIB-794](https://fiscozen.atlassian.net/browse/LIB-794)

This feature makes it possible for the FzTypeahead to only render one label at a time.