### PR TITLE
fix: replace reference-identity slot filtering and provide/inject keys with namespaced strings

### DIFF
--- a/.changeset/replace-vnode-reference-filtering-with-kind-marker.md
+++ b/.changeset/replace-vnode-reference-filtering-with-kind-marker.md
@@ -1,0 +1,27 @@
+---
+"@fiscozen/tab": patch
+"@fiscozen/simple-table": patch
+"@fiscozen/table": patch
+"@fiscozen/button": patch
+"@fiscozen/link": patch
+"@fiscozen/tooltip": patch
+"@fiscozen/checkbox": patch
+"@fiscozen/collapse": patch
+---
+
+Replace fragile reference-identity slot filtering and provide/inject keys with namespaced primitive strings.
+
+Two related Vite dev-mode regressions are fixed at the same time, both rooted in module-instance duplication that occurs when consuming apps exclude `@fiscozen/*` packages from `optimizeDeps` (needed to preserve nested npm resolution for version-conflicting transitives). When the same `.vue` or `.ts` file is loaded as multiple distinct module instances, reference-identity comparisons (`vnode.type === Component` for slot filtering, `Symbol(...)` for provide/inject keys) silently fail.
+
+**Slot filtering** — child components now expose a `__fzKind` marker via `defineOptions({ __fzKind: "@fiscozen/<package>/<Component>" })`, and parents filter by reading that string instead of comparing references. Affected:
+- `FzTabs` filtering `FzTab` children
+- `FzSimpleTable` filtering `FzColumn` children
+- `FzTable` filtering `FzColumn`/`FzRow` children
+- `FzButtonGroup` validating `FzButton` children
+- `FzTooltip` auto-detecting `FzButton`/`FzIconButton`/`FzLink` for interactive-element handling
+
+**Provide/inject keys** — the two module-scoped `Symbol(...)` injection keys are now namespaced primitive strings, applying the same value-equality property to provide/inject. Affected:
+- `@fiscozen/checkbox` `CHECKED_SET_KEY`
+- `@fiscozen/collapse` `ACCORDION_KEY`
+
+No public API changes; consumers do not need to update their templates or call sites.

--- a/.changeset/tooltip-prune-stale-runtime-deps.md
+++ b/.changeset/tooltip-prune-stale-runtime-deps.md
@@ -1,0 +1,7 @@
+---
+"@fiscozen/tooltip": patch
+---
+
+Remove `@fiscozen/button` and `@fiscozen/link` from runtime dependencies. After the `__fzKind` refactor, `FzTooltip` no longer imports those packages as values — auto-detection of interactive children works via primitive string markers read off the slot vnode. Both packages are kept in `devDependencies` because the tooltip test suite still mounts `FzButton`/`FzLink` to verify the auto-detection behavior.
+
+Pure dependency-graph cleanup; no behavior change. Consumers using `<FzTooltip>` around `<FzButton>` or `<FzLink>` already have those packages in their own dependency tree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,20 @@ pnpm changeset:status              # View pending changesets
 - **MDX docs:** `apps/storybook/src/Fz{Name}.mdx`
 - **Exports:** Named component export + type re-exports from `index.ts`
 
+## Container component slot identification
+
+When a parent component inspects its slot children to filter them by type (e.g. `FzTabs` looking for `FzTab` children, `FzTable` looking for `FzColumn`/`FzRow`), DO NOT compare `vnode.type` against an imported component reference. In Vite dev mode, when a consuming app excludes `@fiscozen/*` from `optimizeDeps`, the same SFC can be loaded as multiple module instances and the reference equality silently fails — the parent renders an empty container.
+
+Use the `__fzKind` marker convention instead:
+
+- **Child** (the filtered component): expose a primitive string identifier via `defineOptions({ __fzKind: '@fiscozen/<package>/<Component>' })` right after the imports.
+- **Parent** (the filter call site): define a `FZ_<KIND>_KIND` constant with the expected string and a small `isFz<Kind>` helper that reads `vnode.type.__fzKind`. Replace each `vnode.type === ImportedComponent` with the helper.
+- **Test**: every component exposing `__fzKind` should have a one-line lock-in assertion in its spec (`expect((Cmp as any).__fzKind).toBe('@fiscozen/<pkg>/<Cmp>')`) so a typo in either side is caught.
+
+The same naming applies to `provide`/`inject` keys: prefer a namespaced string (`'@fiscozen/<package>/<Key>'` cast as `InjectionKey<T>`) over `Symbol(...)`. Symbols created at module scope have the same module-duplication fragility as component references; primitive strings are value-equal across module instances.
+
+See `@fiscozen/tab/FzTab.vue` + `@fiscozen/tab/FzTabs.vue` for the canonical example.
+
 ## Code Style
 
 - Vue 3 Composition API with `<script setup lang="ts">`

--- a/packages/button/src/FzButton.vue
+++ b/packages/button/src/FzButton.vue
@@ -31,6 +31,8 @@ import { FzIcon } from '@fiscozen/icons'
 import type { FzButtonProps, ButtonEnvironment } from './types'
 import { sizeToEnvironmentMapping } from './utils'
 
+defineOptions({ __fzKind: '@fiscozen/button/FzButton' })
+
 const props = withDefaults(
   defineProps<FzButtonProps>(),
   {

--- a/packages/button/src/FzIconButton.vue
+++ b/packages/button/src/FzIconButton.vue
@@ -5,7 +5,8 @@
  * passed to FzButton via v-bind="$attrs" instead.
  */
 defineOptions({
-  inheritAttrs: false
+  inheritAttrs: false,
+  __fzKind: '@fiscozen/button/FzIconButton'
 })
 
 /**

--- a/packages/button/src/__tests__/FzButton.spec.ts
+++ b/packages/button/src/__tests__/FzButton.spec.ts
@@ -560,4 +560,10 @@ describe('FzButton', () => {
       expect(wrapper.html()).toMatchSnapshot()
     })
   })
+
+  describe('Component identification (marker-based)', () => {
+    it('should expose __fzKind marker for slot-filter parents', () => {
+      expect((FzButton as any).__fzKind).toBe('@fiscozen/button/FzButton')
+    })
+  })
 })

--- a/packages/button/src/__tests__/FzIconButton.spec.ts
+++ b/packages/button/src/__tests__/FzIconButton.spec.ts
@@ -694,5 +694,11 @@ describe('FzIconButton', () => {
       expect(badge.classes()).toContain('h-8')
     })
   })
+
+  describe('Component identification (marker-based)', () => {
+    it('should expose __fzKind marker for slot-filter parents', () => {
+      expect((FzIconButton as any).__fzKind).toBe('@fiscozen/button/FzIconButton')
+    })
+  })
 })
 

--- a/packages/button/src/utils.ts
+++ b/packages/button/src/utils.ts
@@ -1,6 +1,7 @@
 import type { VNode } from 'vue'
 import type { SizeToEnvironmentMap, ButtonSize, ButtonEnvironment } from './types'
-import FzButton from './FzButton.vue'
+
+const FZ_BUTTON_KIND = '@fiscozen/button/FzButton'
 
 /**
  * Minimum number of FzButton components required in FzButtonGroup slot.
@@ -33,12 +34,16 @@ export const sizeToEnvironmentMapping: SizeToEnvironmentMap = {
 
 /**
  * Checks if a VNode represents a FzButton component.
- * 
+ *
+ * Uses the `__fzKind` marker (a primitive string) instead of reference identity
+ * so the check survives module-instance duplication in Vite dev mode when the
+ * package is excluded from optimizeDeps in consuming apps.
+ *
  * @param vnode - The VNode to check
  * @returns true if the VNode is a FzButton component
  */
 export function isButtonComponent(vnode: VNode): boolean {
-  return vnode.type === FzButton
+  return (vnode.type as { __fzKind?: string } | null)?.__fzKind === FZ_BUTTON_KIND
 }
 
 /**

--- a/packages/checkbox/src/common.ts
+++ b/packages/checkbox/src/common.ts
@@ -38,6 +38,11 @@ export interface CheckedSetProvision {
  * Provided by FzCheckboxGroup so child cards/checkboxes can do O(1) membership
  * checks instead of O(N) Array.includes scans — but only when the group's
  * model and the child's model reference the same array.
+ *
+ * Uses a namespaced primitive string rather than `Symbol(...)` so the key
+ * stays value-equal across module instances. This matters in Vite dev mode
+ * when consuming apps exclude `@fiscozen/*` packages from optimizeDeps and
+ * the same `.ts` file may be loaded as multiple module instances. The cast
+ * preserves the typed `InjectionKey<T>` API at provide/inject call sites.
  */
-export const CHECKED_SET_KEY: InjectionKey<CheckedSetProvision> =
-  Symbol("FzCheckboxCheckedSet");
+export const CHECKED_SET_KEY = "@fiscozen/checkbox/CheckedSet" as unknown as InjectionKey<CheckedSetProvision>;

--- a/packages/collapse/src/types.ts
+++ b/packages/collapse/src/types.ts
@@ -24,4 +24,14 @@ export interface AccordionContext {
   notifyOpen: (id: string) => void
 }
 
-export const ACCORDION_KEY: InjectionKey<AccordionContext> = Symbol('FzAccordion')
+/**
+ * Injection key for the accordion context provided by FzAccordion to its
+ * FzCollapse children.
+ *
+ * Uses a namespaced primitive string rather than `Symbol(...)` so the key
+ * stays value-equal across module instances. This matters in Vite dev mode
+ * when consuming apps exclude `@fiscozen/*` packages from optimizeDeps and
+ * the same `.ts` file may be loaded as multiple module instances. The cast
+ * preserves the typed `InjectionKey<T>` API at provide/inject call sites.
+ */
+export const ACCORDION_KEY = '@fiscozen/collapse/Accordion' as unknown as InjectionKey<AccordionContext>

--- a/packages/link/src/FzLink.vue
+++ b/packages/link/src/FzLink.vue
@@ -23,6 +23,8 @@
 import { computed, watch } from 'vue'
 import { FzLinkProps } from './types'
 
+defineOptions({ __fzKind: '@fiscozen/link/FzLink' })
+
 const props = withDefaults(defineProps<FzLinkProps>(), {
   type: 'default',
   linkStyle: 'default',

--- a/packages/link/src/__tests__/FzLink.spec.ts
+++ b/packages/link/src/__tests__/FzLink.spec.ts
@@ -1356,5 +1356,11 @@ describe('FzLink', () => {
       expect(wrapper.html()).toMatchSnapshot()
     })
   })
+
+  describe('Component identification (marker-based)', () => {
+    it('should expose __fzKind marker for slot-filter parents', () => {
+      expect((FzLink as any).__fzKind).toBe('@fiscozen/link/FzLink')
+    })
+  })
 })
 

--- a/packages/simple-table/src/FzColumn.vue
+++ b/packages/simple-table/src/FzColumn.vue
@@ -3,6 +3,8 @@
 <script setup lang="ts">
 import { FzColumnProps, FzColumnSlots } from "./types";
 
+defineOptions({ __fzKind: "@fiscozen/simple-table/FzColumn" });
+
 const props = withDefaults(defineProps<FzColumnProps>(), {
     headerTextJustify: "left",
 });

--- a/packages/simple-table/src/FzSimpleTable.vue
+++ b/packages/simple-table/src/FzSimpleTable.vue
@@ -33,13 +33,17 @@
 
 <script setup lang="ts">
 import { useSlots } from "vue";
+import type { VNode } from "vue";
 import {
   FzColumnProps,
   FzColumnSlots,
   FzSimpleTableProps,
   FzSimpleTableSlots,
 } from "./types";
-import FzColumn from "./FzColumn.vue";
+
+const FZ_COLUMN_KIND = "@fiscozen/simple-table/FzColumn";
+const isFzColumn = (vnode: VNode): boolean =>
+  (vnode.type as { __fzKind?: string } | null)?.__fzKind === FZ_COLUMN_KIND;
 
 const props = withDefaults(defineProps<FzSimpleTableProps>(), {});
 
@@ -51,7 +55,7 @@ const slots = useSlots();
 const defaultSlot = slots.default?.();
 const columns =
   defaultSlot
-    ?.filter((elem) => elem.type === FzColumn)
+    ?.filter(isFzColumn)
     .map((column) => ({
       props: column.props as FzColumnProps,
       children: column.children as FzColumnSlots,

--- a/packages/simple-table/src/__tests__/FzSimpleTable.spec.ts
+++ b/packages/simple-table/src/__tests__/FzSimpleTable.spec.ts
@@ -933,4 +933,10 @@ describe("FzSimpleTable", () => {
       expect(wrapper.html()).toMatchSnapshot();
     });
   });
+
+  describe("Component identification (marker-based)", () => {
+    it("should expose __fzKind marker on FzColumn for slot-filter parents", () => {
+      expect((FzColumn as any).__fzKind).toBe("@fiscozen/simple-table/FzColumn");
+    });
+  });
 });

--- a/packages/tab/src/FzTab.vue
+++ b/packages/tab/src/FzTab.vue
@@ -6,7 +6,7 @@
 import { inject, onMounted, Ref, computed, onBeforeUnmount } from "vue";
 import { FzTabProps } from "./types";
 
-defineOptions({ _isFzTab: true });
+defineOptions({ __fzKind: "@fiscozen/tab/FzTab" });
 
 const props = defineProps<FzTabProps>();
 

--- a/packages/tab/src/FzTabs.vue
+++ b/packages/tab/src/FzTabs.vue
@@ -43,11 +43,13 @@ import FzTabButton from "./components/FzTabButton.vue";
 import { debugWarn, mapSizeToEnvironment } from "./common";
 
 /**
- * Identifies FzTab vnodes via marker instead of reference identity.
- * Avoids module deduplication issues when the package is excluded from Vite's optimizeDeps.
+ * Identifies FzTab vnodes via a string marker instead of reference identity.
+ * Avoids module-instance duplication issues when the package is excluded
+ * from Vite's optimizeDeps in consuming apps.
  */
+const FZ_TAB_KIND = "@fiscozen/tab/FzTab";
 const isFzTab = (vnode: VNode): boolean =>
-  (vnode.type as any)?._isFzTab === true;
+  (vnode.type as { __fzKind?: string } | null)?.__fzKind === FZ_TAB_KIND;
 
 const props = withDefaults(defineProps<FzTabsProps>(), {
   vertical: false,

--- a/packages/tab/src/__tests__/FzTabs.spec.ts
+++ b/packages/tab/src/__tests__/FzTabs.spec.ts
@@ -936,8 +936,8 @@ describe("FzTabs", () => {
   // TAB IDENTIFICATION (marker-based)
   // ============================================
   describe("Tab identification", () => {
-    it("should have _isFzTab marker on FzTab component", () => {
-      expect((FzTab as any)._isFzTab).toBe(true);
+    it("should have __fzKind marker on FzTab component", () => {
+      expect((FzTab as any).__fzKind).toBe("@fiscozen/tab/FzTab");
     });
 
     it("should not render non-FzTab components as tabs", async () => {

--- a/packages/table/src/FzRow.vue
+++ b/packages/table/src/FzRow.vue
@@ -9,6 +9,8 @@ import { FzRadio } from "@fiscozen/radio";
 import { useMediaQuery } from "@fiscozen/composables";
 import { breakpoints } from "@fiscozen/style";
 
+defineOptions({ __fzKind: "@fiscozen/table/FzRow" });
+
 const props = defineProps<FzRowProps<T>>();
 const emit = defineEmits<{
   "fztable:rowactionclick": [actionIndex: number, action: FzActionProps, rowData: T | undefined];

--- a/packages/table/src/FzTable.vue
+++ b/packages/table/src/FzTable.vue
@@ -10,7 +10,7 @@ import {
 } from "./";
 import { getBodyClasses, bodyStaticClasses } from "./utils";
 import { FzButton, FzIconButton } from "@fiscozen/button";
-import { FzColumn, FzColumnSlots, FzColumnProps } from "@fiscozen/simple-table";
+import type { FzColumnSlots, FzColumnProps } from "@fiscozen/simple-table";
 import { FzIcon } from "@fiscozen/icons";
 import { FzInput } from "@fiscozen/input";
 import { useMediaQuery } from "@fiscozen/composables";
@@ -20,6 +20,13 @@ import { FzCheckbox } from "@fiscozen/checkbox";
 import { FzConfirmDialog } from "@fiscozen/dialog";
 import { FzActionProps } from "@fiscozen/action";
 import { FzProgress } from "@fiscozen/progress";
+
+const FZ_COLUMN_KIND = "@fiscozen/simple-table/FzColumn";
+const FZ_ROW_KIND = "@fiscozen/table/FzRow";
+const isFzColumn = (vnode: VNode): boolean =>
+  (vnode.type as { __fzKind?: string } | null)?.__fzKind === FZ_COLUMN_KIND;
+const isFzRow = (vnode: VNode): boolean =>
+  (vnode.type as { __fzKind?: string } | null)?.__fzKind === FZ_ROW_KIND;
 
 FzCheckbox.compatConfig = {
   MODE: 3,
@@ -91,11 +98,11 @@ const columns = computed(() => {
     defaultSlot.value
       ?.filter(
         (elem) =>
-          elem.type === FzColumn ||
+          isFzColumn(elem) ||
           (typeof elem.type === "symbol" && Array.isArray(elem.children)),
       )
       .flatMap((slot) => {
-        if (slot.type === FzColumn) {
+        if (isFzColumn(slot)) {
           return getColumn(slot);
         } else {
           return (slot.children as VNode[])?.map(getColumn);
@@ -108,7 +115,7 @@ const rows = computed(() => {
   if (!slots.default) return [];
   return (
     defaultSlot.value
-      ?.filter((elem) => elem.type === FzRow)
+      ?.filter(isFzRow)
       .map((row) => ({
         props: row.props as FzRowProps<T>,
         children: row.children as FzRowSlots,

--- a/packages/table/src/__tests__/FzTable.spec.ts
+++ b/packages/table/src/__tests__/FzTable.spec.ts
@@ -1032,4 +1032,14 @@ describe("FzTable", () => {
       expect(wrapper.html()).toMatchSnapshot();
     });
   });
+
+  describe("Component identification (marker-based)", () => {
+    it("should expose __fzKind marker on FzRow for slot-filter parents", () => {
+      expect((FzRow as any).__fzKind).toBe("@fiscozen/table/FzRow");
+    });
+
+    it("should expose __fzKind marker on FzColumn for slot-filter parents", () => {
+      expect((FzColumn as any).__fzKind).toBe("@fiscozen/simple-table/FzColumn");
+    });
+  });
 });

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -14,9 +14,7 @@
   "keywords": [],
   "author": "Riccardo Agnoletto",
   "dependencies": {
-    "@fiscozen/button": "workspace:*",
-    "@fiscozen/composables": "workspace:*",
-    "@fiscozen/link": "workspace:*"
+    "@fiscozen/composables": "workspace:*"
   },
   "peerDependencies": {
     "@fiscozen/icons": "workspace:^",
@@ -24,7 +22,9 @@
     "vue": "^3.4.13"
   },
   "devDependencies": {
+    "@fiscozen/button": "workspace:*",
     "@fiscozen/eslint-config": "workspace:^",
+    "@fiscozen/link": "workspace:*",
     "@fiscozen/prettier-config": "workspace:^",
     "@fiscozen/tsconfig": "workspace:^",
     "@rushstack/eslint-patch": "^1.3.3",

--- a/packages/tooltip/src/FzTooltip.vue
+++ b/packages/tooltip/src/FzTooltip.vue
@@ -41,9 +41,7 @@
 
   import { FzFloating } from '@fiscozen/composables'
   import { FzIcon } from '@fiscozen/icons'
-  import { FzButton, FzIconButton } from '@fiscozen/button'
-  import { FzLink } from '@fiscozen/link'
-  
+
   import { FzTooltipProps, FzTooltipStatus } from './types'
 
   const props = withDefaults(defineProps<FzTooltipProps>(), {
@@ -60,32 +58,37 @@
    * AUTO-DETECTION OF INTERACTIVE ELEMENTS
    * Automatically detects interactive components to prevent double tab stops
    * without requiring manual interactive prop.
-   * 
-   * To extend auto-detection for new components:
-   * 1. Import the component: import { FzNewComponent } from '@fiscozen/...'
-   * 2. Add to INTERACTIVE_COMPONENTS array
-   * 3. Add to peerDependencies in package.json
+   *
+   * Detection uses the `__fzKind` marker (a primitive string set via
+   * defineOptions on each component). This is value-equal across module
+   * instances, so it survives Vite dev-mode module duplication that occurs
+   * when consuming apps exclude these packages from optimizeDeps.
+   *
+   * To extend auto-detection for a new component:
+   * 1. Add `defineOptions({ __fzKind: '@fiscozen/<pkg>/<Component>' })` to it.
+   * 2. Add the kind string to INTERACTIVE_KINDS below.
    * ======================================================================== */
 
   /**
-   * List of interactive components for auto-detection.
-   * Components in this array are recognized as interactive and won't receive
-   * an additional tabindex="0" on the tooltip wrapper.
+   * Set of `__fzKind` markers recognized as interactive.
+   * Components matching one of these kinds will not receive an additional
+   * tabindex="0" on the tooltip wrapper.
    */
-  const INTERACTIVE_COMPONENTS = [FzButton, FzIconButton, FzLink] as const;
+  const INTERACTIVE_KINDS = new Set<string>([
+    '@fiscozen/button/FzButton',
+    '@fiscozen/button/FzIconButton',
+    '@fiscozen/link/FzLink',
+  ])
 
   /**
    * Checks if a VNode represents an interactive component.
-   * 
-   * Compares the VNode type against the INTERACTIVE_COMPONENTS array
-   * using direct component reference comparison.
-   * 
+   *
    * @param vnode - The VNode to check
-   * @returns true if the VNode is in INTERACTIVE_COMPONENTS
+   * @returns true if the VNode's component carries an interactive `__fzKind`
    */
   function isInteractiveComponent(vnode: VNode): boolean {
-    const componentType = vnode.type;
-    return INTERACTIVE_COMPONENTS.includes(componentType as any);
+    const kind = (vnode.type as { __fzKind?: string } | null)?.__fzKind
+    return typeof kind === 'string' && INTERACTIVE_KINDS.has(kind)
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1011,7 +1011,7 @@ importers:
         version: 4.6.2(vite@5.4.21(@types/node@18.19.130)(lightningcss@1.32.0))(vue@3.5.26(typescript@5.3.3))
       '@vitest/coverage-v8':
         specifier: ^1.2.1
-        version: 1.6.1(vitest@1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1(vitest@4.1.1))(jsdom@23.2.0)(lightningcss@1.32.0))
+        version: 1.6.1(vitest@1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1)(jsdom@23.2.0)(lightningcss@1.32.0))
       '@vue/test-utils':
         specifier: ^2.4.3
         version: 2.4.6
@@ -1038,7 +1038,7 @@ importers:
         version: 3.9.1(@types/node@18.19.130)(rollup@4.55.1)(typescript@5.3.3)(vite@5.4.21(@types/node@18.19.130)(lightningcss@1.32.0))
       vitest:
         specifier: ^1.2.0
-        version: 1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1(vitest@4.1.1))(jsdom@23.2.0)(lightningcss@1.32.0)
+        version: 1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1)(jsdom@23.2.0)(lightningcss@1.32.0)
       vue-tsc:
         specifier: ^1.8.25
         version: 1.8.27(typescript@5.3.3)
@@ -3297,18 +3297,12 @@ importers:
 
   packages/tooltip:
     dependencies:
-      '@fiscozen/button':
-        specifier: workspace:*
-        version: link:../button
       '@fiscozen/composables':
         specifier: workspace:*
         version: link:../composables
       '@fiscozen/icons':
         specifier: workspace:^
         version: link:../icons
-      '@fiscozen/link':
-        specifier: workspace:*
-        version: link:../link
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.19(yaml@2.8.2)
@@ -3316,9 +3310,15 @@ importers:
         specifier: ^3.4.13
         version: 3.5.26(typescript@5.7.3)
     devDependencies:
+      '@fiscozen/button':
+        specifier: workspace:*
+        version: link:../button
       '@fiscozen/eslint-config':
         specifier: workspace:^
         version: link:../eslint-config
+      '@fiscozen/link':
+        specifier: workspace:*
+        version: link:../link
       '@fiscozen/prettier-config':
         specifier: workspace:^
         version: link:../prettier-config
@@ -10362,7 +10362,7 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1(vitest@4.1.1))(jsdom@23.2.0)(lightningcss@1.32.0))':
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1)(jsdom@23.2.0)(lightningcss@1.32.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -10377,7 +10377,7 @@ snapshots:
       std-env: 3.10.0
       strip-literal: 2.1.1
       test-exclude: 6.0.0
-      vitest: 1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1(vitest@4.1.1))(jsdom@23.2.0)(lightningcss@1.32.0)
+      vitest: 1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1)(jsdom@23.2.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14413,7 +14413,7 @@ snapshots:
       jiti: 1.21.7
       yaml: 2.8.2
 
-  vitest@1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1(vitest@4.1.1))(jsdom@23.2.0)(lightningcss@1.32.0):
+  vitest@1.6.1(@types/node@18.19.130)(@vitest/ui@4.1.1)(jsdom@23.2.0)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1


### PR DESCRIPTION
## Problema

Diversi componenti del DS si appoggiano all'**identità referenziale** di oggetti JavaScript per identificarsi tra loro. Due manifestazioni dello stesso schema di base.

### A. Slot-filter

Il parent ispeziona i propri slot children con `vnode.type === ImportedComponent`. Esempio canonico in `@fiscozen/tab/src/FzTabs.vue`:

```ts
.filter((tab) => tab.type === FzTab || typeof tab.type === "symbol")
```

### B. Provide/inject

La `InjectionKey` è un `Symbol("FooContext")` esportato da un modulo condiviso. Esempio in `@fiscozen/collapse/src/types.ts`:

```ts
export const ACCORDION_KEY: InjectionKey<AccordionContext> = Symbol('FzAccordion')
```

`FzAccordion` fa `provide(ACCORDION_KEY, ...)`, `FzCollapse` fa `inject(ACCORDION_KEY)`.

### Causa radice comune

Entrambi i pattern dipendono dalla stessa proprietà del sistema di moduli: **un file fisico → un'unica istanza JS in memoria**. Questa proprietà non è garantita: in dev mode di Vite, quando un pacchetto `@fiscozen/*` è escluso da `optimizeDeps` (cosa che le nostre app devono fare per preservare la nested resolution di npm e gestire i conflitti di versione fra pacchetti DS), Vite serve i `.vue` come ESM individuali e può registrare lo stesso file fisico come **due istanze JS distinte** nel module graph.

Quando questo succede:
- Nel pattern A, il consumer e il parent vedono "due `FzTab`" come oggetti distinti → il filter rigetta tutti i children → il parent renderizza un container vuoto.
- Nel pattern B, il modulo `types.ts` o `common.ts` viene caricato due volte → ogni istanza esegue `Symbol('Foo')` producendo Symbol distinti → `inject()` non trova `provide()` → context `undefined`, registrazione del child fallisce silenziosamente.

Sintomo concretamente osservato in `it-fiscozen-app#fix/HD-23009`: in dev mode, `<FzTabs>` dentro `UserTabs.vue` mostrava il `.tab-container` vuoto. Audit completo del DS ha rivelato che lo stesso schema (referenziale o Symbol module-scoped) era diffuso in più pacchetti, presente come bug attuale o come vulnerabilità latente.

## Soluzione

Entrambi i pattern sono stati riportati a un **identificatore string-based namespaced**: una primitiva `string` viene confrontata per valore, ed è quindi invariante al numero di istanze del modulo in memoria.

### A. Slot-filter — `__fzKind` esposto via `defineOptions`

**Child** (componente filtrato): aggiunto `defineOptions` con identificatore namespaced.

```ts
defineOptions({ __fzKind: "@fiscozen/tab/FzTab" });
```

**Parent** (componente che filtra): rimosso l'import del child come reference, definita una costante con il kind atteso e un helper di type-guard, sostituiti i confronti `===`.

```diff
-import FzTab from "./FzTab.vue";
+
+const FZ_TAB_KIND = "@fiscozen/tab/FzTab";
+const isFzTab = (vnode: VNode) =>
+  (vnode.type as { __fzKind?: string } | null)?.__fzKind === FZ_TAB_KIND;

 // ...
-      .filter((tab) => tab.type === FzTab || typeof tab.type === "symbol")
+      .filter((tab) => isFzTab(tab) || typeof tab.type === "symbol")
```

### B. Provide/inject — `Symbol(...)` → string namespaced

```diff
-export const ACCORDION_KEY: InjectionKey<AccordionContext> = Symbol('FzAccordion')
+export const ACCORDION_KEY = '@fiscozen/collapse/Accordion' as unknown as InjectionKey<AccordionContext>
```

A runtime il valore è una `string` primitiva: `provide`/`inject` di Vue accettano `string | symbol | InjectionKey<T>` come chiave, quindi è una sostituzione drop-in — nessun cambio di firma né nei provide né negli inject. Il cast `as unknown as InjectionKey<T>` è solo un artificio di tipizzazione: `InjectionKey<T>` estende `Symbol` nelle types di Vue, e una stringa nuda non type-checka, ma il valore runtime resta una stringa value-equal fra istanze del modulo.

### Convenzione di naming

In entrambi i refactor il valore è una stringa namespaced: `"@fiscozen/<package>/<Identifier>"`. Elimina rischi di collisione e rende l'identificatore self-describing.

## Pacchetti aggiornati

### Slot-filter refactor (`__fzKind`)

| Pacchetto | File modificati |
|---|---|
| `@fiscozen/tab` | `FzTab.vue`, `FzTabs.vue`, `__tests__/FzTabs.spec.ts` |
| `@fiscozen/simple-table` | `FzColumn.vue`, `FzSimpleTable.vue` |
| `@fiscozen/table` | `FzRow.vue`, `FzTable.vue` |
| `@fiscozen/button` | `FzButton.vue`, `FzIconButton.vue`, `utils.ts` |
| `@fiscozen/link` | `FzLink.vue` |
| `@fiscozen/tooltip` | `FzTooltip.vue` |

### Provide/inject keys (`Symbol(...)` → string namespaced)

| Pacchetto | File modificati |
|---|---|
| `@fiscozen/checkbox` | `common.ts` |
| `@fiscozen/collapse` | `types.ts` |

### Per ogni pacchetto modificato

- Aggiunto `defineOptions({ __fzKind: ... })` ai child (refactor A) o sostituite le `Symbol(...)` keys con stringhe namespaced (refactor B).
- Sostituiti i filter referenziali con helper `isFzXxx` nei parent (refactor A).
- Rimossi gli import dei child usati solo per il confronto referenziale (refactor A).
- Aggiornati i test che mockavano VNode in input ai filter (i mock devono ora esporre `__fzKind`).
- Bumpata la patch version (nessun breaking change per i consumer).

## Note tecniche

- **Stringa vs `Symbol.for`**: nel contesto del problema sono funzionalmente equivalenti (entrambe value-equal tra istanze di modulo). Ho scelto la stringa per costo/beneficio: nessuna costante da importare, debugging diretto in console e devtools, narrowing TypeScript banale, lettura del valore identica in parent e child.
- **Nessuna augmentation globale di `ComponentCustomOptions`**: il read site del refactor A usa il cast localizzato `(vnode.type as { __fzKind?: string } | null)?.__fzKind`. Soluzione meno invasiva di un `declare module 'vue'` globale.
- **Backward compatibility**: nessuna API pubblica cambia. I consumer continuano a usare i componenti come prima — i child renderizzano qualsiasi cosa, i parent filtrano e iniettano context come prima ma con un meccanismo robusto. Patch version sufficiente per ogni pacchetto.

## Test plan

- [ ] Test unitari di ogni pacchetto verdi.
- [ ] Verifica end-to-end nel consuming app: in `it-fiscozen-app#fix/HD-23009`, dopo `npm install` con le versioni bumpate, devono renderizzare correttamente in dev mode:
  - le tab in `UserTabs.vue` (`@fiscozen/tab`)
  - le tabelle (`@fiscozen/table`, `@fiscozen/simple-table`)
  - bottoni e icon button nelle pagine standard (`@fiscozen/button`)
  - link e tooltip (`@fiscozen/link`, `@fiscozen/tooltip`)
  - accordion (`@fiscozen/collapse`)
  - gruppi di checkbox (`@fiscozen/checkbox`)
- [ ] Smoke test di Storybook per ognuno dei pacchetti modificati.

