### PR TITLE
FzTypeahead filteredOptions deprecated and debounce fix

### DIFF
--- a/apps/storybook/src/stories/Typeahead.stories.ts
+++ b/apps/storybook/src/stories/Typeahead.stories.ts
@@ -194,6 +194,48 @@ const RemoteLoading: Story = {
   }
 }
 
-export { Default, Precompiled, PrecompiledObject, NoDelayTime, HundredOptions, RemoteLoading }
+async function remoteCallback(text?: string) {
+  const res = await fetch(`https://dummyjson.com/users/search?q=${text}`)
+  const data = await res.json()
+
+  return data.users.map((user: any) => ({
+    label: user.firstName + ' ' + user.lastName,
+    value: user.id
+  }))
+}
+
+const RemoteLoadingWithRemoteFunction: Story = {
+  render: (args) => ({
+    components: {FzTypeahead},
+    setup() {
+      const text = ref();
+      return {
+        text,
+        args
+      }
+    },
+    methods: {
+    },
+    template: `
+      <div class="h-[100vh] w-[100-vw] p-16">
+        <FzTypeahead v-bind="args" v-model="text" @fztypeahead:input="onInputChange"/>
+      </div>
+    `
+  }),
+  args: {
+    inputProps: {
+      label: 'This is a label',
+      placeholder: 'This is a placeholder'
+    },
+    selectProps: {
+      isOpen: false,
+      options: []
+    },
+    remoteFn: remoteCallback
+  }
+
+}
+
+export { Default, Precompiled, PrecompiledObject, NoDelayTime, HundredOptions, RemoteLoading, RemoteLoadingWithRemoteFunction }
 
 export default meta

--- a/apps/storybook/src/stories/Typeahead.stories.ts
+++ b/apps/storybook/src/stories/Typeahead.stories.ts
@@ -194,17 +194,24 @@ const RemoteLoading: Story = {
   }
 }
 
-async function remoteCallback(text?: string) {
-  const res = await fetch(`https://dummyjson.com/users/search?q=${text}`)
-  const data = await res.json()
-
-  return data.users.map((user: any) => ({
-    label: user.firstName + ' ' + user.lastName,
-    value: user.id
-  }))
+function remoteCallback(this: typeof FzTypeahead, text?: string) {
+  if(!text) {
+    this.args.selectProps.options = []
+    return
+  }
+  
+  const asyncCall = async () => {
+    const res = await fetch(`https://dummyjson.com/users/search?q=${text}`)
+    const data = await res.json()
+    this.args.selectProps.options = data.users.map((user: any) => ({
+        label: user.firstName + ' ' + user.lastName,
+        value: user.id
+    }))
+  }
+  asyncCall()
 }
 
-const RemoteLoadingWithRemoteFunction: Story = {
+const RemoteLoadingWithAPICall: Story = {
   render: (args) => ({
     components: {FzTypeahead},
     setup() {
@@ -215,6 +222,7 @@ const RemoteLoadingWithRemoteFunction: Story = {
       }
     },
     methods: {
+      onInputChange: remoteCallback
     },
     template: `
       <div class="h-[100vh] w-[100-vw] p-16">
@@ -230,12 +238,11 @@ const RemoteLoadingWithRemoteFunction: Story = {
     selectProps: {
       isOpen: false,
       options: []
-    },
-    remoteFn: remoteCallback
+    }
   }
 
 }
 
-export { Default, Precompiled, PrecompiledObject, NoDelayTime, HundredOptions, RemoteLoading, RemoteLoadingWithRemoteFunction }
+export { Default, Precompiled, PrecompiledObject, NoDelayTime, HundredOptions, RemoteLoading, RemoteLoadingWithAPICall }
 
 export default meta

--- a/apps/storybook/src/stories/Typeahead.stories.ts
+++ b/apps/storybook/src/stories/Typeahead.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import { FzTypeahead, FzTypeaheadProps } from '@fiscozen/typeahead'
 import { ref } from 'vue'
+import { FzSelectOptionsProps } from '@fiscozen/select'
 
 const meta: Meta<typeof FzTypeahead> = {
   title: '@fiscozen/typeahead/FzTypeahead',
@@ -152,10 +153,10 @@ const HundredOptions: Story = {
 }
 
 const remoteOptions = [{label: 'Foo', value: 'foo'}, {label: 'Bar', value: 'bar'}, {label: 'Baz', value: 'baz'}, {label: 'Qux', value: 'qux'}];
-const filteredOptions = ref([]);
+const filteredOptions = ref<FzSelectOptionsProps[]>([]);
 
-async function remoteLoader(searchString) {
-  const result = await new Promise((resolve) => {
+async function remoteLoader(searchString: string) {
+  const result : FzSelectOptionsProps[] = await new Promise((resolve) => {
     setTimeout(() => {
       resolve(remoteOptions.filter((record) => {return record.value.toLowerCase().indexOf(searchString.toLowerCase()) >= 0}));
     }, 500);
@@ -188,9 +189,10 @@ const RemoteLoading: Story = {
       placeholder: 'This is a placeholder'
     },
     selectProps: {
+      options: [],
       isOpen: false
     },
-    filteredOptions: filteredOptions
+    filteredOptions: filteredOptions.value
   }
 }
 

--- a/apps/storybook/src/stories/Typeahead.stories.ts
+++ b/apps/storybook/src/stories/Typeahead.stories.ts
@@ -240,7 +240,8 @@ const RemoteLoadingWithAPICall: Story = {
     selectProps: {
       isOpen: false,
       options: []
-    }
+    },
+    filtrable: false
   }
 
 }

--- a/packages/typeahead/package.json
+++ b/packages/typeahead/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/typeahead",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Design System Typeahead component",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/typeahead/src/FzTypeahead.vue
+++ b/packages/typeahead/src/FzTypeahead.vue
@@ -28,7 +28,10 @@ import {
 import { FzInput } from "@fiscozen/input";
 import Fuse from "fuse.js";
 
-const props = withDefaults(defineProps<FzTypeaheadProps>(), { delayTime: 500 });
+const props = withDefaults(defineProps<FzTypeaheadProps>(), {
+  delayTime: 500,
+  filtrable: true,
+});
 const emit = defineEmits(["fztypeahead:input", "fztypeahead:select"]);
 
 const [model, modelModifiers] = defineModel<string, "object">({
@@ -105,6 +108,8 @@ const internalOptions = computed<FzSelectOptionsProps[]>(() => {
 
   if (props.filteredOptions) {
     res = props.filteredOptions;
+  } else if (!props.filtrable) {
+    res = props.selectProps.options;
   } else if (props.filterFn) {
     res = props.filterFn(inputValue.value);
   } else if (inputValue.value) {

--- a/packages/typeahead/src/FzTypeahead.vue
+++ b/packages/typeahead/src/FzTypeahead.vue
@@ -62,6 +62,11 @@ const safeInputContainer = computed(() => {
 
 onMounted(() => {
   updateModelDependencies(model.value);
+  if (props.filteredOptions) {
+    console.warn(
+      "filteredOptions prop is deprecated, use selectProps.options instead",
+    );
+  }
 });
 
 watch(model, (value) => {
@@ -90,34 +95,15 @@ const debounceHandleInput = debounce(
 
 function handleInput(val: string) {
   inputValue.value = val;
-  if (props.remoteFn) {
-    debounceRemoteFn(val);
-    return;
-  }
-
   const selected = internalOptions.value.find((opt) => opt.value === val);
   if (!selected) model.value = undefined;
   debounceHandleInput(val);
 }
 
-const remoteOptions = ref<FzSelectOptionsProps[] | undefined>(undefined);
-const debounceRemoteFn = debounce((search) => {
-  if (search === "") {
-    // TODO: when there will be a disabled option, here we should add it with a message like "No results found"
-    remoteOptions.value = [];
-    return;
-  }
-  props.remoteFn!(search).then((res) => {
-    remoteOptions.value = res;
-  });
-}, props.delayTime);
-
 const internalOptions = computed<FzSelectOptionsProps[]>(() => {
   let res = props.selectProps.options;
 
-  if (remoteOptions.value) {
-    res = remoteOptions.value;
-  } else if (props.filteredOptions) {
+  if (props.filteredOptions) {
     res = props.filteredOptions;
   } else if (props.filterFn) {
     res = props.filterFn(inputValue.value);

--- a/packages/typeahead/src/__tests__/debounce.spec.ts
+++ b/packages/typeahead/src/__tests__/debounce.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { debounce } from "../utils";
+
+describe("debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  it("should call the function after the specified timeout", () => {
+    const func = vi.fn();
+    const debouncedFunc = debounce(func, 300);
+
+    debouncedFunc();
+    expect(func).not.toHaveBeenCalled();
+
+    // Avanza il timer di 300ms
+    vi.advanceTimersByTime(300);
+    expect(func).toHaveBeenCalled();
+  });
+
+  it("should not call the function if called again within the timeout", () => {
+    const func = vi.fn();
+    const debouncedFunc = debounce(func, 300);
+
+    debouncedFunc();
+    debouncedFunc();
+    expect(func).not.toHaveBeenCalled();
+
+    // Avanza il timer di 300ms
+    vi.advanceTimersByTime(300);
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call the function with the correct arguments", () => {
+    const func = vi.fn();
+    const debouncedFunc = debounce(func, 300);
+
+    debouncedFunc("arg1", "arg2");
+    expect(func).not.toHaveBeenCalled();
+
+    // Avanza il timer di 300ms
+    vi.advanceTimersByTime(300);
+    expect(func).toHaveBeenCalledWith("arg1", "arg2");
+  });
+});

--- a/packages/typeahead/src/types.ts
+++ b/packages/typeahead/src/types.ts
@@ -6,6 +6,12 @@ interface FzTypeaheadProps {
   inputProps: FzInputProps;
   filteredOptions?: FzSelectOptionsProps[];
   filterFn?: (text?: string) => FzSelectOptionsProps[];
+  /**
+   * Callback function called after writing some text in the input. It will be called after 'delayTime'. It should return a primise of FzSelectOptionsProps[]
+   * @param text
+   * @returns Promise<FzSelectOptionsProps[]>
+   */
+  remoteFn?: (text: string) => Promise<FzSelectOptionsProps[]>;
   delayTime?: number;
 }
 

--- a/packages/typeahead/src/types.ts
+++ b/packages/typeahead/src/types.ts
@@ -4,14 +4,11 @@ import { FzInputProps } from "@fiscozen/input";
 interface FzTypeaheadProps {
   selectProps: FzSelectProps;
   inputProps: FzInputProps;
+  /**
+   * @deprecated use `selectProps.options` instead
+   */
   filteredOptions?: FzSelectOptionsProps[];
   filterFn?: (text?: string) => FzSelectOptionsProps[];
-  /**
-   * Callback function called after writing some text in the input. It will be called after 'delayTime'. It should return a primise of FzSelectOptionsProps[]
-   * @param text
-   * @returns Promise<FzSelectOptionsProps[]>
-   */
-  remoteFn?: (text: string) => Promise<FzSelectOptionsProps[]>;
   delayTime?: number;
 }
 

--- a/packages/typeahead/src/types.ts
+++ b/packages/typeahead/src/types.ts
@@ -5,6 +5,10 @@ interface FzTypeaheadProps {
   selectProps: FzSelectProps;
   inputProps: FzInputProps;
   /**
+   * If true, writing in the input will filter the options
+   */
+  filtrable?: boolean;
+  /**
    * @deprecated use `selectProps.options` instead
    */
   filteredOptions?: FzSelectOptionsProps[];


### PR DESCRIPTION
~~Motivation:~~

~~I believe that handling the private state of the FzTypeahead, specifically the 'filteredOptions,' is not the most appropriate approach. Instead, I have created a callback function that returns a promise of FzSelectOptions, which is invoked (with a debounce) each time a user types into the input. This allows the end user to avoid creating a ref within the components for the filtered options and simply link the API call (or a function that transforms the API call to the correct format) to the FzTypeahead.~~

Deprecated `filteredOptions` in favor of using only `options`. Added `filterable` prop to enable or disable the ability to filter options by typing in the input text (enabled by default).

Additionally, I have fixed the debounce issue: previously, it was called every time with a different timer id, leading to a queue of functions being created and launched. Now, the correct function should be launched just once.