### PR TITLE
Collapse 0.1.3

### DIFF
--- a/packages/collapse/package.json
+++ b/packages/collapse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiscozen/collapse",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Design System Icon Collapse Component",
   "scripts": {
     "coverage": "vitest run --coverage",


### PR DESCRIPTION
L'obiettivo della pr era quello di gestire la chiusura automatica di altri collapse all'apertura di uno tramite v-model. Il codice prodotto però nella versione 0.1.2 è risultato parecchio buggato in fase di utilizzo in app, per cui questa nuova versione serve per evitarne l'utilizzo. Non so se esiste un meccanismo per cancellare una determinata versione da npm.

Per ottenere il risultato che cercavo bastava usare l'attributo nativo name...