### PR TITLE
fix: Floating position

### DIFF
--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/composables",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Design System utility composables",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/composables/package.json
+++ b/packages/composables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/composables",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Design System utility composables",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/composables/src/FzFloating.vue
+++ b/packages/composables/src/FzFloating.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { ref, useSlots, watch, toRef, computed, onBeforeUnmount, toRefs } from 'vue'
+import { ref, useSlots, watch, toRef, computed, onBeforeUnmount, toRefs, defineExpose } from 'vue'
 import { useFloating } from './composables'
 import { FzFloatingProps, FzUseFloatingArgs } from './types'
 
@@ -100,6 +100,10 @@ const contentClass = computed(() => {
   }
 
   return ['bg-core-white fixed p-4', props.contentClass]
+})
+
+defineExpose({
+  setPosition: floating.setPosition
 })
 </script>
 

--- a/packages/composables/src/composables/useFloating.ts
+++ b/packages/composables/src/composables/useFloating.ts
@@ -297,6 +297,9 @@ export const useFloating = (
         translateY = 0
       }
 
+      if(float.position.y < 0) float.position.y = 0
+      if(float.position.x < 0) float.position.x = 0
+
       safeElementDomRef.value.style.top = `${float.position.y}px`
       safeElementDomRef.value.style.left = `${float.position.x}px`
       safeElementDomRef.value.style.position = 'fixed'

--- a/packages/composables/src/composables/useFloating.ts
+++ b/packages/composables/src/composables/useFloating.ts
@@ -38,7 +38,7 @@ export const useFloating = (
   const floatObserver = ref(new IntersectionObserver(handleIntersect, options))
   const actualPosition = ref<FzFloatingPosition>()
 
-  const setPosition = () =>
+  const setPosition = (ignoreCallback: boolean = false) =>
     nextTick(() => {
       actualPosition.value = args.position ? args.position.value : 'auto'
       safeElementDomRef.value = (
@@ -297,9 +297,6 @@ export const useFloating = (
         translateY = 0
       }
 
-      if(float.position.y < 0) float.position.y = 0
-      if(float.position.x < 0) float.position.x = 0
-
       safeElementDomRef.value.style.top = `${float.position.y}px`
       safeElementDomRef.value.style.left = `${float.position.x}px`
       safeElementDomRef.value.style.position = 'fixed'
@@ -307,7 +304,7 @@ export const useFloating = (
 
       rect.value = safeElementDomRef.value.getBoundingClientRect()
 
-      if (args.callback?.value) {
+      if (args.callback?.value && !ignoreCallback) {
         args.callback.value(rect, openerRect, containerRect, position, actualPosition)
       }
     })

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/select",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Design System Select component",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/select/src/FzSelect.vue
+++ b/packages/select/src/FzSelect.vue
@@ -1,6 +1,7 @@
 <template>
   <FzFloating
     :position="position ?? 'auto-vertical-start'"
+    ref="floatingRef"
     :isOpen
     class="flex flex-col gap-8 overflow-visible"
     :teleport="teleport"
@@ -138,6 +139,7 @@ const visibleOptions = ref<FzSelectOptionsProps[]>([]);
 const OPTIONS_HEIGHT = 20;
 const OPTIONS_BUFFER = 5;
 const maxHeight = ref("");
+const floatingRef = ref<InstanceType<typeof FzFloating>>();
 
 const calculateMaxHeight = (
   rect: Ref<DOMRect | undefined>,
@@ -156,6 +158,7 @@ const calculateMaxHeight = (
     maxHeight.value = pos.includes("bottom")
       ? `calc(100vh - ${bottom}px - ${OPTIONS_BUFFER * OPTIONS_HEIGHT}px)`
       : `${top}px`;
+    floatingRef.value?.setPosition(true);
   });
 };
 


### PR DESCRIPTION
Jira: [LIB-1292](https://fiscozen.atlassian.net/browse/LIB-1292)

Sometimes, if an FzSelect with many options opens its dropdown upwards and the dropdown is larger than the screen, the dropdown's position might be calculated incorrectly, resulting in a negative Y value. This causes a space to appear between the FzSelect and the dropdown. This fix corrects this by setting any negative Y or X position to 0, so the dropdown stays on the screen.

After internal discussions, we decided it's best to expose `setPosition` from `FzFloating` and call it in `FzSelect` to recalculate the floating position when the container's maxHeight changes.

[LIB-1292]: https://fiscozen.atlassian.net/browse/LIB-1292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ