### PR TITLE
fix(LIB): Input event optionally disabled when focusing the typeahead

### DIFF
--- a/packages/typeahead/package.json
+++ b/packages/typeahead/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/typeahead",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Design System Typeahead component",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/typeahead/src/FzTypeahead.vue
+++ b/packages/typeahead/src/FzTypeahead.vue
@@ -90,7 +90,7 @@ const safeInputContainer = computed(() => {
 
 const handleInputFocus = (isOpen: boolean, handlePickerClick: () => void) => {
   if (!isOpen) handlePickerClick();
-  handleInput(inputValue.value, isOpen);
+  handleInput(inputValue.value, isOpen, props.disableEmitOnFocus);
 };
 
 onMounted(() => {
@@ -132,12 +132,12 @@ const debounceHandleInput = debounce(
   props.delayTime,
 );
 
-function handleInput(val: string, isOpen: boolean) {
+function handleInput(val: string, isOpen: boolean, disableEmitOnFocus = false) {
   dirtyInput.value = true;
   const selected = internalOptions.value?.find((opt) => opt.label === val);
   inputValue.value = val;
   if (!selected && !props.disableFreeInput) model.value = undefined;
-  debounceHandleInput(val);
+  if (!disableEmitOnFocus) debounceHandleInput(val);
   if (!isOpen) {
     fzselect.value.forceOpen();
   }
@@ -171,7 +171,7 @@ const internalOptions = computed<FzSelectOptionsProps[] | undefined>(() => {
 });
 
 const safeSelectOpts = computed<FzSelectProps>(() =>
-  reactive({
+  ({
     position: "bottom",
     ...props.selectProps,
     options: internalOptions.value || [],

--- a/packages/typeahead/src/types.ts
+++ b/packages/typeahead/src/types.ts
@@ -83,6 +83,10 @@ interface FzTypeaheadProps {
    * Disable free input (not selection)
    */
   disableFreeInput?: boolean;
+  /** 
+   * Disable the input emit on focus event
+   */
+  disableEmitOnFocus?: boolean;
 }
 
 export { FzTypeaheadProps };


### PR DESCRIPTION
Attualmente, l’evento `input` viene emesso anche quando si effettua il `focus` sulla typeahead. Sebbene contro-intuitivo, questo comportamento serve principalmente a:

- caricare le opzioni della select
- permettere la selezione di un valore tra queste opzioni.

Tuttavia, ci sono alcuni svantaggi, soprattutto quando ci si collega a un’API:

- a ogni focus viene effettuata una chiamata all’API,
- se sono presenti valori precaricati nelle opzioni, al focus viene inviata una richiesta vuota che sovrascrive i dati precaricati.

Credo che dobbiamo discuterne internamente per capire come muoverci. Per il momento, dato il tempo a disposizione, ho aggiunto una props che consente di disabilitare questo comportamento.