### PR TITLE
Feat/lib 2534 update fzinput

### DIFF
--- a/.changeset/input-emphasis-reset-on-user-input.md
+++ b/.changeset/input-emphasis-reset-on-user-input.md
@@ -1,0 +1,5 @@
+---
+"@fiscozen/input": minor
+---
+
+Add emphasis reset on user input: highlighted and aiReasoning states revert to default when the user types, while programmatic value changes preserve emphasis. Sparkles icon now uses solid variant.

--- a/apps/storybook/src/stories/form/Input.stories.ts
+++ b/apps/storybook/src/stories/form/Input.stories.ts
@@ -744,9 +744,8 @@ export const Highlighted: Story = {
   args: {
     ...Template.args,
     highlighted: true,
-    'onUpdate:modelValue': fn()
   },
-  play: async ({ args, canvasElement, step }) => {
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
     await step('Verify input is rendered and accessible', async () => {
@@ -760,16 +759,6 @@ export const Highlighted: Story = {
       const input = canvas.getByRole('textbox', { name: /Input Label/i })
       const container = input.closest('.fz-input > div')
       await expect(container).toHaveAttribute('tabindex', '0')
-    })
-
-    await step('Verify input is interactive', async () => {
-      const input = canvas.getByRole('textbox', { name: /Input Label/i })
-      await userEvent.clear(input)
-      const inputElement = input as HTMLInputElement
-      inputElement.value = 'Test value'
-      inputElement.dispatchEvent(new Event('input', { bubbles: true }))
-      await expect(input).toHaveValue('Test value')
-      await expect(args['onUpdate:modelValue']).toHaveBeenCalled()
     })
   }
 }
@@ -803,9 +792,8 @@ export const AIReasoning: Story = {
   args: {
     ...Template.args,
     aiReasoning: true,
-    'onUpdate:modelValue': fn()
   },
-  play: async ({ args, canvasElement, step }) => {
+  play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
 
     await step('Verify sparkles icon is auto-rendered with aria-hidden', async () => {
@@ -820,16 +808,6 @@ export const AIReasoning: Story = {
       const input = canvas.getByRole('textbox', { name: /Input Label/i })
       await expect(input).toHaveAttribute('aria-invalid', 'false')
       await expect(input).toHaveAttribute('aria-disabled', 'false')
-    })
-
-    await step('Verify input is interactive', async () => {
-      const input = canvas.getByRole('textbox', { name: /Input Label/i })
-      await userEvent.clear(input)
-      const inputElement = input as HTMLInputElement
-      inputElement.value = 'AI suggestion'
-      inputElement.dispatchEvent(new Event('input', { bubbles: true }))
-      await expect(input).toHaveValue('AI suggestion')
-      await expect(args['onUpdate:modelValue']).toHaveBeenCalled()
     })
   }
 }

--- a/apps/storybook/src/stories/form/Input.stories.ts
+++ b/apps/storybook/src/stories/form/Input.stories.ts
@@ -839,12 +839,14 @@ export const AIReasoningWithLeftIcon: Story = {
   args: {
     ...Template.args,
     aiReasoning: true,
-    leftIcon: 'search'
+    leftIcon: 'magnifying-glass'
   },
   play: async ({ canvasElement, step }) => {
     await step('Verify leftIcon overrides auto sparkles', async () => {
-      const searchIcon = canvasElement.querySelector('.fa-search')
-      await expect(searchIcon).toBeInTheDocument()
+      const leftIcon = canvasElement.querySelector(
+        '[class*="magnifying-glass"], [data-icon="magnifying-glass"]'
+      )
+      await expect(leftIcon).toBeInTheDocument()
 
       const sparklesIcon = canvasElement.querySelector('.fa-sparkles')
       await expect(sparklesIcon).not.toBeInTheDocument()

--- a/apps/storybook/src/stories/form/Input.stories.ts
+++ b/apps/storybook/src/stories/form/Input.stories.ts
@@ -27,7 +27,8 @@ const meta = {
         type: { summary: "'sm' | 'md' | 'lg'" },
         category: 'Deprecated'
       },
-      description: 'Deprecated: Use environment prop instead. Size values map to environments: sm/md → backoffice, lg → frontoffice'
+      description:
+        'Deprecated: Use environment prop instead. Size values map to environments: sm/md → backoffice, lg → frontoffice'
     },
     type: {
       options: ['text', 'password', 'email', 'number', 'tel', 'url'],
@@ -62,6 +63,16 @@ const meta = {
       options: all.map((icon) => icon.prefix) as string[],
       control: {
         type: 'select'
+      }
+    },
+    highlighted: {
+      control: {
+        type: 'boolean'
+      }
+    },
+    aiReasoning: {
+      control: {
+        type: 'boolean'
       }
     }
   },
@@ -124,7 +135,7 @@ export const Default: Story = {
       inputElement.value = 'Test value'
       inputElement.dispatchEvent(new Event('input', { bubbles: true }))
       await expect(input).toHaveValue('Test value')
-      
+
       // ROBUST CHECK: Verify the update:modelValue spy WAS called
       await expect(args['onUpdate:modelValue']).toHaveBeenCalled()
     })
@@ -134,7 +145,7 @@ export const Default: Story = {
       await expect(input).toHaveAttribute('aria-required', 'false')
       await expect(input).toHaveAttribute('aria-invalid', 'false')
       await expect(input).toHaveAttribute('aria-disabled', 'false')
-      
+
       // Verify aria-labelledby links to label
       const labelledBy = input.getAttribute('aria-labelledby')
       await expect(labelledBy).toBeTruthy()
@@ -184,10 +195,10 @@ export const Disabled: Story = {
 
     await step('Verify update:modelValue is NOT called when typing in disabled input', async () => {
       const input = canvas.getByRole('textbox', { name: /Input Label/i })
-      
+
       // Attempt to type in the disabled input
       await userEvent.type(input, 'Test')
-      
+
       // ROBUST CHECK: Verify the update:modelValue spy was NOT called
       await expect(args['onUpdate:modelValue']).not.toHaveBeenCalled()
     })
@@ -232,10 +243,10 @@ export const Readonly: Story = {
 
     await step('Verify update:modelValue is NOT called when typing in readonly input', async () => {
       const input = canvas.getByRole('textbox', { name: /Input Label/i })
-      
+
       // Attempt to type in the readonly input
       await userEvent.type(input, 'New text')
-      
+
       // ROBUST CHECK: Verify the update:modelValue spy was NOT called
       await expect(args['onUpdate:modelValue']).not.toHaveBeenCalled()
     })
@@ -725,6 +736,221 @@ export const FloatingLabelEmpty: Story = {
     if (floatingPlaceholderFocused) {
       await expect(floatingPlaceholderFocused.textContent).toBe('Enter your email')
     }
+  }
+}
+
+export const Highlighted: Story = {
+  ...Template,
+  args: {
+    ...Template.args,
+    highlighted: true,
+    'onUpdate:modelValue': fn()
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify input is rendered and accessible', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      await expect(input).toBeInTheDocument()
+      await expect(input).toHaveAttribute('aria-invalid', 'false')
+      await expect(input).toHaveAttribute('aria-disabled', 'false')
+    })
+
+    await step('Verify container is keyboard accessible', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      const container = input.closest('.fz-input > div')
+      await expect(container).toHaveAttribute('tabindex', '0')
+    })
+
+    await step('Verify input is interactive', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      await userEvent.clear(input)
+      const inputElement = input as HTMLInputElement
+      inputElement.value = 'Test value'
+      inputElement.dispatchEvent(new Event('input', { bubbles: true }))
+      await expect(input).toHaveValue('Test value')
+      await expect(args['onUpdate:modelValue']).toHaveBeenCalled()
+    })
+  }
+}
+
+export const HighlightedBackoffice: Story = {
+  ...Template,
+  args: {
+    ...Template.args,
+    highlighted: true,
+    environment: 'backoffice'
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify highlighted input renders with backoffice environment', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      await expect(input).toBeInTheDocument()
+      await expect(input).toHaveAttribute('aria-invalid', 'false')
+    })
+
+    await step('Verify container is keyboard accessible', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      const container = input.closest('.fz-input > div')
+      await expect(container).toHaveAttribute('tabindex', '0')
+    })
+  }
+}
+
+export const AIReasoning: Story = {
+  ...Template,
+  args: {
+    ...Template.args,
+    aiReasoning: true,
+    'onUpdate:modelValue': fn()
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify sparkles icon is auto-rendered with aria-hidden', async () => {
+      const sparklesIcon = canvasElement.querySelector('.fa-sparkles')
+      await expect(sparklesIcon).toBeInTheDocument()
+
+      const iconWrapper = sparklesIcon?.closest('[aria-hidden="true"]')
+      await expect(iconWrapper).toBeInTheDocument()
+    })
+
+    await step('Verify input is accessible', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      await expect(input).toHaveAttribute('aria-invalid', 'false')
+      await expect(input).toHaveAttribute('aria-disabled', 'false')
+    })
+
+    await step('Verify input is interactive', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      await userEvent.clear(input)
+      const inputElement = input as HTMLInputElement
+      inputElement.value = 'AI suggestion'
+      inputElement.dispatchEvent(new Event('input', { bubbles: true }))
+      await expect(input).toHaveValue('AI suggestion')
+      await expect(args['onUpdate:modelValue']).toHaveBeenCalled()
+    })
+  }
+}
+
+export const AIReasoningWithLeftIcon: Story = {
+  ...Template,
+  args: {
+    ...Template.args,
+    aiReasoning: true,
+    leftIcon: 'search'
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Verify leftIcon overrides auto sparkles', async () => {
+      const searchIcon = canvasElement.querySelector('.fa-search')
+      await expect(searchIcon).toBeInTheDocument()
+
+      const sparklesIcon = canvasElement.querySelector('.fa-sparkles')
+      await expect(sparklesIcon).not.toBeInTheDocument()
+    })
+
+    await step('Verify input is accessible', async () => {
+      const canvas = within(canvasElement)
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      await expect(input).toBeInTheDocument()
+      await expect(input).toHaveAttribute('aria-invalid', 'false')
+    })
+  }
+}
+
+export const HighlightedError: Story = {
+  ...Template,
+  render: (args) => ({
+    components: { FzInput },
+    setup() {
+      const modelValue = ref(args.modelValue || '')
+      return { args, modelValue }
+    },
+    template: `
+      <FzInput v-bind="args" v-model="modelValue">
+        <template #errorMessage>This field has an error</template>
+      </FzInput>
+    `
+  }),
+  args: {
+    ...Template.args,
+    highlighted: true,
+    error: true
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify error state takes priority via ARIA', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      await expect(input).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    await step('Verify error message is displayed', async () => {
+      const errorMessage = canvas.getByText('This field has an error')
+      await expect(errorMessage).toBeVisible()
+    })
+
+    await step('Verify error message is linked via aria-describedby', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      const describedBy = input.getAttribute('aria-describedby')
+      await expect(describedBy).toBeTruthy()
+      if (describedBy) {
+        const errorElement = canvasElement.querySelector(`#${describedBy}`)
+        await expect(errorElement).toBeInTheDocument()
+      }
+    })
+  }
+}
+
+export const HighlightedDisabled: Story = {
+  ...Template,
+  args: {
+    ...Template.args,
+    highlighted: true,
+    disabled: true
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify disabled state takes priority', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      await expect(input).toBeDisabled()
+      await expect(input).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    await step('Verify container is not keyboard accessible when disabled', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      const container = input.closest('.fz-input > div')
+      await expect(container).not.toHaveAttribute('tabindex')
+    })
+  }
+}
+
+export const AIReasoningFloatingLabel: Story = {
+  ...Template,
+  args: {
+    ...Template.args,
+    aiReasoning: true,
+    variant: 'floating-label',
+    placeholder: 'AI-generated suggestion'
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify sparkles icon is rendered with aria-hidden', async () => {
+      const sparklesIcon = canvasElement.querySelector('.fa-sparkles')
+      await expect(sparklesIcon).toBeInTheDocument()
+
+      const iconWrapper = sparklesIcon?.closest('[aria-hidden="true"]')
+      await expect(iconWrapper).toBeInTheDocument()
+    })
+
+    await step('Verify input is accessible with floating label', async () => {
+      const input = canvas.getByRole('textbox', { name: /Input Label/i })
+      await expect(input).toBeInTheDocument()
+      await expect(input).toHaveAttribute('aria-invalid', 'false')
+    })
   }
 }
 

--- a/packages/input/src/FzInput.vue
+++ b/packages/input/src/FzInput.vue
@@ -27,6 +27,8 @@ const props = withDefaults(defineProps<FzInputProps>(), {
   variant: "normal",
   environment: "frontoffice",
   autocomplete: false,
+  highlighted: false,
+  aiReasoning: false,
 });
 
 defineOptions({
@@ -306,6 +308,15 @@ const isReadonlyOrDisabled = computed(
 );
 
 /**
+ * Computed class for the auto-rendered AI sparkles icon.
+ * Muted when the input is in error, disabled, or readonly state.
+ */
+const aiIconClass = computed(() => {
+  if (isReadonlyOrDisabled.value || props.error) return "text-grey-300";
+  return "text-purple-600";
+});
+
+/**
  * Determines if right icon is clickable (not rendered as button)
  */
 const isRightIconClickable = computed(
@@ -384,6 +395,13 @@ defineExpose({
                   handleIconKeydown(e, 'fzinput:left-icon-click')
               : undefined
           "
+        />
+        <FzIcon
+          v-else-if="aiReasoning"
+          name="sparkles"
+          size="md"
+          aria-hidden="true"
+          :class="aiIconClass"
         />
       </slot>
       <div class="flex flex-col justify-around min-w-0 grow">

--- a/packages/input/src/FzInput.vue
+++ b/packages/input/src/FzInput.vue
@@ -119,6 +119,46 @@ const inputRef: Ref<HTMLInputElement | null> = ref(null);
 const uniqueId = generateInputId();
 const isFocused = ref(false);
 
+/**
+ * Internal visual state for emphasis props.
+ * These track the effective visual state which can differ from props when
+ * the user types into a highlighted/aiReasoning input (user input resets emphasis).
+ * Programmatic value changes (via v-model) do not affect these states.
+ */
+const effectiveHighlighted = ref(props.highlighted);
+const effectiveAiReasoning = ref(props.aiReasoning);
+
+watch(
+  () => props.highlighted,
+  (val) => {
+    effectiveHighlighted.value = val;
+  },
+);
+watch(
+  () => props.aiReasoning,
+  (val) => {
+    effectiveAiReasoning.value = val;
+  },
+);
+
+/**
+ * Resets visual emphasis (highlighted/aiReasoning) when user physically types.
+ * Only triggered by native input events (user interaction), not programmatic v-model updates.
+ * Emits update events so parents using v-model:highlighted / v-model:aiReasoning stay in sync.
+ */
+const handleUserInput = () => {
+  if (effectiveHighlighted.value) {
+    effectiveHighlighted.value = false;
+    emit("update:highlighted", false);
+  }
+  if (effectiveAiReasoning.value) {
+    effectiveAiReasoning.value = false;
+    emit("update:aiReasoning", false);
+  }
+};
+
+const propsRefs = toRefs(props);
+
 const {
   staticContainerClass,
   computedContainerClass,
@@ -129,7 +169,11 @@ const {
   containerWidth,
   showNormalPlaceholder,
 } = useInputStyle(
-  toRefs(props),
+  {
+    ...propsRefs,
+    highlighted: effectiveHighlighted,
+    aiReasoning: effectiveAiReasoning,
+  },
   containerRef,
   model,
   effectiveEnvironment,
@@ -187,6 +231,8 @@ const emit = defineEmits<{
   "fzinput:left-icon-click": [];
   "fzinput:right-icon-click": [];
   "fzinput:second-right-icon-click": [];
+  "update:highlighted": [value: boolean];
+  "update:aiReasoning": [value: boolean];
 }>();
 
 /**
@@ -397,8 +443,9 @@ defineExpose({
           "
         />
         <FzIcon
-          v-else-if="aiReasoning"
+          v-else-if="effectiveAiReasoning"
           name="sparkles"
+          variant="fas"
           size="md"
           aria-hidden="true"
           :class="aiIconClass"
@@ -430,6 +477,7 @@ defineExpose({
           :aria-labelledby="ariaLabelledBy"
           :aria-describedby="ariaDescribedBy"
           v-bind="inputAttrs"
+          @input="handleUserInput"
           @blur="
             (e) => {
               isFocused = false;

--- a/packages/input/src/__tests__/FzInput.spec.ts
+++ b/packages/input/src/__tests__/FzInput.spec.ts
@@ -1,1109 +1,1499 @@
-import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
-import { FzInput } from '..'
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { FzInput } from "..";
 
-const NUMBER_OF_INPUTS = 1000
+const NUMBER_OF_INPUTS = 1000;
 
-describe('FzInput', () => {
-  describe('Rendering', () => {
-    it('renders label', async () => {
+describe("FzInput", () => {
+  describe("Rendering", () => {
+    it("renders label", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
+          label: "Label",
         },
         slots: {},
-      })
+      });
 
-      expect(wrapper.text()).toContain('Label')
-    })
+      expect(wrapper.text()).toContain("Label");
+    });
 
-    it('renders leftIcon', async () => {
+    it("renders leftIcon", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          leftIcon: 'calendar-lines',
+          label: "Label",
+          leftIcon: "calendar-lines",
         },
         slots: {},
-      })
+      });
 
-      expect(wrapper.find('.fa-calendar-lines')).toBeTruthy()
-    })
+      expect(wrapper.find(".fa-calendar-lines")).toBeTruthy();
+    });
 
-    it('renders rightIcon', async () => {
+    it("renders rightIcon", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          rightIcon: 'credit-card',
+          label: "Label",
+          rightIcon: "credit-card",
         },
         slots: {},
-      })
+      });
 
-      expect(wrapper.find('.fa-credit-card')).toBeTruthy()
-    })
+      expect(wrapper.find(".fa-credit-card")).toBeTruthy();
+    });
 
-    it('renders helpText', async () => {
+    it("renders helpText", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
+          label: "Label",
         },
         slots: {
-          helpText: 'This is a helper text',
+          helpText: "This is a helper text",
         },
-      })
+      });
 
-      await wrapper.vm.$nextTick()
-      expect(wrapper.text()).toContain('This is a helper text')
-    })
+      await wrapper.vm.$nextTick();
+      expect(wrapper.text()).toContain("This is a helper text");
+    });
 
-    it('renders errorMessage', async () => {
+    it("renders errorMessage", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
+          label: "Label",
           error: true,
         },
         slots: {
-          errorMessage: 'This is an error message',
+          errorMessage: "This is an error message",
         },
-      })
+      });
 
-      await wrapper.vm.$nextTick()
-      expect(wrapper.text()).toContain('This is an error message')
-    })
-  })
+      await wrapper.vm.$nextTick();
+      expect(wrapper.text()).toContain("This is an error message");
+    });
+  });
 
-  describe('Input types', () => {
-    it('renders email type', async () => {
+  describe("Input types", () => {
+    it("renders email type", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          type: 'email',
-        },
-        slots: {},
-      })
-
-      expect(wrapper.find('input').attributes('type')).toBe('email')
-    })
-
-    it('renders tel type', async () => {
-      const wrapper = mount(FzInput, {
-        props: {
-          label: 'Label',
-          type: 'tel',
+          label: "Label",
+          type: "email",
         },
         slots: {},
-      })
+      });
 
-      expect(wrapper.find('input').attributes('type')).toBe('tel')
-    })
+      expect(wrapper.find("input").attributes("type")).toBe("email");
+    });
 
-    it('renders password type', async () => {
+    it("renders tel type", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          type: 'password',
+          label: "Label",
+          type: "tel",
         },
         slots: {},
-      })
+      });
 
-      expect(wrapper.find('input').attributes('type')).toBe('password')
-    })
-  })
+      expect(wrapper.find("input").attributes("type")).toBe("tel");
+    });
 
-  describe('Input states', () => {
-    it('renders disabled', async () => {
+    it("renders password type", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
+          label: "Label",
+          type: "password",
+        },
+        slots: {},
+      });
+
+      expect(wrapper.find("input").attributes("type")).toBe("password");
+    });
+  });
+
+  describe("Input states", () => {
+    it("renders disabled", async () => {
+      const wrapper = mount(FzInput, {
+        props: {
+          label: "Label",
           disabled: true,
         },
         slots: {},
-      })
+      });
 
-      expect(wrapper.find('input').attributes('disabled')).toBe('')
-    })
+      expect(wrapper.find("input").attributes("disabled")).toBe("");
+    });
 
-    it('renders required', async () => {
+    it("renders required", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
+          label: "Label",
           required: true,
         },
         slots: {},
-      })
+      });
 
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      expect(wrapper.find('input').attributes('required')).toBe('')
-      expect(wrapper.text()).toContain('*')
-    })
+      expect(wrapper.find("input").attributes("required")).toBe("");
+      expect(wrapper.text()).toContain("*");
+    });
 
     it('applies autocomplete="off" by default', async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
+          label: "Label",
         },
         slots: {},
-      })
+      });
 
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      expect(wrapper.find('input').attributes('autocomplete')).toBe('off')
-    })
+      expect(wrapper.find("input").attributes("autocomplete")).toBe("off");
+    });
 
     it('applies autocomplete="off" when autocomplete is false', async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
+          label: "Label",
           autocomplete: false,
         },
         slots: {},
-      })
+      });
 
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      expect(wrapper.find('input').attributes('autocomplete')).toBe('off')
-    })
+      expect(wrapper.find("input").attributes("autocomplete")).toBe("off");
+    });
 
     it('applies autocomplete="on" when autocomplete is true', async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
+          label: "Label",
           autocomplete: true,
         },
         slots: {},
-      })
+      });
 
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      expect(wrapper.find('input').attributes('autocomplete')).toBe('on')
-    })
-  })
+      expect(wrapper.find("input").attributes("autocomplete")).toBe("on");
+    });
+  });
 
-  describe('Events', () => {
-    it('emits fzinput:right-icon-click event', async () => {
+  describe("Events", () => {
+    it("emits fzinput:right-icon-click event", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          rightIcon: 'eye',
+          label: "Label",
+          rightIcon: "eye",
         },
         slots: {},
-      })
+      });
 
-      await wrapper.find('.fa-eye').trigger('click')
+      await wrapper.find(".fa-eye").trigger("click");
 
-      expect(wrapper.emitted('fzinput:right-icon-click')).toBeTruthy()
-    })
+      expect(wrapper.emitted("fzinput:right-icon-click")).toBeTruthy();
+    });
 
-    it('emits fzinput:left-icon-click event', async () => {
+    it("emits fzinput:left-icon-click event", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          leftIcon: 'eye',
+          label: "Label",
+          leftIcon: "eye",
         },
         slots: {},
-      })
+      });
 
-      await wrapper.find('.fa-eye').trigger('click')
+      await wrapper.find(".fa-eye").trigger("click");
 
-      expect(wrapper.emitted('fzinput:left-icon-click')).toBeTruthy()
-    })
+      expect(wrapper.emitted("fzinput:left-icon-click")).toBeTruthy();
+    });
 
-    it('does not emit fzinput:right-icon-click event when disabled', async () => {
+    it("does not emit fzinput:right-icon-click event when disabled", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          rightIcon: 'eye',
+          label: "Label",
+          rightIcon: "eye",
           disabled: true,
         },
         slots: {},
-      })
+      });
 
-      await wrapper.find('.fa-eye').trigger('click')
+      await wrapper.find(".fa-eye").trigger("click");
 
-      expect(wrapper.emitted('fzinput:right-icon-click')).toBeFalsy()
-    })
+      expect(wrapper.emitted("fzinput:right-icon-click")).toBeFalsy();
+    });
 
-    it('does not emit fzinput:right-icon-click event when readonly', async () => {
+    it("does not emit fzinput:right-icon-click event when readonly", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          rightIcon: 'eye',
+          label: "Label",
+          rightIcon: "eye",
           readonly: true,
         },
         slots: {},
-      })
+      });
 
-      await wrapper.find('.fa-eye').trigger('click')
+      await wrapper.find(".fa-eye").trigger("click");
 
-      expect(wrapper.emitted('fzinput:right-icon-click')).toBeFalsy()
-    })
+      expect(wrapper.emitted("fzinput:right-icon-click")).toBeFalsy();
+    });
 
-    it('does not emit fzinput:left-icon-click event when disabled', async () => {
+    it("does not emit fzinput:left-icon-click event when disabled", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          leftIcon: 'eye',
+          label: "Label",
+          leftIcon: "eye",
           disabled: true,
         },
         slots: {},
-      })
+      });
 
-      await wrapper.find('.fa-eye').trigger('click')
+      await wrapper.find(".fa-eye").trigger("click");
 
-      expect(wrapper.emitted('fzinput:left-icon-click')).toBeFalsy()
-    })
+      expect(wrapper.emitted("fzinput:left-icon-click")).toBeFalsy();
+    });
 
-    it('does not emit fzinput:left-icon-click event when readonly', async () => {
+    it("does not emit fzinput:left-icon-click event when readonly", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          leftIcon: 'eye',
+          label: "Label",
+          leftIcon: "eye",
           readonly: true,
         },
         slots: {},
-      })
+      });
 
-      await wrapper.find('.fa-eye').trigger('click')
+      await wrapper.find(".fa-eye").trigger("click");
 
-      expect(wrapper.emitted('fzinput:left-icon-click')).toBeFalsy()
-    })
+      expect(wrapper.emitted("fzinput:left-icon-click")).toBeFalsy();
+    });
 
-    it('does not emit fzinput:second-right-icon-click event when disabled', async () => {
+    it("does not emit fzinput:second-right-icon-click event when disabled", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          secondRightIcon: 'eye',
+          label: "Label",
+          secondRightIcon: "eye",
           disabled: true,
         },
         slots: {},
-      })
+      });
 
-      await wrapper.find('.fa-eye').trigger('click')
+      await wrapper.find(".fa-eye").trigger("click");
 
-      expect(wrapper.emitted('fzinput:second-right-icon-click')).toBeFalsy()
-    })
+      expect(wrapper.emitted("fzinput:second-right-icon-click")).toBeFalsy();
+    });
 
-    it('does not emit fzinput:second-right-icon-click event when readonly', async () => {
+    it("does not emit fzinput:second-right-icon-click event when readonly", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          secondRightIcon: 'eye',
+          label: "Label",
+          secondRightIcon: "eye",
           readonly: true,
         },
         slots: {},
-      })
+      });
 
-      await wrapper.find('.fa-eye').trigger('click')
+      await wrapper.find(".fa-eye").trigger("click");
 
-      expect(wrapper.emitted('fzinput:second-right-icon-click')).toBeFalsy()
-    })
+      expect(wrapper.emitted("fzinput:second-right-icon-click")).toBeFalsy();
+    });
 
-    it('does not emit fzinput:right-icon-click event when disabled and rightIconButton is true', async () => {
+    it("does not emit fzinput:right-icon-click event when disabled and rightIconButton is true", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          rightIcon: 'eye',
+          label: "Label",
+          rightIcon: "eye",
           rightIconButton: true,
           disabled: true,
         },
         slots: {},
-      })
+      });
 
-      const button = wrapper.findComponent({ name: 'FzIconButton' })
-      await button.trigger('click')
+      const button = wrapper.findComponent({ name: "FzIconButton" });
+      await button.trigger("click");
 
-      expect(wrapper.emitted('fzinput:right-icon-click')).toBeFalsy()
-    })
+      expect(wrapper.emitted("fzinput:right-icon-click")).toBeFalsy();
+    });
 
-    it('does not emit fzinput:second-right-icon-click event when disabled and secondRightIconButton is true', async () => {
+    it("does not emit fzinput:second-right-icon-click event when disabled and secondRightIconButton is true", async () => {
       const wrapper = mount(FzInput, {
         props: {
-          label: 'Label',
-          secondRightIcon: 'eye',
+          label: "Label",
+          secondRightIcon: "eye",
           secondRightIconButton: true,
           disabled: true,
         },
         slots: {},
-      })
+      });
 
-      const buttons = wrapper.findAllComponents({ name: 'FzIconButton' })
-      await buttons[0].trigger('click')
+      const buttons = wrapper.findAllComponents({ name: "FzIconButton" });
+      await buttons[0].trigger("click");
 
-      expect(wrapper.emitted('fzinput:second-right-icon-click')).toBeFalsy()
-    })
-  })
+      expect(wrapper.emitted("fzinput:second-right-icon-click")).toBeFalsy();
+    });
+  });
 
-  describe('Accessibility', () => {
-    describe('Input ARIA attributes', () => {
-      it('applies aria-required when required is true', async () => {
+  describe("Accessibility", () => {
+    describe("Input ARIA attributes", () => {
+      it("applies aria-required when required is true", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             required: true,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        expect(input.getAttribute('aria-required')).toBe('true')
-      })
+        const input = wrapper.find("input").element as HTMLInputElement;
+        expect(input.getAttribute("aria-required")).toBe("true");
+      });
 
       it('applies aria-required="false" when required is false', async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             required: false,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        expect(input.getAttribute('aria-required')).toBe('false')
-      })
+        const input = wrapper.find("input").element as HTMLInputElement;
+        expect(input.getAttribute("aria-required")).toBe("false");
+      });
 
-      it('applies aria-invalid when error is true', async () => {
+      it("applies aria-invalid when error is true", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             error: true,
           },
           slots: {
-            errorMessage: 'Error message',
+            errorMessage: "Error message",
           },
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        expect(input.getAttribute('aria-invalid')).toBe('true')
-      })
+        const input = wrapper.find("input").element as HTMLInputElement;
+        expect(input.getAttribute("aria-invalid")).toBe("true");
+      });
 
       it('applies aria-invalid="false" when error is false', async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             error: false,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        expect(input.getAttribute('aria-invalid')).toBe('false')
-      })
+        const input = wrapper.find("input").element as HTMLInputElement;
+        expect(input.getAttribute("aria-invalid")).toBe("false");
+      });
 
-      it('applies aria-disabled when disabled is true', async () => {
+      it("applies aria-disabled when disabled is true", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             disabled: true,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        expect(input.getAttribute('aria-disabled')).toBe('true')
-      })
+        const input = wrapper.find("input").element as HTMLInputElement;
+        expect(input.getAttribute("aria-disabled")).toBe("true");
+      });
 
       it('applies aria-disabled="false" when disabled is false', async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             disabled: false,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        expect(input.getAttribute('aria-disabled')).toBe('false')
-      })
+        const input = wrapper.find("input").element as HTMLInputElement;
+        expect(input.getAttribute("aria-disabled")).toBe("false");
+      });
 
-      it('applies aria-labelledby when label is provided', async () => {
+      it("applies aria-labelledby when label is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Test Label',
+            label: "Test Label",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        const labelId = input.getAttribute('aria-labelledby')
-        expect(labelId).toBeTruthy()
-        
+        const input = wrapper.find("input").element as HTMLInputElement;
+        const labelId = input.getAttribute("aria-labelledby");
+        expect(labelId).toBeTruthy();
+
         // Verify label element exists with matching id
-        const label = wrapper.find('label').element as HTMLLabelElement
-        expect(label.getAttribute('id')).toBe(labelId)
-      })
+        const label = wrapper.find("label").element as HTMLLabelElement;
+        expect(label.getAttribute("id")).toBe(labelId);
+      });
 
-      it('does not apply aria-labelledby when label is not provided', async () => {
+      it("does not apply aria-labelledby when label is not provided", async () => {
         const wrapper = mount(FzInput, {
           props: {},
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        expect(input.getAttribute('aria-labelledby')).toBeNull()
-      })
+        const input = wrapper.find("input").element as HTMLInputElement;
+        expect(input.getAttribute("aria-labelledby")).toBeNull();
+      });
 
-      it('does not apply aria-labelledby when custom label slot is provided', async () => {
+      it("does not apply aria-labelledby when custom label slot is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Test Label',
+            label: "Test Label",
           },
           slots: {
-            label: () => 'Custom Label Slot',
+            label: () => "Custom Label Slot",
           },
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        const ariaLabelledBy = input.getAttribute('aria-labelledby')
-        
+        const input = wrapper.find("input").element as HTMLInputElement;
+        const ariaLabelledBy = input.getAttribute("aria-labelledby");
+
         // aria-labelledby should not be set because the default label element
         // with id="${uniqueId}-label" doesn't exist when custom slot is used
-        expect(ariaLabelledBy).toBeNull()
-        
-        // Verify default label element is not rendered
-        const defaultLabel = wrapper.find('label')
-        expect(defaultLabel.exists()).toBe(false)
-      })
+        expect(ariaLabelledBy).toBeNull();
 
-      it('applies aria-describedby when helpText slot is provided', async () => {
+        // Verify default label element is not rendered
+        const defaultLabel = wrapper.find("label");
+        expect(defaultLabel.exists()).toBe(false);
+      });
+
+      it("applies aria-describedby when helpText slot is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
           },
           slots: {
-            helpText: 'Help text',
+            helpText: "Help text",
           },
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        const describedBy = input.getAttribute('aria-describedby')
-        expect(describedBy).toBeTruthy()
-        
+        const input = wrapper.find("input").element as HTMLInputElement;
+        const describedBy = input.getAttribute("aria-describedby");
+        expect(describedBy).toBeTruthy();
+
         // Verify help text element exists with matching id
-        const helpText = wrapper.find(`#${describedBy}`)
-        expect(helpText.exists()).toBe(true)
-        expect(helpText.text()).toContain('Help text')
-      })
+        const helpText = wrapper.find(`#${describedBy}`);
+        expect(helpText.exists()).toBe(true);
+        expect(helpText.text()).toContain("Help text");
+      });
 
-      it('applies aria-describedby when errorMessage slot is provided', async () => {
+      it("applies aria-describedby when errorMessage slot is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             error: true,
           },
           slots: {
-            errorMessage: 'Error message',
+            errorMessage: "Error message",
           },
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        const describedBy = input.getAttribute('aria-describedby')
-        expect(describedBy).toBeTruthy()
-        
+        const input = wrapper.find("input").element as HTMLInputElement;
+        const describedBy = input.getAttribute("aria-describedby");
+        expect(describedBy).toBeTruthy();
+
         // Verify error message element exists with matching id
-        const errorMessage = wrapper.find(`#${describedBy}`)
-        expect(errorMessage.exists()).toBe(true)
-        expect(errorMessage.text()).toContain('Error message')
-      })
+        const errorMessage = wrapper.find(`#${describedBy}`);
+        expect(errorMessage.exists()).toBe(true);
+        expect(errorMessage.text()).toContain("Error message");
+      });
 
-      it('does not apply aria-describedby when neither helpText nor errorMessage are provided', async () => {
+      it("does not apply aria-describedby when neither helpText nor errorMessage are provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const input = wrapper.find('input').element as HTMLInputElement
-        expect(input.getAttribute('aria-describedby')).toBeNull()
-      })
-    })
+        const input = wrapper.find("input").element as HTMLInputElement;
+        expect(input.getAttribute("aria-describedby")).toBeNull();
+      });
+    });
 
-    describe('Error message accessibility', () => {
+    describe("Error message accessibility", () => {
       it('applies role="alert" to error message container', async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             error: true,
           },
           slots: {
-            errorMessage: 'Error message',
+            errorMessage: "Error message",
           },
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const errorContainer = wrapper.find('[role="alert"]')
-        expect(errorContainer.exists()).toBe(true)
-        expect(errorContainer.text()).toContain('Error message')
-      })
+        const errorContainer = wrapper.find('[role="alert"]');
+        expect(errorContainer.exists()).toBe(true);
+        expect(errorContainer.text()).toContain("Error message");
+      });
 
-      it('does not render error container when error is false', async () => {
+      it("does not render error container when error is false", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             error: false,
           },
           slots: {
-            errorMessage: 'Error message',
+            errorMessage: "Error message",
           },
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const errorContainer = wrapper.find('[role="alert"]')
-        expect(errorContainer.exists()).toBe(false)
-      })
-    })
+        const errorContainer = wrapper.find('[role="alert"]');
+        expect(errorContainer.exists()).toBe(false);
+      });
+    });
 
-    describe('Decorative icons accessibility', () => {
+    describe("Decorative icons accessibility", () => {
       it('applies aria-hidden="true" to valid checkmark icon', async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             valid: true,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the check icon (FzIcon with name="check")
-        const checkIcons = wrapper.findAllComponents({ name: 'FzIcon' })
-        const checkIcon = checkIcons.find((icon) => icon.props('name') === 'check')
-        
-        expect(checkIcon?.exists()).toBe(true)
-        const rootElement = checkIcon?.element as HTMLElement
-        expect(rootElement.getAttribute('aria-hidden')).toBe('true')
-      })
+        const checkIcons = wrapper.findAllComponents({ name: "FzIcon" });
+        const checkIcon = checkIcons.find(
+          (icon) => icon.props("name") === "check",
+        );
+
+        expect(checkIcon?.exists()).toBe(true);
+        const rootElement = checkIcon?.element as HTMLElement;
+        expect(rootElement.getAttribute("aria-hidden")).toBe("true");
+      });
 
       it('applies aria-hidden="true" to error icon', async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             error: true,
           },
           slots: {
-            errorMessage: 'Error message',
+            errorMessage: "Error message",
           },
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the error icon (FzIcon with name="circle-xmark")
-        const errorIcons = wrapper.findAllComponents({ name: 'FzIcon' })
-        const errorIcon = errorIcons.find((icon) => icon.props('name') === 'circle-xmark')
-        
-        expect(errorIcon?.exists()).toBe(true)
-        const rootElement = errorIcon?.element as HTMLElement
-        expect(rootElement.getAttribute('aria-hidden')).toBe('true')
-      })
-    })
+        const errorIcons = wrapper.findAllComponents({ name: "FzIcon" });
+        const errorIcon = errorIcons.find(
+          (icon) => icon.props("name") === "circle-xmark",
+        );
 
-    describe('Container accessibility', () => {
+        expect(errorIcon?.exists()).toBe(true);
+        const rootElement = errorIcon?.element as HTMLElement;
+        expect(rootElement.getAttribute("aria-hidden")).toBe("true");
+      });
+    });
+
+    describe("Container accessibility", () => {
       it('applies tabindex="0" to container when not disabled', async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const container = wrapper.find('.fz-input > div').element as HTMLElement
-        expect(container.getAttribute('tabindex')).toBe('0')
-      })
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.getAttribute("tabindex")).toBe("0");
+      });
 
-      it('removes tabindex from container when disabled', async () => {
+      it("removes tabindex from container when disabled", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             disabled: true,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const container = wrapper.find('.fz-input > div').element as HTMLElement
-        expect(container.getAttribute('tabindex')).toBeNull()
-      })
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.getAttribute("tabindex")).toBeNull();
+      });
 
-      it('removes tabindex from container when readonly', async () => {
+      it("removes tabindex from container when readonly", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             readonly: true,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
-        const container = wrapper.find('.fz-input > div').element as HTMLElement
-        expect(container.getAttribute('tabindex')).toBeNull()
-      })
-    })
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.getAttribute("tabindex")).toBeNull();
+      });
+    });
 
-    describe('Left icon accessibility', () => {
-      it('applies accessibility attributes when leftIconAriaLabel is provided', async () => {
+    describe("Left icon accessibility", () => {
+      it("applies accessibility attributes when leftIconAriaLabel is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            leftIcon: 'calendar-lines',
-            leftIconAriaLabel: 'Open calendar',
+            label: "Label",
+            leftIcon: "calendar-lines",
+            leftIconAriaLabel: "Open calendar",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the FzIcon component wrapper div (root element)
-        const iconComponent = wrapper.findComponent({ name: 'FzIcon' })
-        expect(iconComponent.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = iconComponent.element as HTMLElement
-        
-        // Verify attributes are on the root element
-        expect(rootElement.getAttribute('role')).toBe('button')
-        expect(rootElement.getAttribute('aria-label')).toBe('Open calendar')
-        expect(rootElement.getAttribute('tabindex')).toBe('0')
-      })
+        const iconComponent = wrapper.findComponent({ name: "FzIcon" });
+        expect(iconComponent.exists()).toBe(true);
 
-      it('does not apply accessibility attributes when leftIconAriaLabel is not provided', async () => {
+        // Get the root element (div wrapper)
+        const rootElement = iconComponent.element as HTMLElement;
+
+        // Verify attributes are on the root element
+        expect(rootElement.getAttribute("role")).toBe("button");
+        expect(rootElement.getAttribute("aria-label")).toBe("Open calendar");
+        expect(rootElement.getAttribute("tabindex")).toBe("0");
+      });
+
+      it("does not apply accessibility attributes when leftIconAriaLabel is not provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            leftIcon: 'calendar-lines',
+            label: "Label",
+            leftIcon: "calendar-lines",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the FzIcon component wrapper
-        const iconComponent = wrapper.findComponent({ name: 'FzIcon' })
-        expect(iconComponent.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = iconComponent.element as HTMLElement
-        
-        // Verify attributes are not on the root element
-        expect(rootElement.getAttribute('role')).toBeNull()
-        expect(rootElement.getAttribute('aria-label')).toBeNull()
-        expect(rootElement.getAttribute('tabindex')).toBeNull()
-      })
+        const iconComponent = wrapper.findComponent({ name: "FzIcon" });
+        expect(iconComponent.exists()).toBe(true);
 
-      it('removes tabindex when disabled and leftIconAriaLabel is provided', async () => {
+        // Get the root element (div wrapper)
+        const rootElement = iconComponent.element as HTMLElement;
+
+        // Verify attributes are not on the root element
+        expect(rootElement.getAttribute("role")).toBeNull();
+        expect(rootElement.getAttribute("aria-label")).toBeNull();
+        expect(rootElement.getAttribute("tabindex")).toBeNull();
+      });
+
+      it("removes tabindex when disabled and leftIconAriaLabel is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            leftIcon: 'calendar-lines',
-            leftIconAriaLabel: 'Open calendar',
+            label: "Label",
+            leftIcon: "calendar-lines",
+            leftIconAriaLabel: "Open calendar",
             disabled: true,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the FzIcon component wrapper
-        const iconComponent = wrapper.findComponent({ name: 'FzIcon' })
-        expect(iconComponent.exists()).toBe(true)
-        
+        const iconComponent = wrapper.findComponent({ name: "FzIcon" });
+        expect(iconComponent.exists()).toBe(true);
+
         // Get the root element (div wrapper)
-        const rootElement = iconComponent.element as HTMLElement
-        
+        const rootElement = iconComponent.element as HTMLElement;
+
         // Verify attributes are on the root element
-        expect(rootElement.getAttribute('role')).toBe('button')
-        expect(rootElement.getAttribute('aria-label')).toBe('Open calendar')
-        expect(rootElement.getAttribute('tabindex')).toBeNull() // Removed when disabled
-        expect(rootElement.getAttribute('aria-disabled')).toBe('true')
-      })
+        expect(rootElement.getAttribute("role")).toBe("button");
+        expect(rootElement.getAttribute("aria-label")).toBe("Open calendar");
+        expect(rootElement.getAttribute("tabindex")).toBeNull(); // Removed when disabled
+        expect(rootElement.getAttribute("aria-disabled")).toBe("true");
+      });
 
-      it('has keyboard handler when leftIconAriaLabel is provided', async () => {
+      it("has keyboard handler when leftIconAriaLabel is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            leftIcon: 'calendar-lines',
-            leftIconAriaLabel: 'Open calendar',
+            label: "Label",
+            leftIcon: "calendar-lines",
+            leftIconAriaLabel: "Open calendar",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the FzIcon component wrapper
-        const iconComponent = wrapper.findComponent({ name: 'FzIcon' })
-        expect(iconComponent.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = iconComponent.element as HTMLElement
-        
-        // Verify icon is keyboard accessible (has tabindex)
-        expect(rootElement.getAttribute('tabindex')).toBe('0')
-        // Keyboard interaction is tested in Storybook play functions
-      })
-    })
+        const iconComponent = wrapper.findComponent({ name: "FzIcon" });
+        expect(iconComponent.exists()).toBe(true);
 
-    describe('Right icon accessibility', () => {
-      it('applies accessibility attributes when rightIconAriaLabel is provided', async () => {
+        // Get the root element (div wrapper)
+        const rootElement = iconComponent.element as HTMLElement;
+
+        // Verify icon is keyboard accessible (has tabindex)
+        expect(rootElement.getAttribute("tabindex")).toBe("0");
+        // Keyboard interaction is tested in Storybook play functions
+      });
+    });
+
+    describe("Right icon accessibility", () => {
+      it("applies accessibility attributes when rightIconAriaLabel is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            rightIcon: 'eye',
-            rightIconAriaLabel: 'Toggle visibility',
+            label: "Label",
+            rightIcon: "eye",
+            rightIconAriaLabel: "Toggle visibility",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the FzIcon component wrapper (not the inner img)
-        const iconComponent = wrapper.findComponent({ name: 'FzIcon' })
-        expect(iconComponent.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = iconComponent.element as HTMLElement
-        
-        // Verify attributes are on the root element
-        expect(rootElement.getAttribute('role')).toBe('button')
-        expect(rootElement.getAttribute('aria-label')).toBe('Toggle visibility')
-        expect(rootElement.getAttribute('tabindex')).toBe('0')
-      })
+        const iconComponent = wrapper.findComponent({ name: "FzIcon" });
+        expect(iconComponent.exists()).toBe(true);
 
-      it('does not apply accessibility attributes when rightIconAriaLabel is not provided', async () => {
+        // Get the root element (div wrapper)
+        const rootElement = iconComponent.element as HTMLElement;
+
+        // Verify attributes are on the root element
+        expect(rootElement.getAttribute("role")).toBe("button");
+        expect(rootElement.getAttribute("aria-label")).toBe(
+          "Toggle visibility",
+        );
+        expect(rootElement.getAttribute("tabindex")).toBe("0");
+      });
+
+      it("does not apply accessibility attributes when rightIconAriaLabel is not provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            rightIcon: 'eye',
+            label: "Label",
+            rightIcon: "eye",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the FzIcon component wrapper
-        const iconComponent = wrapper.findComponent({ name: 'FzIcon' })
-        expect(iconComponent.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = iconComponent.element as HTMLElement
-        
-        // Verify attributes are not on the root element
-        expect(rootElement.getAttribute('role')).toBeNull()
-        expect(rootElement.getAttribute('aria-label')).toBeNull()
-        expect(rootElement.getAttribute('tabindex')).toBeNull()
-      })
+        const iconComponent = wrapper.findComponent({ name: "FzIcon" });
+        expect(iconComponent.exists()).toBe(true);
 
-      it('removes tabindex when disabled and rightIconAriaLabel is provided', async () => {
+        // Get the root element (div wrapper)
+        const rootElement = iconComponent.element as HTMLElement;
+
+        // Verify attributes are not on the root element
+        expect(rootElement.getAttribute("role")).toBeNull();
+        expect(rootElement.getAttribute("aria-label")).toBeNull();
+        expect(rootElement.getAttribute("tabindex")).toBeNull();
+      });
+
+      it("removes tabindex when disabled and rightIconAriaLabel is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            rightIcon: 'eye',
-            rightIconAriaLabel: 'Toggle visibility',
+            label: "Label",
+            rightIcon: "eye",
+            rightIconAriaLabel: "Toggle visibility",
             disabled: true,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the FzIcon component wrapper
-        const iconComponent = wrapper.findComponent({ name: 'FzIcon' })
-        expect(iconComponent.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = iconComponent.element as HTMLElement
-        
-        // Verify attributes are on the root element
-        expect(rootElement.getAttribute('role')).toBe('button')
-        expect(rootElement.getAttribute('aria-label')).toBe('Toggle visibility')
-        expect(rootElement.getAttribute('tabindex')).toBeNull() // Removed when disabled
-        expect(rootElement.getAttribute('aria-disabled')).toBe('true')
-      })
+        const iconComponent = wrapper.findComponent({ name: "FzIcon" });
+        expect(iconComponent.exists()).toBe(true);
 
-      it('removes tabindex when readonly and rightIconAriaLabel is provided', async () => {
+        // Get the root element (div wrapper)
+        const rootElement = iconComponent.element as HTMLElement;
+
+        // Verify attributes are on the root element
+        expect(rootElement.getAttribute("role")).toBe("button");
+        expect(rootElement.getAttribute("aria-label")).toBe(
+          "Toggle visibility",
+        );
+        expect(rootElement.getAttribute("tabindex")).toBeNull(); // Removed when disabled
+        expect(rootElement.getAttribute("aria-disabled")).toBe("true");
+      });
+
+      it("removes tabindex when readonly and rightIconAriaLabel is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            rightIcon: 'eye',
-            rightIconAriaLabel: 'Toggle visibility',
+            label: "Label",
+            rightIcon: "eye",
+            rightIconAriaLabel: "Toggle visibility",
             readonly: true,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the FzIcon component wrapper
-        const iconComponent = wrapper.findComponent({ name: 'FzIcon' })
-        expect(iconComponent.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = iconComponent.element as HTMLElement
-        
-        // Verify attributes are on the root element
-        expect(rootElement.getAttribute('role')).toBe('button')
-        expect(rootElement.getAttribute('aria-label')).toBe('Toggle visibility')
-        expect(rootElement.getAttribute('tabindex')).toBeNull() // Removed when readonly
-        expect(rootElement.getAttribute('aria-disabled')).toBe('true')
-      })
+        const iconComponent = wrapper.findComponent({ name: "FzIcon" });
+        expect(iconComponent.exists()).toBe(true);
 
-      it('does not apply accessibility attributes when rightIconButton is true', async () => {
+        // Get the root element (div wrapper)
+        const rootElement = iconComponent.element as HTMLElement;
+
+        // Verify attributes are on the root element
+        expect(rootElement.getAttribute("role")).toBe("button");
+        expect(rootElement.getAttribute("aria-label")).toBe(
+          "Toggle visibility",
+        );
+        expect(rootElement.getAttribute("tabindex")).toBeNull(); // Removed when readonly
+        expect(rootElement.getAttribute("aria-disabled")).toBe("true");
+      });
+
+      it("does not apply accessibility attributes when rightIconButton is true", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            rightIcon: 'eye',
+            label: "Label",
+            rightIcon: "eye",
             rightIconButton: true,
-            rightIconAriaLabel: 'Toggle visibility',
+            rightIconAriaLabel: "Toggle visibility",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // When rightIconButton is true, FzIconButton is used instead of FzIcon
-        const iconButton = wrapper.findComponent({ name: 'FzIconButton' })
-        expect(iconButton.exists()).toBe(true)
-      })
+        const iconButton = wrapper.findComponent({ name: "FzIconButton" });
+        expect(iconButton.exists()).toBe(true);
+      });
 
-      it('has keyboard handler when rightIconAriaLabel is provided', async () => {
+      it("has keyboard handler when rightIconAriaLabel is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            rightIcon: 'eye',
-            rightIconAriaLabel: 'Toggle visibility',
+            label: "Label",
+            rightIcon: "eye",
+            rightIconAriaLabel: "Toggle visibility",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find the FzIcon component wrapper
-        const iconComponent = wrapper.findComponent({ name: 'FzIcon' })
-        expect(iconComponent.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = iconComponent.element as HTMLElement
-        
-        // Verify icon is keyboard accessible (has tabindex)
-        expect(rootElement.getAttribute('tabindex')).toBe('0')
-        // Keyboard interaction is tested in Storybook play functions
-      })
-    })
+        const iconComponent = wrapper.findComponent({ name: "FzIcon" });
+        expect(iconComponent.exists()).toBe(true);
 
-    describe('Second right icon accessibility', () => {
-      it('applies accessibility attributes when secondRightIconAriaLabel is provided', async () => {
+        // Get the root element (div wrapper)
+        const rootElement = iconComponent.element as HTMLElement;
+
+        // Verify icon is keyboard accessible (has tabindex)
+        expect(rootElement.getAttribute("tabindex")).toBe("0");
+        // Keyboard interaction is tested in Storybook play functions
+      });
+    });
+
+    describe("Second right icon accessibility", () => {
+      it("applies accessibility attributes when secondRightIconAriaLabel is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            secondRightIcon: 'info-circle',
-            secondRightIconAriaLabel: 'Show information',
+            label: "Label",
+            secondRightIcon: "info-circle",
+            secondRightIconAriaLabel: "Show information",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find all FzIcon components and get the one with secondRightIcon
-        const iconComponents = wrapper.findAllComponents({ name: 'FzIcon' })
-        const secondIconComponent = iconComponents.find((icon) => 
-          icon.props('name') === 'info-circle'
-        )
-        
-        expect(secondIconComponent?.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = secondIconComponent?.element as HTMLElement
-        
-        // Verify attributes are on the root element
-        expect(rootElement.getAttribute('role')).toBe('button')
-        expect(rootElement.getAttribute('aria-label')).toBe('Show information')
-        expect(rootElement.getAttribute('tabindex')).toBe('0')
-      })
+        const iconComponents = wrapper.findAllComponents({ name: "FzIcon" });
+        const secondIconComponent = iconComponents.find(
+          (icon) => icon.props("name") === "info-circle",
+        );
 
-      it('removes tabindex when readonly and secondRightIconAriaLabel is provided', async () => {
+        expect(secondIconComponent?.exists()).toBe(true);
+
+        // Get the root element (div wrapper)
+        const rootElement = secondIconComponent?.element as HTMLElement;
+
+        // Verify attributes are on the root element
+        expect(rootElement.getAttribute("role")).toBe("button");
+        expect(rootElement.getAttribute("aria-label")).toBe("Show information");
+        expect(rootElement.getAttribute("tabindex")).toBe("0");
+      });
+
+      it("removes tabindex when readonly and secondRightIconAriaLabel is provided", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
-            secondRightIcon: 'info-circle',
-            secondRightIconAriaLabel: 'Show information',
+            label: "Label",
+            secondRightIcon: "info-circle",
+            secondRightIconAriaLabel: "Show information",
             readonly: true,
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find all FzIcon components and get the one with secondRightIcon
-        const iconComponents = wrapper.findAllComponents({ name: 'FzIcon' })
-        const secondIconComponent = iconComponents.find((icon) => 
-          icon.props('name') === 'info-circle'
-        )
-        
-        expect(secondIconComponent?.exists()).toBe(true)
-        
-        // Get the root element (div wrapper)
-        const rootElement = secondIconComponent?.element as HTMLElement
-        
-        // Verify attributes are on the root element
-        expect(rootElement.getAttribute('role')).toBe('button')
-        expect(rootElement.getAttribute('aria-label')).toBe('Show information')
-        expect(rootElement.getAttribute('tabindex')).toBeNull() // Removed when readonly
-        expect(rootElement.getAttribute('aria-disabled')).toBe('true')
-      })
-    })
+        const iconComponents = wrapper.findAllComponents({ name: "FzIcon" });
+        const secondIconComponent = iconComponents.find(
+          (icon) => icon.props("name") === "info-circle",
+        );
 
-    describe('Right icons order', () => {
-      it('renders valid checkmark as last icon when all icons are present', async () => {
+        expect(secondIconComponent?.exists()).toBe(true);
+
+        // Get the root element (div wrapper)
+        const rootElement = secondIconComponent?.element as HTMLElement;
+
+        // Verify attributes are on the root element
+        expect(rootElement.getAttribute("role")).toBe("button");
+        expect(rootElement.getAttribute("aria-label")).toBe("Show information");
+        expect(rootElement.getAttribute("tabindex")).toBeNull(); // Removed when readonly
+        expect(rootElement.getAttribute("aria-disabled")).toBe("true");
+      });
+    });
+
+    describe("Right icons order", () => {
+      it("renders valid checkmark as last icon when all icons are present", async () => {
         const wrapper = mount(FzInput, {
           props: {
-            label: 'Label',
+            label: "Label",
             valid: true,
-            secondRightIcon: 'info-circle',
-            rightIcon: 'envelope',
+            secondRightIcon: "info-circle",
+            rightIcon: "envelope",
           },
           slots: {},
-        })
+        });
 
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
 
         // Find all FzIcon components in the right-icon slot
-        const iconComponents = wrapper.findAllComponents({ name: 'FzIcon' })
-        const validIcon = iconComponents.find((icon) => icon.props('name') === 'check')
-        const secondIcon = iconComponents.find((icon) => icon.props('name') === 'info-circle')
-        const rightIcon = iconComponents.find((icon) => icon.props('name') === 'envelope')
+        const iconComponents = wrapper.findAllComponents({ name: "FzIcon" });
+        const validIcon = iconComponents.find(
+          (icon) => icon.props("name") === "check",
+        );
+        const secondIcon = iconComponents.find(
+          (icon) => icon.props("name") === "info-circle",
+        );
+        const rightIcon = iconComponents.find(
+          (icon) => icon.props("name") === "envelope",
+        );
 
-        expect(validIcon?.exists()).toBe(true)
-        expect(secondIcon?.exists()).toBe(true)
-        expect(rightIcon?.exists()).toBe(true)
+        expect(validIcon?.exists()).toBe(true);
+        expect(secondIcon?.exists()).toBe(true);
+        expect(rightIcon?.exists()).toBe(true);
 
         // Get the container div that wraps all right icons
-        const rightIconContainer = wrapper.find('.fz-input > div > div.flex.items-center.gap-4')
-        expect(rightIconContainer.exists()).toBe(true)
+        const rightIconContainer = wrapper.find(
+          ".fz-input > div > div.flex.items-center.gap-4",
+        );
+        expect(rightIconContainer.exists()).toBe(true);
 
         // Get all icon elements in order
-        const icons = rightIconContainer.findAllComponents({ name: 'FzIcon' })
-        expect(icons.length).toBeGreaterThanOrEqual(3)
+        const icons = rightIconContainer.findAllComponents({ name: "FzIcon" });
+        expect(icons.length).toBeGreaterThanOrEqual(3);
 
         // Verify order: secondRightIcon, rightIcon, valid (check)
-        const iconNames = icons.map((icon) => icon.props('name'))
-        const secondIndex = iconNames.indexOf('info-circle')
-        const rightIndex = iconNames.indexOf('envelope')
-        const validIndex = iconNames.indexOf('check')
+        const iconNames = icons.map((icon) => icon.props("name"));
+        const secondIndex = iconNames.indexOf("info-circle");
+        const rightIndex = iconNames.indexOf("envelope");
+        const validIndex = iconNames.indexOf("check");
 
-        expect(secondIndex).toBeLessThan(rightIndex)
-        expect(rightIndex).toBeLessThan(validIndex)
-      })
-    })
-  })
+        expect(secondIndex).toBeLessThan(rightIndex);
+        expect(rightIndex).toBeLessThan(validIndex);
+      });
+    });
+  });
 
-  describe('Attribute forwarding (inheritAttrs: false)', () => {
-    it('applies consumer class to root wrapper div', async () => {
+  describe("Attribute forwarding (inheritAttrs: false)", () => {
+    it("applies consumer class to root wrapper div", async () => {
       const wrapper = mount(FzInput, {
-        props: { label: 'Label' },
-        attrs: { class: 'max-w-xs custom-class' },
-      })
+        props: { label: "Label" },
+        attrs: { class: "max-w-xs custom-class" },
+      });
 
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      const rootDiv = wrapper.element as HTMLElement
-      expect(rootDiv.classList.contains('max-w-xs')).toBe(true)
-      expect(rootDiv.classList.contains('custom-class')).toBe(true)
-      expect(rootDiv.classList.contains('fz-input')).toBe(true)
-    })
+      const rootDiv = wrapper.element as HTMLElement;
+      expect(rootDiv.classList.contains("max-w-xs")).toBe(true);
+      expect(rootDiv.classList.contains("custom-class")).toBe(true);
+      expect(rootDiv.classList.contains("fz-input")).toBe(true);
+    });
 
-    it('does not apply consumer class to native input element', async () => {
+    it("does not apply consumer class to native input element", async () => {
       const wrapper = mount(FzInput, {
-        props: { label: 'Label' },
-        attrs: { class: 'max-w-xs' },
-      })
+        props: { label: "Label" },
+        attrs: { class: "max-w-xs" },
+      });
 
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      const input = wrapper.find('input').element as HTMLInputElement
-      expect(input.classList.contains('max-w-xs')).toBe(false)
-    })
+      const input = wrapper.find("input").element as HTMLInputElement;
+      expect(input.classList.contains("max-w-xs")).toBe(false);
+    });
 
-    it('forwards data-* attributes to native input element', async () => {
+    it("forwards data-* attributes to native input element", async () => {
       const wrapper = mount(FzInput, {
-        props: { label: 'Label' },
-        attrs: { 'data-cy': 'my-input', 'data-testid': 'test-input' },
-      })
+        props: { label: "Label" },
+        attrs: { "data-cy": "my-input", "data-testid": "test-input" },
+      });
 
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      const input = wrapper.find('input').element as HTMLInputElement
-      expect(input.getAttribute('data-cy')).toBe('my-input')
-      expect(input.getAttribute('data-testid')).toBe('test-input')
+      const input = wrapper.find("input").element as HTMLInputElement;
+      expect(input.getAttribute("data-cy")).toBe("my-input");
+      expect(input.getAttribute("data-testid")).toBe("test-input");
 
-      const rootDiv = wrapper.element as HTMLElement
-      expect(rootDiv.getAttribute('data-cy')).toBeNull()
-    })
+      const rootDiv = wrapper.element as HTMLElement;
+      expect(rootDiv.getAttribute("data-cy")).toBeNull();
+    });
 
-    it('forwards consumer id to native input element (overriding internal id)', async () => {
+    it("forwards consumer id to native input element (overriding internal id)", async () => {
       const wrapper = mount(FzInput, {
-        props: { label: 'Label' },
-        attrs: { id: 'custom-id' },
-      })
+        props: { label: "Label" },
+        attrs: { id: "custom-id" },
+      });
 
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      const input = wrapper.find('input').element as HTMLInputElement
-      expect(input.getAttribute('id')).toBe('custom-id')
+      const input = wrapper.find("input").element as HTMLInputElement;
+      expect(input.getAttribute("id")).toBe("custom-id");
 
-      const rootDiv = wrapper.element as HTMLElement
-      expect(rootDiv.getAttribute('id')).toBeNull()
-    })
+      const rootDiv = wrapper.element as HTMLElement;
+      expect(rootDiv.getAttribute("id")).toBeNull();
+    });
 
-    it('forwards consumer aria-* attributes to native input element', async () => {
+    it("forwards consumer aria-* attributes to native input element", async () => {
       const wrapper = mount(FzInput, {
-        props: { label: 'Label' },
+        props: { label: "Label" },
         attrs: {
-          'aria-expanded': 'true',
-          'aria-haspopup': 'listbox',
+          "aria-expanded": "true",
+          "aria-haspopup": "listbox",
         },
-      })
+      });
 
-      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick();
 
-      const input = wrapper.find('input').element as HTMLInputElement
-      expect(input.getAttribute('aria-expanded')).toBe('true')
-      expect(input.getAttribute('aria-haspopup')).toBe('listbox')
+      const input = wrapper.find("input").element as HTMLInputElement;
+      expect(input.getAttribute("aria-expanded")).toBe("true");
+      expect(input.getAttribute("aria-haspopup")).toBe("listbox");
 
-      const rootDiv = wrapper.element as HTMLElement
-      expect(rootDiv.getAttribute('aria-expanded')).toBeNull()
-      expect(rootDiv.getAttribute('aria-haspopup')).toBeNull()
-    })
-  })
+      const rootDiv = wrapper.element as HTMLElement;
+      expect(rootDiv.getAttribute("aria-expanded")).toBeNull();
+      expect(rootDiv.getAttribute("aria-haspopup")).toBeNull();
+    });
+  });
 
-  describe('Edge cases', () => {
+  describe("Visual emphasis states", () => {
+    describe("Highlighted state", () => {
+      it("applies highlighted container classes when highlighted is true", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+        expect(
+          container.classList.contains("border-semantic-warning-200"),
+        ).toBe(true);
+        expect(container.classList.contains("ring-2")).toBe(true);
+        expect(container.classList.contains("ring-semantic-warning-100")).toBe(
+          true,
+        );
+      });
+
+      it("works with backoffice environment", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+            environment: "backoffice",
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("h-32")).toBe(true);
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+      });
+
+      it("works with floating-label variant", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+            variant: "floating-label",
+            placeholder: "Placeholder",
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+        expect(container.classList.contains("h-44")).toBe(true);
+      });
+    });
+
+    describe("AIreasoning state", () => {
+      it("applies aiReasoning container classes when aiReasoning is true", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-purple-50")).toBe(true);
+        expect(container.classList.contains("border-purple-600")).toBe(true);
+        expect(container.classList.contains("ring-2")).toBe(true);
+        expect(container.classList.contains("ring-purple-200")).toBe(true);
+      });
+
+      it("auto-renders sparkles icon when aiReasoning is true", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const icons = wrapper.findAllComponents({ name: "FzIcon" });
+        const sparklesIcon = icons.find(
+          (icon) => icon.props("name") === "sparkles",
+        );
+        expect(sparklesIcon?.exists()).toBe(true);
+
+        const rootElement = sparklesIcon?.element as HTMLElement;
+        expect(rootElement.getAttribute("aria-hidden")).toBe("true");
+      });
+
+      it("does not render sparkles when leftIcon is provided", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+            leftIcon: "search",
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const icons = wrapper.findAllComponents({ name: "FzIcon" });
+        const sparklesIcon = icons.find(
+          (icon) => icon.props("name") === "sparkles",
+        );
+        expect(sparklesIcon).toBeUndefined();
+
+        const searchIcon = icons.find(
+          (icon) => icon.props("name") === "search",
+        );
+        expect(searchIcon?.exists()).toBe(true);
+      });
+
+      it("does not render sparkles when left-icon slot is provided", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+          },
+          slots: {
+            "left-icon": '<span data-testid="custom-icon">Custom</span>',
+          },
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const icons = wrapper.findAllComponents({ name: "FzIcon" });
+        const sparklesIcon = icons.find(
+          (icon) => icon.props("name") === "sparkles",
+        );
+        expect(sparklesIcon).toBeUndefined();
+
+        const customIcon = wrapper.find('[data-testid="custom-icon"]');
+        expect(customIcon.exists()).toBe(true);
+      });
+
+      it("sparkles icon has purple color by default", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const icons = wrapper.findAllComponents({ name: "FzIcon" });
+        const sparklesIcon = icons.find(
+          (icon) => icon.props("name") === "sparkles",
+        );
+        const rootElement = sparklesIcon?.element as HTMLElement;
+        expect(rootElement.classList.contains("text-purple-600")).toBe(true);
+      });
+
+      it("sparkles icon is muted when error is true", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+            error: true,
+          },
+          slots: {
+            errorMessage: "Error message",
+          },
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const icons = wrapper.findAllComponents({ name: "FzIcon" });
+        const sparklesIcon = icons.find(
+          (icon) => icon.props("name") === "sparkles",
+        );
+        const rootElement = sparklesIcon?.element as HTMLElement;
+        expect(rootElement.classList.contains("text-grey-300")).toBe(true);
+      });
+
+      it("sparkles icon is muted when disabled", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+            disabled: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const icons = wrapper.findAllComponents({ name: "FzIcon" });
+        const sparklesIcon = icons.find(
+          (icon) => icon.props("name") === "sparkles",
+        );
+        const rootElement = sparklesIcon?.element as HTMLElement;
+        expect(rootElement.classList.contains("text-grey-300")).toBe(true);
+      });
+
+      it("works with floating-label variant", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+            variant: "floating-label",
+            placeholder: "Placeholder",
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-purple-50")).toBe(true);
+        expect(container.classList.contains("h-44")).toBe(true);
+      });
+    });
+
+    describe("State priority", () => {
+      it("error overrides highlighted", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+            error: true,
+          },
+          slots: {
+            errorMessage: "Error message",
+          },
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("border-semantic-error-200")).toBe(
+          true,
+        );
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          false,
+        );
+        expect(container.classList.contains("ring-2")).toBe(false);
+      });
+
+      it("error overrides aiReasoning", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+            error: true,
+          },
+          slots: {
+            errorMessage: "Error message",
+          },
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("border-semantic-error-200")).toBe(
+          true,
+        );
+        expect(container.classList.contains("bg-purple-50")).toBe(false);
+        expect(container.classList.contains("ring-2")).toBe(false);
+      });
+
+      it("disabled overrides highlighted", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+            disabled: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-grey-100")).toBe(true);
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          false,
+        );
+        expect(container.classList.contains("ring-2")).toBe(false);
+      });
+
+      it("disabled overrides aiReasoning", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+            disabled: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-grey-100")).toBe(true);
+        expect(container.classList.contains("bg-purple-50")).toBe(false);
+        expect(container.classList.contains("ring-2")).toBe(false);
+      });
+
+      it("readonly overrides highlighted", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+            readonly: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-grey-100")).toBe(true);
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          false,
+        );
+      });
+
+      it("highlighted takes priority over aiReasoning when both are set", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+            aiReasoning: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+        expect(container.classList.contains("bg-purple-50")).toBe(false);
+      });
+    });
+  });
+
+  describe("Edge cases", () => {
     it(`renders ${NUMBER_OF_INPUTS} input with different ids`, async () => {
       const wrapperList = Array.from({ length: NUMBER_OF_INPUTS }).map((_, i) =>
         mount(FzInput, {
@@ -1112,14 +1502,13 @@ describe('FzInput', () => {
           },
           slots: {},
         }),
-      )
+      );
 
-      await Promise.all(wrapperList.map((w) => w.vm.$nextTick()))
+      await Promise.all(wrapperList.map((w) => w.vm.$nextTick()));
 
-      const ids = wrapperList.map((w) => w.find('input').attributes('id'))
+      const ids = wrapperList.map((w) => w.find("input").attributes("id"));
 
-      expect(new Set(ids).size).toBe(NUMBER_OF_INPUTS)
-    })
-  })
-})
-
+      expect(new Set(ids).size).toBe(NUMBER_OF_INPUTS);
+    });
+  });
+});

--- a/packages/input/src/__tests__/FzInput.spec.ts
+++ b/packages/input/src/__tests__/FzInput.spec.ts
@@ -1226,9 +1226,10 @@ describe("FzInput", () => {
 
         const icons = wrapper.findAllComponents({ name: "FzIcon" });
         const sparklesIcon = icons.find(
-          (icon) => icon.props("name") === "sparkles",
+          (icon: any) => icon.props("name") === "sparkles",
         );
         expect(sparklesIcon?.exists()).toBe(true);
+        expect(sparklesIcon?.props("variant")).toBe("fas");
 
         const rootElement = sparklesIcon?.element as HTMLElement;
         expect(rootElement.getAttribute("aria-hidden")).toBe("true");
@@ -1489,6 +1490,334 @@ describe("FzInput", () => {
           true,
         );
         expect(container.classList.contains("bg-purple-50")).toBe(false);
+      });
+    });
+  });
+
+  describe("User input resets emphasis", () => {
+    const findSparkles = (wrapper: ReturnType<typeof mount>) => {
+      const icons = wrapper.findAllComponents({ name: "FzIcon" });
+      return icons.find((icon: any) => icon.props("name") === "sparkles");
+    };
+
+    describe("programmatic modelValue change preserves emphasis", () => {
+      it("highlighted styling persists after programmatic value change", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+            modelValue: "",
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+
+        await wrapper.setProps({ modelValue: "programmatic value" });
+
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+        expect(container.classList.contains("ring-semantic-warning-100")).toBe(
+          true,
+        );
+        expect(wrapper.emitted("update:highlighted")).toBeUndefined();
+      });
+
+      it("aiReasoning styling and sparkles persist after programmatic value change", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+            modelValue: "",
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-purple-50")).toBe(true);
+        expect(findSparkles(wrapper)?.exists()).toBe(true);
+
+        await wrapper.setProps({ modelValue: "programmatic value" });
+
+        expect(container.classList.contains("bg-purple-50")).toBe(true);
+        expect(container.classList.contains("ring-purple-200")).toBe(true);
+        expect(findSparkles(wrapper)?.exists()).toBe(true);
+        expect(wrapper.emitted("update:aiReasoning")).toBeUndefined();
+      });
+
+      it("emphasis persists through multiple programmatic value changes", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+            modelValue: "",
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+
+        await wrapper.setProps({ modelValue: "first" });
+        await wrapper.setProps({ modelValue: "second" });
+        await wrapper.setProps({ modelValue: "third" });
+
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+        expect(wrapper.emitted("update:highlighted")).toBeUndefined();
+      });
+
+      it("emphasis persists when programmatic value is cleared to empty string", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+            modelValue: "initial",
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+
+        await wrapper.setProps({ modelValue: "" });
+
+        expect(container.classList.contains("bg-purple-50")).toBe(true);
+        expect(findSparkles(wrapper)?.exists()).toBe(true);
+        expect(wrapper.emitted("update:aiReasoning")).toBeUndefined();
+      });
+    });
+
+    describe("user input reverts to default state", () => {
+      it("highlighted reverts to default styling on user input", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+
+        await wrapper.find("input").setValue("user typed");
+
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          false,
+        );
+        expect(
+          container.classList.contains("border-semantic-warning-200"),
+        ).toBe(false);
+        expect(container.classList.contains("ring-semantic-warning-100")).toBe(
+          false,
+        );
+        expect(container.classList.contains("border-grey-300")).toBe(true);
+      });
+
+      it("aiReasoning reverts to default styling and hides sparkles on user input", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            aiReasoning: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        expect(container.classList.contains("bg-purple-50")).toBe(true);
+        expect(findSparkles(wrapper)?.exists()).toBe(true);
+
+        await wrapper.find("input").setValue("user typed");
+
+        expect(container.classList.contains("bg-purple-50")).toBe(false);
+        expect(container.classList.contains("border-purple-600")).toBe(false);
+        expect(container.classList.contains("ring-purple-200")).toBe(false);
+        expect(container.classList.contains("border-grey-300")).toBe(true);
+        expect(findSparkles(wrapper)).toBeUndefined();
+      });
+
+      it("both highlighted and aiReasoning revert on user input", async () => {
+        const wrapper = mount(FzInput, {
+          props: {
+            label: "Label",
+            highlighted: true,
+            aiReasoning: true,
+          },
+          slots: {},
+        });
+
+        await wrapper.vm.$nextTick();
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        // highlighted takes priority
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+
+        await wrapper.find("input").setValue("user typed");
+
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          false,
+        );
+        expect(container.classList.contains("bg-purple-50")).toBe(false);
+        expect(container.classList.contains("border-grey-300")).toBe(true);
+        expect(findSparkles(wrapper)).toBeUndefined();
+      });
+
+      it("emits update:highlighted false on user input", async () => {
+        const wrapper = mount(FzInput, {
+          props: { label: "Label", highlighted: true },
+          slots: {},
+        });
+
+        await wrapper.find("input").setValue("typed");
+
+        expect(wrapper.emitted("update:highlighted")).toEqual([[false]]);
+      });
+
+      it("emits update:aiReasoning false on user input", async () => {
+        const wrapper = mount(FzInput, {
+          props: { label: "Label", aiReasoning: true },
+          slots: {},
+        });
+
+        await wrapper.find("input").setValue("typed");
+
+        expect(wrapper.emitted("update:aiReasoning")).toEqual([[false]]);
+      });
+
+      it("emits both update events when both are active", async () => {
+        const wrapper = mount(FzInput, {
+          props: { label: "Label", highlighted: true, aiReasoning: true },
+          slots: {},
+        });
+
+        await wrapper.find("input").setValue("typed");
+
+        expect(wrapper.emitted("update:highlighted")).toEqual([[false]]);
+        expect(wrapper.emitted("update:aiReasoning")).toEqual([[false]]);
+      });
+
+      it("does not emit update events when no emphasis is active", async () => {
+        const wrapper = mount(FzInput, {
+          props: { label: "Label" },
+          slots: {},
+        });
+
+        await wrapper.find("input").setValue("typed");
+
+        expect(wrapper.emitted("update:highlighted")).toBeUndefined();
+        expect(wrapper.emitted("update:aiReasoning")).toBeUndefined();
+      });
+
+      it("only emits once even with multiple user keystrokes", async () => {
+        const wrapper = mount(FzInput, {
+          props: { label: "Label", highlighted: true },
+          slots: {},
+        });
+
+        const input = wrapper.find("input");
+        await input.setValue("a");
+        await input.setValue("ab");
+        await input.setValue("abc");
+
+        // First keystroke resets emphasis; subsequent ones have nothing to reset
+        expect(wrapper.emitted("update:highlighted")).toEqual([[false]]);
+      });
+    });
+
+    describe("re-enabling emphasis after user reset", () => {
+      it("re-applies highlighted when prop cycles false → true after user reset", async () => {
+        const wrapper = mount(FzInput, {
+          props: { label: "Label", highlighted: true },
+          slots: {},
+        });
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        await wrapper.find("input").setValue("typed");
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          false,
+        );
+
+        // Parent syncs to false then re-enables
+        await wrapper.setProps({ highlighted: false });
+        await wrapper.setProps({ highlighted: true });
+
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+      });
+
+      it("re-applies aiReasoning and sparkles when prop cycles false → true after user reset", async () => {
+        const wrapper = mount(FzInput, {
+          props: { label: "Label", aiReasoning: true },
+          slots: {},
+        });
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        await wrapper.find("input").setValue("typed");
+        expect(container.classList.contains("bg-purple-50")).toBe(false);
+        expect(findSparkles(wrapper)).toBeUndefined();
+
+        await wrapper.setProps({ aiReasoning: false });
+        await wrapper.setProps({ aiReasoning: true });
+
+        expect(container.classList.contains("bg-purple-50")).toBe(true);
+        expect(findSparkles(wrapper)?.exists()).toBe(true);
+      });
+
+      it("user can type again after re-enabled emphasis to reset it a second time", async () => {
+        const wrapper = mount(FzInput, {
+          props: { label: "Label", highlighted: true },
+          slots: {},
+        });
+
+        const container = wrapper.find(".fz-input > div")
+          .element as HTMLElement;
+        const input = wrapper.find("input");
+
+        // First cycle: user types → reset
+        await input.setValue("first");
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          false,
+        );
+
+        // Parent re-enables
+        await wrapper.setProps({ highlighted: false });
+        await wrapper.setProps({ highlighted: true });
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          true,
+        );
+
+        // Second cycle: user types again → reset again
+        await input.setValue("second");
+        expect(container.classList.contains("bg-semantic-warning-50")).toBe(
+          false,
+        );
+        expect(wrapper.emitted("update:highlighted")).toEqual([
+          [false],
+          [false],
+        ]);
       });
     });
   });

--- a/packages/input/src/types.ts
+++ b/packages/input/src/types.ts
@@ -1,5 +1,5 @@
 import { IconButtonVariant } from "@fiscozen/button";
-import { IconSize , IconVariant } from "@fiscozen/icons";
+import { IconSize, IconVariant } from "@fiscozen/icons";
 
 export type InputEnvironment = "backoffice" | "frontoffice";
 
@@ -128,7 +128,7 @@ type FzInputProps = {
    * Visual presentation style. 'floating-label' moves placeholder above input when focused/filled
    * @default 'normal'
    */
-  variant?: 'normal' | 'floating-label';
+  variant?: "normal" | "floating-label";
   /**
    * HTML5 pattern attribute for native browser validation
    */
@@ -142,6 +142,22 @@ type FzInputProps = {
    * @default false
    */
   readonly?: boolean;
+  /**
+   * Shows highlighted state with warning colors (orange border, warm background, glow ring).
+   * Overridden by error, disabled, and readonly states.
+   * If both highlighted and aiReasoning are true, highlighted takes priority.
+   * @default false
+   */
+  highlighted?: boolean;
+  /**
+   * Shows AI reasoning state with purple colors (purple border, light purple background, glow ring).
+   * Auto-renders a sparkles icon unless leftIcon prop or left-icon slot is provided.
+   * Overridden by error, disabled, readonly, and highlighted states.
+   * @note When both aiReasoning and leftIcon are provided, leftIcon takes visual precedence
+   * and no sparkles icon is rendered.
+   * @default false
+   */
+  aiReasoning?: boolean;
   /**
    * Native maxlength attribute. Limits maximum number of characters
    */
@@ -158,39 +174,38 @@ type FzInputProps = {
   leftIconClass?: string;
 };
 
-interface FzCurrencyInputProps
-  extends Omit<
-    FzInputProps,
-    | "type"
-    | "modelValue"
-    | "rightIcon"
-    | "rightIconSize"
-    | "rightIconVariant"
-    | "rightIconButton"
-    | "rightIconButtonVariant"
-    | "rightIconAriaLabel"
-    | "rightIconClass"
-    | "secondRightIcon"
-    | "secondRightIconClass"
-    | "secondRightIconVariant"
-    | "secondRightIconButton"
-    | "secondRightIconButtonVariant"
-    | "secondRightIconAriaLabel"
-  > {
+interface FzCurrencyInputProps extends Omit<
+  FzInputProps,
+  | "type"
+  | "modelValue"
+  | "rightIcon"
+  | "rightIconSize"
+  | "rightIconVariant"
+  | "rightIconButton"
+  | "rightIconButtonVariant"
+  | "rightIconAriaLabel"
+  | "rightIconClass"
+  | "secondRightIcon"
+  | "secondRightIconClass"
+  | "secondRightIconVariant"
+  | "secondRightIconButton"
+  | "secondRightIconButtonVariant"
+  | "secondRightIconAriaLabel"
+> {
   /**
    * The v-model value.
-   * 
+   *
    * **Type assertion**: This prop accepts `number | string | undefined | null` as input,
    * but the component **always emits** `number | undefined | null` (never `string`).
    * Strings are automatically parsed (Italian format: "1.234,56" → 1234.56) and converted
    * to numbers internally.
-   * 
+   *
    * **nullOnEmpty**: When `nullOnEmpty` is `true`, empty input emits `null` instead of `undefined`.
-   * 
+   *
    * **Deprecation**: String values are deprecated and will be removed in a future version.
    * A console warning is shown when strings are used. Please use `number | undefined | null` instead
    * for type safety and future compatibility.
-   * 
+   *
    * @example
    * ```vue
    * <!-- ✅ Recommended: number | undefined | null -->
@@ -200,7 +215,7 @@ interface FzCurrencyInputProps
    * <template>
    *   <FzCurrencyInput v-model="amount" />
    * </template>
-   * 
+   *
    * <!-- ✅ With nullOnEmpty: number | null -->
    * <script setup>
    * const amount = ref<number | null>(null);
@@ -208,7 +223,7 @@ interface FzCurrencyInputProps
    * <template>
    *   <FzCurrencyInput v-model="amount" :nullOnEmpty="true" />
    * </template>
-   * 
+   *
    * <!-- ⚠️ Deprecated: string (still works but shows warning) -->
    * <script setup>
    * const amount = ref<string>("1234,56");

--- a/packages/input/src/useInputStyle.ts
+++ b/packages/input/src/useInputStyle.ts
@@ -19,7 +19,7 @@ export default function useInputStyle(
   container: Ref<HTMLElement | null>,
   model: Ref<string | undefined>,
   effectiveEnvironment: ComputedRef<InputEnvironment>,
-  isFocused: Ref<boolean>
+  isFocused: Ref<boolean>,
 ) {
   const containerWidth = computed(() =>
     container.value ? `${container.value.clientWidth}px` : "auto",
@@ -36,14 +36,18 @@ export default function useInputStyle(
   const computedContainerClass = computed(() => {
     const env = effectiveEnvironment.value;
     return [
-      props.variant?.value === 'normal' ? mapContainerClass[env] : mapContainerClass.frontoffice,
+      props.variant?.value === "normal"
+        ? mapContainerClass[env]
+        : mapContainerClass.frontoffice,
       evaluateProps(),
     ];
   });
 
   const computedLabelClass = computed(() => [
     "font-normal text-base",
-    (props.disabled?.value || props.readonly?.value) ? "text-grey-300" : "text-core-black",
+    props.disabled?.value || props.readonly?.value
+      ? "text-grey-300"
+      : "text-core-black",
   ]);
 
   // Input styles: transparent background (inherits from container), no border, placeholder color grey-300
@@ -51,22 +55,22 @@ export default function useInputStyle(
 
   // Input text size: 16px for both environments (as per design specs)
   const textSizeMap: Record<InputEnvironment, string> = {
-    backoffice: 'text-base',
-    frontoffice: 'text-base',
+    backoffice: "text-base",
+    frontoffice: "text-base",
   };
 
   /**
    * Determines when to show the normal placeholder inside the input.
-   * 
+   *
    * For floating-label variant:
    * - Shows placeholder inside input only when input is empty AND not focused
    * - When focused or has value, placeholder "floats" above as <span>
-   * 
+   *
    * For normal variant:
    * - Always shows placeholder inside input
    */
   const showNormalPlaceholder = computed(() => {
-    if (props.variant?.value !== 'floating-label') {
+    if (props.variant?.value !== "floating-label") {
       return true; // Normal variant: always show placeholder inside
     }
     // Floating-label variant: show placeholder inside only when empty AND not focused
@@ -75,7 +79,7 @@ export default function useInputStyle(
 
   const computedInputClass = computed(() => {
     const env = effectiveEnvironment.value;
-    if (props.variant?.value === 'floating-label') {
+    if (props.variant?.value === "floating-label") {
       return [textSizeMap[env]];
     }
     return [];
@@ -84,45 +88,60 @@ export default function useInputStyle(
   // Help text styles: Inter, 16px, normal, 400, line-height 20px (125%), color grey-500
   const computedHelpClass = computed(() => [
     "font-normal text-base",
-    (props.disabled?.value || props.readonly?.value) ? "text-grey-300" : "text-grey-500",
+    props.disabled?.value || props.readonly?.value
+      ? "text-grey-300"
+      : "text-grey-500",
   ]);
 
   // Error text styles: same as helpText (Inter, 16px, normal, 400, line-height 20px) but with core-black color
   const computedErrorClass = computed(() => [
     "font-normal text-base",
-    (props.disabled?.value || props.readonly?.value) ? "text-grey-300" : "text-core-black",
+    props.disabled?.value || props.readonly?.value
+      ? "text-grey-300"
+      : "text-core-black",
   ]);
 
   /**
    * Helper functions to identify UI states.
-   * 
+   *
    * These functions explicitly describe when each UI representation should be applied,
    * making the component logic more declarative and maintainable.
-   * Priority order: error (highest) > disabled/readonly > default
+   * Priority order: error (highest) > disabled/readonly > highlighted > aiReasoning > default
    */
   const isError = (p: typeof props) => !!p.error?.value;
-  const isDisabled = (p: typeof props) => !!p.disabled?.value || !!p.readonly?.value;
-  const isDefault = (p: typeof props) => !p.error?.value && !p.disabled?.value && !p.readonly?.value;
+  const isDisabled = (p: typeof props) =>
+    !!p.disabled?.value || !!p.readonly?.value;
+  const isHighlighted = (p: typeof props) => !!p.highlighted?.value;
+  const isAiReasoning = (p: typeof props) => !!p.aiReasoning?.value;
 
   /**
    * Evaluates container styles based on props with priority order:
    * 1. error (highest priority)
    * 2. disabled/readonly (same styling)
-   * 3. default
-   * 
-   * Focus states are handled separately:
+   * 3. highlighted (persistent warning emphasis, overrides focus)
+   * 4. aiReasoning (persistent purple emphasis, overrides focus)
+   * 5. default (fallback)
+   *
+   * Focus states:
    * - error+focus: border-semantic-error-300
    * - default+focus: border-blue-600
+   * - highlighted/aiReasoning: persistent styling regardless of focus
    */
-  const evaluateProps = () => {
+  const evaluateProps = (): string => {
     switch (true) {
       case isError(props):
         return "border-semantic-error-200 has-[:focus]:border-semantic-error-300 bg-core-white text-core-black cursor-text";
-      
+
       case isDisabled(props):
         return "bg-grey-100 border-grey-100 text-grey-300 cursor-not-allowed";
-      
-      case isDefault(props):
+
+      case isHighlighted(props):
+        return "bg-semantic-warning-50 border-semantic-warning-200 ring-2 ring-semantic-warning-100 text-core-black cursor-text";
+
+      case isAiReasoning(props):
+        return "bg-purple-50 border-purple-600 ring-2 ring-purple-200 text-core-black cursor-text";
+
+      default:
         return "border-grey-300 has-[:focus]:border-blue-600 bg-core-white text-core-black cursor-text";
     }
   };
@@ -136,6 +155,6 @@ export default function useInputStyle(
     computedHelpClass,
     computedErrorClass,
     containerWidth,
-    showNormalPlaceholder
+    showNormalPlaceholder,
   };
 }

--- a/packages/style/fns.js
+++ b/packages/style/fns.js
@@ -210,17 +210,19 @@ function generateColorSafelist(colors) {
     patterns.push(`text-${colorName}`);
     patterns.push(`bg-${colorName}`);
     patterns.push(`border-${colorName}`);
+    patterns.push(`ring-${colorName}`);
     patterns.push(`hover:text-${colorName}`);
     patterns.push(`hover:bg-${colorName}`);
     patterns.push(`hover:border-${colorName}`);
   });
-  
+
   // Add default weight classes (e.g., text-blue uses weight 500 by default)
   SAFE_COLOR_NAMES.forEach(colorName => {
     if (colorName !== 'core') {
       patterns.push(`text-${colorName}`);
       patterns.push(`bg-${colorName}`);
       patterns.push(`border-${colorName}`);
+      patterns.push(`ring-${colorName}`);
       patterns.push(`hover:text-${colorName}`);
       patterns.push(`hover:bg-${colorName}`);
       patterns.push(`hover:border-${colorName}`);
@@ -237,19 +239,21 @@ function generateColorSafelist(colors) {
           patterns.push(`text-${fullColorName}`);
           patterns.push(`bg-${fullColorName}`);
           patterns.push(`border-${fullColorName}`);
+          patterns.push(`ring-${fullColorName}`);
           patterns.push(`hover:text-${fullColorName}`);
           patterns.push(`hover:bg-${fullColorName}`);
           patterns.push(`hover:border-${fullColorName}`);
         });
       }
     });
-    
+
     // Add default semantic color classes (e.g., text-semantic-error uses weight 200)
     SEMANTIC_COLOR_NAMES.forEach(semanticType => {
       const fullColorName = `semantic-${semanticType}`;
       patterns.push(`text-${fullColorName}`);
       patterns.push(`bg-${fullColorName}`);
       patterns.push(`border-${fullColorName}`);
+      patterns.push(`ring-${fullColorName}`);
       patterns.push(`hover:text-${fullColorName}`);
       patterns.push(`hover:bg-${fullColorName}`);
       patterns.push(`hover:border-${fullColorName}`);


### PR DESCRIPTION
Jira: [LIB-2534](https://fiscozen.atlassian.net/browse/LIB-2534)

[LIB-2534]: https://fiscozen.atlassian.net/browse/LIB-2534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `highlighted`/`aiReasoning` props that change `FzInput` styling and emit sync events on user input, which could affect consumers relying on current visual/interaction behavior. Broadly covered by new unit tests and Storybook stories, but the component is widely used so regressions are possible.
> 
> **Overview**
> Adds two new `FzInput` emphasis props: **`highlighted`** (warning styling) and **`aiReasoning`** (purple styling with an auto-rendered sparkles icon when no left icon/slot is provided).
> 
> Emphasis styling is integrated into `useInputStyle` with explicit priority (*error/disabled/readonly override emphasis; `highlighted` overrides `aiReasoning`*), and `FzInput` now resets these emphasis states on native user typing while emitting `update:highlighted` / `update:aiReasoning` for `v-model` sync.
> 
> Expands Storybook coverage with new stories for highlighted/AI reasoning variants and adds extensive unit tests for styling, icon rendering, state priority, and “user input resets emphasis” behavior; also updates the Tailwind safelist generator to include `ring-*` classes used by the new styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f2a0ae1115ca967f9578904cb6e5ad1feb35cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->