### PR TITLE
fix(HD-16309): handle tab key

### DIFF
--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/datepicker",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Design System Datepicker component",
   "scripts": {
     "coverage": "vitest run --coverage",

--- a/packages/datepicker/src/FzDatepicker.vue
+++ b/packages/datepicker/src/FzDatepicker.vue
@@ -18,12 +18,13 @@
     :model-value="modelValue"
   >
     <template
-      #dp-input="{ value, onBlur, onInput, onEnter, onPaste, closeMenu }"
+      #dp-input="{ value, onBlur, onInput, onEnter, onPaste, onTab, closeMenu }"
     >
       <FzInput
         @blur="onBlur"
         @update:modelValue="(e) => handleInputModelUpdate(onInput, e)"
         @keyup.enter="onEnter"
+        @keydown.tab="onTab"
         @paste="
           (e: ClipboardEvent) => handlePaste(onPaste, closeMenu, e, value)
         "


### PR DESCRIPTION
Jira: [HD-16309](https://fiscozen.atlassian.net/browse/HD-16309)

Carino che il tab faccia perdere il focus alla input, ma abbia bisogno di una gestione tutta sua per funzionare e non basti gestire l'onBlur.

Utilizzato onTab (di VuePicker) per gestire il tab.
Si sposta da una input all'altra e tiene il valore editato dall'utente.

[HD-16309]: https://fiscozen.atlassian.net/browse/HD-16309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ