### PR TITLE
LIB-1332 fix(dialog): closeModal can be called if modal is already closed

### DIFF
--- a/apps/storybook/src/stories/Dialog.stories.ts
+++ b/apps/storybook/src/stories/Dialog.stories.ts
@@ -29,6 +29,7 @@ const simpleDialog = (args: FzConfirmDialogProps) => ({
   template: `
     <div class="w-screen h-screen">
       <FzButton @click="dialog.show()">Open Modal</FzButton>
+      <FzButton @click="dialog.close()">Close modal</FzButton>
       <FzDialog v-bind="args" ref="dialog"><template #header>{{args.title}}</template></FzDialog>
     </div>
   `

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/dialog",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Design System Dialog component",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/dialog/src/FzDialog.vue
+++ b/packages/dialog/src/FzDialog.vue
@@ -64,7 +64,7 @@ const showModal = () => {
 };
 
 const closeModal = (returnVal?: string) => {
-  dialog.value!.close(returnVal);
+  dialog.value?.close(returnVal);
 };
 
 function handleModalClose() {


### PR DESCRIPTION
Jira: [LIB-1332](https://fiscozen.atlassian.net/browse/LIB-1332)

With the FzDialog now being rendered only when open, a new issue was introduced.
The exposed closeModal function expects the native dialog to always be rendered, as in the ref to always exist.
The issue presents itself when the closeModal function is called and the dialog is already closed. An exception is thrown.
In my opinion, closeModal should be idempotent.