### PR TITLE
feat(LIB-1911): align FzStepper with Figma design

### DIFF
--- a/.changeset/lib-1911-badge-circle.md
+++ b/.changeset/lib-1911-badge-circle.md
@@ -1,0 +1,5 @@
+---
+"@fiscozen/badge": patch
+---
+
+Fix number variant badge not rendering as a circle in flex containers

--- a/.changeset/lib-1911-stepper-figma-alignment.md
+++ b/.changeset/lib-1911-stepper-figma-alignment.md
@@ -1,0 +1,5 @@
+---
+"@fiscozen/stepper": minor
+---
+
+Align FzStepper with Figma design: new props, visual improvements and refactoring

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -22,7 +22,7 @@
     "postinstall": "node scripts/postinstall-playwright.cjs"
   },
   "dependencies": {
-    "@awesome.me/kit-8137893ad3": "^1.0.416",
+    "@awesome.me/kit-8137893ad3": "^1.0.417",
     "@fiscozen/action": "workspace:^",
     "@fiscozen/actionlist": "workspace:^",
     "@fiscozen/alert": "workspace:^",

--- a/apps/storybook/src/FzStepper.mdx
+++ b/apps/storybook/src/FzStepper.mdx
@@ -1,0 +1,190 @@
+import { Meta, Controls, Markdown } from '@storybook/addon-docs/blocks'
+import { FzStepper } from '@fiscozen/stepper'
+
+<Meta title="Documentation/Navigation/FzStepper" component={FzStepper} />
+
+# FzStepper
+
+A multi-step progress indicator that guides users through a sequential workflow. Supports desktop and mobile layouts, two color environments, and per-step status indicators.
+
+## Overview
+
+FzStepper renders a horizontal step list on desktop and collapses into an expandable dropdown on mobile. Each step can carry a status (completed, error, disabled) and optional text truncation.
+
+### Key Features
+
+- **Dual layout**: Horizontal row on desktop, collapsible dropdown on mobile
+- **Environment theming**: Blue accent for `frontoffice`, dark accent for `backoffice`
+- **Step statuses**: `completed`, `error`, `disabled` with distinct icons and colors
+- **Error styling**: Dashed red progress bar and red title text for error steps
+- **Mobile navigation**: Optional step-list dropdown (`hasStepperList`)
+- **Text truncation**: Per-step single-line truncation via `isTextTruncated`
+- **Description control**: Per-step visibility toggle via `hasStepDescription`
+- **v-model binding**: Two-way binding for `activeStep`
+
+## Properties
+
+### Stepper Props
+
+<Markdown>
+  {`
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| \`steps\` | \`FzStepProps[]\` | — | Array of step objects. Recommended max: 8 steps. |
+| \`environment\` | \`'frontoffice' \\| 'backoffice'\` | \`'frontoffice'\` | Accent color theme for the active step. |
+| \`hasStepbar\` | \`boolean\` | \`true\` | Show or hide the progress bar above each step. |
+| \`hasStepperList\` | \`boolean\` | \`true\` | Mobile only. When \`false\`, hides the step navigation dropdown and shows only the active step. |
+| \`forceMobile\` | \`boolean\` | \`false\` | **Deprecated.** Forces the mobile layout on all screen sizes. |
+| \`v-model:activeStep\` | \`number\` | \`0\` | Index of the currently active step. |
+`}
+</Markdown>
+
+### Step Props (`FzStepProps`)
+
+<Markdown>
+  {`
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| \`title\` | \`string\` | — | Step title (required). |
+| \`description\` | \`string\` | — | Optional step description. |
+| \`status\` | \`'completed' \\| 'error' \\| 'disabled'\` | — | Step status. \`current\` is computed internally from \`activeStep\` and must not be passed. |
+| \`isTextTruncated\` | \`boolean\` | \`false\` | Truncates title and description to a single line with ellipsis. |
+| \`hasStepDescription\` | \`boolean\` | \`true\` | Hides the description even if a description string is provided when set to \`false\`. |
+`}
+</Markdown>
+
+## Visual behaviour by status
+
+<Markdown>
+  {`
+| Status | Icon | Progress bar | Title color |
+|--------|------|-------------|-------------|
+| current | numbered badge | blue (frontoffice) / dark (backoffice) | black |
+| default | numbered badge (grey) | grey-200 | black |
+| completed | ✓ circle-check | grey-500 | black |
+| error | ⚠ circle-exclamation | dashed red | red |
+| disabled | numbered badge (faded) | grey-200, 20% opacity | grey (faded) |
+`}
+</Markdown>
+
+## Usage Examples
+
+### Basic stepper
+
+```vue
+<template>
+  <FzStepper v-model:activeStep="activeStep" :steps="steps" />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { FzStepper } from '@fiscozen/stepper'
+import type { FzStepProps } from '@fiscozen/stepper'
+
+const activeStep = ref(0)
+
+const steps: FzStepProps[] = [
+  { title: 'Informazioni', description: 'Inserisci i dati personali' },
+  { title: 'Documenti', description: 'Carica i documenti richiesti' },
+  { title: 'Riepilogo', description: 'Verifica e conferma' },
+]
+</script>
+```
+
+### Backoffice environment
+
+```vue
+<FzStepper
+  environment="backoffice"
+  v-model:activeStep="activeStep"
+  :steps="steps"
+/>
+```
+
+### Without progress bar
+
+```vue
+<FzStepper :hasStepbar="false" v-model:activeStep="activeStep" :steps="steps" />
+```
+
+### Mobile without step navigation
+
+```vue
+<!-- User sees only the active step, no dropdown to jump between steps -->
+<FzStepper
+  :hasStepperList="false"
+  v-model:activeStep="activeStep"
+  :steps="steps"
+/>
+```
+
+### With truncated text (useful in narrow layouts)
+
+```vue
+<script setup lang="ts">
+const steps = [
+  { title: 'Very long step title that should be clipped', isTextTruncated: true },
+  { title: 'Another step', isTextTruncated: true },
+]
+</script>
+```
+
+### Hiding description per step
+
+```vue
+<script setup lang="ts">
+const steps = [
+  { title: 'Step 1', description: 'Shown', hasStepDescription: true },
+  { title: 'Step 2', description: 'Hidden', hasStepDescription: false },
+]
+</script>
+```
+
+### Marking steps as completed programmatically
+
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { FzStepProps } from '@fiscozen/stepper'
+
+const currentStep = ref(0)
+
+const steps = computed<FzStepProps[]>(() => [
+  {
+    title: 'Seleziona cliente',
+    description: 'Scegli il cliente',
+    status: currentStep.value > 0 ? 'completed' : undefined,
+  },
+  {
+    title: 'Verifica dati',
+    description: 'Controlla le informazioni',
+    status: currentStep.value > 1 ? 'completed' : undefined,
+  },
+  {
+    title: 'Conferma',
+    description: 'Completa il processo',
+  },
+])
+</script>
+```
+
+## Best Practices
+
+- Keep step titles short and action-oriented (e.g. "Inserisci dati", not "Step 1").
+- Use at most 8 steps — beyond that, consider splitting the workflow.
+- Mark preceding steps as `completed` when the user advances, so progress is clear.
+- Use `environment="backoffice"` in admin contexts to stay consistent with the rest of the UI.
+- Set `hasStepperList="false"` when the user cannot navigate backward (e.g. a linear wizard).
+- Use `isTextTruncated` only in space-constrained layouts; prefer full text when space allows.
+
+## Accessibility
+
+- Step icons (check, exclamation) are visual only — provide meaningful `title` and `description` text for screen readers.
+- Disabled steps are visually de-emphasised (20% opacity, no-pointer cursor) and block interaction.
+
+## Import
+
+```typescript
+import { FzStepper } from '@fiscozen/stepper'
+import type { FzStepProps, FzStepperProps, FzStepStatus } from '@fiscozen/stepper'
+```

--- a/apps/storybook/src/stories/navigation/Stepper.stories.ts
+++ b/apps/storybook/src/stories/navigation/Stepper.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
-import { expect, userEvent, within, waitFor, fn } from 'storybook/test'
+import { expect, userEvent, within, waitFor } from 'storybook/test'
 import { FzStepper } from '@fiscozen/stepper'
 import { ref } from 'vue'
 
@@ -8,12 +8,18 @@ const meta: Meta<typeof FzStepper> = {
   component: FzStepper,
   tags: ['autodocs'],
   argTypes: {
-    forceMobile: {
-      control: 'boolean'
-    }
+    environment: {
+      control: 'select',
+      options: ['frontoffice', 'backoffice']
+    },
+    hasStepbar: { control: 'boolean' },
+    hasStepperList: { control: 'boolean' },
+    forceMobile: { table: { disable: true } }
   },
   args: {
-    forceMobile: false
+    environment: 'frontoffice',
+    hasStepbar: true,
+    hasStepperList: true
   },
   decorators: []
 }
@@ -21,494 +27,288 @@ const meta: Meta<typeof FzStepper> = {
 type Story = StoryObj<typeof meta>
 
 const steps = [
-      {
-        title: 'Step 1',
-        description: 'Description 1',
-        status: 'completed'
-      },
-      {
-        title: 'Step 2',
-        description: 'Description 2'
-      },
-      {
-        title: 'Step 3',
-        description: 'Description 3',
-        status: 'error'
-      },
-      {
-        title: 'Step 4',
-        description: 'Description 4',
-        status: 'disabled'
-      },
-      {
-        title: 'Step 5',
-        description: 'Description 5'
-      }
+  {
+    title: 'Informazioni',
+    description: 'Inserisci i dati personali',
+    status: 'completed' as const
+  },
+  {
+    title: 'Documenti',
+    description: 'Carica i documenti richiesti'
+  },
+  {
+    title: 'Riepilogo',
+    description: 'Verifica e conferma',
+    status: 'error' as const
+  },
+  {
+    title: 'Pagamento',
+    description: 'Seleziona il metodo di pagamento'
+  },
+  {
+    title: 'Conferma',
+    description: 'Completa il processo'
+  }
 ]
 
-const Default: Story = {
-  args: {
-    steps,
+const truncatedSteps = [
+  {
+    title: 'Caricamento dei documenti di identità e fiscali obbligatori',
+    description:
+      'Carica il documento di identità in corso di validità e il codice fiscale in formato PDF',
+    isTextTruncated: true,
+    status: 'completed' as const
   },
-  decorators: [() => ({ template: '<div style="padding:20px;" class="h-screen"><story/></div>' })],
-  render: (args) => ({
+  {
+    title: 'Verifica e validazione dei dati inseriti nel modulo di registrazione',
+    description:
+      'Controlla attentamente tutte le informazioni inserite prima di procedere con la fase successiva',
+    isTextTruncated: true
+  },
+  {
+    title: 'Conferma definitiva e invio della pratica al commercialista assegnato',
+    description:
+      'La pratica verrà inviata al commercialista che ti contatterà entro 24 ore lavorative',
+    isTextTruncated: true
+  },
+  {
+    title: 'Revisione approfondita dei termini e delle condizioni contrattuali',
+    description:
+      'Leggi con attenzione i termini del contratto prima di procedere con la firma digitale',
+    isTextTruncated: true
+  },
+  {
+    title: 'Pagamento della quota di iscrizione e attivazione del servizio',
+    description:
+      'Seleziona il metodo di pagamento preferito tra carta di credito, bonifico o PayPal',
+    isTextTruncated: true
+  },
+  {
+    title: 'Ricezione della conferma e accesso alla dashboard personale',
+    description:
+      'Riceverai una email di conferma con le credenziali di accesso alla tua area riservata',
+    isTextTruncated: true
+  }
+]
+
+const renderTemplate = `
+  <div class="w-full flex flex-col items-center">
+    <FzStepper v-bind="args" v-model:activeStep="activeStep" />
+    <div class="w-full mt-16 bg-gray-100 p-4 rounded h-[200px] flex items-center justify-center" data-testid="active-step-display">
+      current active step is {{activeStep + 1}}
+    </div>
+  </div>
+`
+
+const defaultDecorator = [
+  () => ({ template: '<div style="padding:20px;" class="h-screen"><story/></div>' })
+]
+
+function makeRender(initialStep = 1) {
+  return (args: any) => ({
     components: { FzStepper },
     setup() {
-      const activeStep = ref(1)
-      return {
-        args,
-        activeStep
-      }
+      const activeStep = ref(initialStep)
+      return { args, activeStep }
     },
-    template: `
-      <div class="w-full flex flex-col items-center">
-        <FzStepper v-bind="args" v-model:activeStep="activeStep" />
-        <div class="w-full mt-16 bg-gray-100 p-4 rounded h-[200px] flex items-center justify-center" data-testid="active-step-display">
-          current active step is {{activeStep + 1}}
-        </div>
-      </div> 
-    `
-  }),
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement)
-
-    await step('Verify stepper renders correctly', async () => {
-      const stepper = canvasElement.querySelector('.fz-stepper')
-      await expect(stepper).toBeInTheDocument()
-      await expect(stepper).toBeVisible()
-    })
-
-    await step('Verify all steps are rendered', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      await expect(stepElements.length).toBe(5)
-    })
-
-    await step('Verify initial active step display', async () => {
-      const activeStepDisplay = canvas.getByTestId('active-step-display')
-      await expect(activeStepDisplay).toHaveTextContent('current active step is 2')
-    })
-
-    await step('Verify step titles and descriptions are visible', async () => {
-      const step1 = canvas.getByText('Step 1')
-      await expect(step1).toBeVisible()
-      const desc1 = canvas.getByText('Description 1')
-      await expect(desc1).toBeVisible()
-    })
-
-    await step('Verify progress bar is visible', async () => {
-      const progressBars = canvasElement.querySelectorAll('.fz-stepper__progress')
-      await expect(progressBars.length).toBeGreaterThan(0)
-    })
-  }
+    template: renderTemplate
+  })
 }
 
-const NoProgress: Story = {
-  args: {
-    steps,
-    disableProgressBar: true
-  },
-  decorators: [() => ({ template: '<div style="padding:20px;" class="h-screen"><story/></div>' })],
-  render: (args) => ({
-    components: { FzStepper },
-    setup() {
-      const activeStep = ref(1)
-      return {
-        args,
-        activeStep
-      }
-    },
-    template: `
-      <div class="w-full flex flex-col items-center">
-        <FzStepper v-bind="args" v-model:activeStep="activeStep" />
-        <div class="w-full mt-16 bg-gray-100 p-4 rounded h-[200px] flex items-center justify-center" data-testid="active-step-display">
-          current active step is {{activeStep + 1}}
-        </div>
-      </div> 
-    `
-  }),
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement)
+// ============================================
+// DEFAULT
+// ============================================
 
+const defaultSteps = [
+  { title: 'Completed', description: 'This step is completed', status: 'completed' as const },
+  { title: 'Current', description: 'This is the active step' },
+  { title: 'Default', description: 'This step has no status' },
+  { title: 'Error', description: 'This step has an error', status: 'error' as const },
+  { title: 'Disabled', description: 'This step is disabled', status: 'disabled' as const }
+]
+
+export const Default: Story = {
+  args: { steps: defaultSteps },
+  decorators: defaultDecorator,
+  render: makeRender(1),
+  play: async ({ canvasElement, step }) => {
     await step('Verify stepper renders', async () => {
-      const stepper = canvasElement.querySelector('.fz-stepper')
+      await expect(canvasElement.querySelector('.fz-stepper')).toBeInTheDocument()
+    })
+
+    await step('Verify all 5 steps are rendered', async () => {
+      const stepEls = canvasElement.querySelectorAll('.fz-stepper__step')
+      await expect(stepEls.length).toBe(5)
+    })
+
+    await step('Verify progress bars are visible', async () => {
+      const bars = canvasElement.querySelectorAll('.fz-stepper__progress')
+      await expect(bars.length).toBeGreaterThan(0)
+    })
+  }
+}
+
+// ============================================
+// ENVIRONMENT
+// ============================================
+
+export const Frontoffice: Story = {
+  args: { steps, environment: 'frontoffice' },
+  decorators: defaultDecorator,
+  render: makeRender(1),
+  play: async ({ canvasElement, step }) => {
+    await step('Verify current step bar is blue', async () => {
+      const bars = canvasElement.querySelectorAll('.fz-stepper__progress')
+      const currentBar = Array.from(bars).find((b) => b.classList.contains('bg-blue-500'))
+      await expect(currentBar).toBeInTheDocument()
+    })
+  }
+}
+
+export const Backoffice: Story = {
+  args: { steps, environment: 'backoffice' },
+  decorators: defaultDecorator,
+  render: makeRender(1),
+  play: async ({ canvasElement, step }) => {
+    await step('Verify current step bar is blue (bar is always blue)', async () => {
+      const bars = canvasElement.querySelectorAll('.fz-stepper__progress')
+      const currentBar = Array.from(bars).find((b) => b.classList.contains('bg-blue-500'))
+      await expect(currentBar).toBeInTheDocument()
+    })
+  }
+}
+
+// ============================================
+// STEPBAR
+// ============================================
+
+export const NoStepbar: Story = {
+  args: { steps, hasStepbar: false },
+  decorators: defaultDecorator,
+  render: makeRender(1),
+  play: async ({ canvasElement, step }) => {
+    await step('Verify stepbar is hidden', async () => {
+      const bars = canvasElement.querySelectorAll('.fz-stepper__progress')
+      await expect(bars.length).toBe(0)
+    })
+
+    await step('Verify steps are still rendered', async () => {
+      const stepEls = canvasElement.querySelectorAll('.fz-stepper__step')
+      await expect(stepEls.length).toBe(5)
+    })
+  }
+}
+
+// ============================================
+// TEXT TRUNCATION
+// ============================================
+
+export const TextTruncated: Story = {
+  args: { steps: truncatedSteps },
+  decorators: defaultDecorator,
+  render: makeRender(0),
+  play: async ({ canvasElement, step }) => {
+    await step('Verify titles have truncate class', async () => {
+      const titles = canvasElement.querySelectorAll('.fz-stepper__title')
+      for (const title of Array.from(titles)) {
+        await expect(title).toHaveClass('truncate')
+      }
+    })
+
+    await step('Verify descriptions have truncate class', async () => {
+      const descs = canvasElement.querySelectorAll('.fz-stepper__description')
+      for (const desc of Array.from(descs)) {
+        await expect(desc).toHaveClass('truncate')
+      }
+    })
+  }
+}
+
+// ============================================
+// DESCRIPTION VISIBILITY
+// ============================================
+
+export const NoDescription: Story = {
+  args: {
+    steps: steps.map((s) => ({ ...s, hasStepDescription: false }))
+  },
+  decorators: defaultDecorator,
+  render: makeRender(1),
+  play: async ({ canvasElement, step }) => {
+    await step('Verify no description elements are rendered', async () => {
+      const descs = canvasElement.querySelectorAll('.fz-stepper__description')
+      await expect(descs.length).toBe(0)
+    })
+
+    await step('Verify step titles are still visible', async () => {
+      const canvas = within(canvasElement)
+      await expect(canvas.getByText('Informazioni')).toBeVisible()
+    })
+  }
+}
+
+// ============================================
+// MOBILE
+// ============================================
+
+export const MobileWithList: Story = {
+  args: { steps },
+  decorators: defaultDecorator,
+  render: makeRender(1),
+  parameters: {
+    viewport: { defaultViewport: 'xs' }
+  },
+  play: async ({ canvasElement, step }) => {
+    await step('Verify mobile layout renders', async () => {
+      const stepper = canvasElement.querySelector('.fz-stepper.flex.flex-col')
       await expect(stepper).toBeInTheDocument()
     })
 
-    await step('Verify progress bar is hidden when disableProgressBar is true', async () => {
-      const progressBars = canvasElement.querySelectorAll('.fz-stepper__progress')
-      await expect(progressBars.length).toBe(0)
-    })
-
-    await step('Verify steps are still rendered without progress bar', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      await expect(stepElements.length).toBe(5)
-    })
-  }
-}
-
-export { Default, NoProgress }
-
-// ============================================
-// STEP NAVIGATION STORIES
-// ============================================
-
-export const StepNavigation: Story = {
-  args: {
-    steps,
-    'onUpdate:activeStep': fn()
-  },
-  decorators: [() => ({ template: '<div style="padding:20px;" class="h-screen"><story/></div>' })],
-  render: (args) => ({
-    components: { FzStepper },
-    setup() {
-      const activeStep = ref(0)
-      const handleUpdate = (value: number) => {
-        activeStep.value = value
-        args['onUpdate:activeStep'](value)
-      }
-      return {
-        args,
-        activeStep,
-        handleUpdate
-      }
-    },
-    template: `
-      <div class="w-full flex flex-col items-center">
-        <FzStepper v-bind="args" :activeStep="activeStep" @update:activeStep="handleUpdate" />
-        <div class="w-full mt-16 bg-gray-100 p-4 rounded h-[200px] flex items-center justify-center" data-testid="active-step-display">
-          current active step is {{activeStep + 1}}
-        </div>
-      </div> 
-    `
-  }),
-  play: async ({ args, canvasElement, step }) => {
-    const canvas = within(canvasElement)
-
-    await step('Verify initial state - Step 1 is active', async () => {
-      const activeStepDisplay = canvas.getByTestId('active-step-display')
-      await expect(activeStepDisplay).toHaveTextContent('current active step is 1')
-    })
-
-    await step('Click on Step 2 to navigate', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      await userEvent.click(stepElements[1] as HTMLElement)
-      
-      await waitFor(() => {
-        const activeStepDisplay = canvas.getByTestId('active-step-display')
-        expect(activeStepDisplay).toHaveTextContent('current active step is 2')
-      }, { timeout: 1000 })
-      
-      // ROBUST CHECK: Verify handler WAS called
-      await expect(args['onUpdate:activeStep']).toHaveBeenCalledWith(1)
-    })
-
-    await step('Click on Step 3 to navigate', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      await userEvent.click(stepElements[2] as HTMLElement)
-      
-      await waitFor(() => {
-        const activeStepDisplay = canvas.getByTestId('active-step-display')
-        expect(activeStepDisplay).toHaveTextContent('current active step is 3')
-      }, { timeout: 1000 })
-    })
-
-    await step('Click on Step 5 to navigate', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      await userEvent.click(stepElements[4] as HTMLElement)
-      
-      await waitFor(() => {
-        const activeStepDisplay = canvas.getByTestId('active-step-display')
-        expect(activeStepDisplay).toHaveTextContent('current active step is 5')
-      }, { timeout: 1000 })
-    })
-
-    await step('Click back on Step 1 to navigate backwards', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      await userEvent.click(stepElements[0] as HTMLElement)
-      
-      await waitFor(() => {
-        const activeStepDisplay = canvas.getByTestId('active-step-display')
-        expect(activeStepDisplay).toHaveTextContent('current active step is 1')
-      }, { timeout: 1000 })
-    })
-  }
-}
-
-export const DisabledStepBehavior: Story = {
-  args: {
-    steps,
-    'onUpdate:activeStep': fn()
-  },
-  decorators: [() => ({ template: '<div style="padding:20px;" class="h-screen"><story/></div>' })],
-  render: (args) => ({
-    components: { FzStepper },
-    setup() {
-      const activeStep = ref(0)
-      const handleUpdate = (value: number) => {
-        activeStep.value = value
-        args['onUpdate:activeStep'](value)
-      }
-      return {
-        args,
-        activeStep,
-        handleUpdate
-      }
-    },
-    template: `
-      <div class="w-full flex flex-col items-center">
-        <FzStepper v-bind="args" :activeStep="activeStep" @update:activeStep="handleUpdate" />
-        <div class="w-full mt-16 bg-gray-100 p-4 rounded h-[200px] flex items-center justify-center" data-testid="active-step-display">
-          current active step is {{activeStep + 1}}
-        </div>
-      </div> 
-    `
-  }),
-  play: async ({ args, canvasElement, step }) => {
-    const canvas = within(canvasElement)
-
-    await step('Verify initial state - Step 1 is active', async () => {
-      const activeStepDisplay = canvas.getByTestId('active-step-display')
-      await expect(activeStepDisplay).toHaveTextContent('current active step is 1')
-    })
-
-    await step('Verify Step 4 (disabled) has disabled styling', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      const disabledStep = stepElements[3] as HTMLElement
-      await expect(disabledStep).toHaveClass('opacity-[.2]')
-      await expect(disabledStep).toHaveClass('!cursor-not-allowed')
-    })
-
-    await step('Click on disabled Step 4 - should not change active step', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      const disabledStep = stepElements[3] as HTMLElement
-      const activeStepDisplay = canvas.getByTestId('active-step-display')
-      
-      // Verify initial state
-      await expect(activeStepDisplay).toHaveTextContent(/current active step is 1/)
-      
-      // Clear any previous calls
-      args['onUpdate:activeStep'].mockClear()
-      
-      await userEvent.click(disabledStep)
-      
-      // Wait a short time to ensure no state change occurred
-      await new Promise(resolve => setTimeout(resolve, 100))
-      
-      // Verify the active step is still 1 (hasn't changed)
-      await expect(activeStepDisplay).toHaveTextContent(/current active step is 1/)
-      
-      // ROBUST CHECK: Verify handler was NOT called for disabled step
-      await expect(args['onUpdate:activeStep']).not.toHaveBeenCalled()
-    })
-
-    await step('Click on current Step 1 - should not change active step', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      const currentStep = stepElements[0] as HTMLElement
-      
-      // Clear any previous calls
-      args['onUpdate:activeStep'].mockClear()
-      
-      await userEvent.click(currentStep)
-      
-      // Wait a bit to ensure no state change occurred
-      await new Promise(resolve => setTimeout(resolve, 100))
-      
-      const activeStepDisplay = canvas.getByTestId('active-step-display')
-      await expect(activeStepDisplay).toHaveTextContent('current active step is 1')
-      
-      // ROBUST CHECK: Verify handler was NOT called when clicking current step
-      await expect(args['onUpdate:activeStep']).not.toHaveBeenCalled()
-    })
-  }
-}
-
-export const StepStatuses: Story = {
-  args: {
-    steps,
-  },
-  decorators: [() => ({ template: '<div style="padding:20px;" class="h-screen"><story/></div>' })],
-  render: (args) => ({
-    components: { FzStepper },
-    setup() {
-      const activeStep = ref(1)
-      return {
-        args,
-        activeStep
-      }
-    },
-    template: `
-      <div class="w-full flex flex-col items-center">
-        <FzStepper v-bind="args" v-model:activeStep="activeStep" />
-        <div class="w-full mt-16 bg-gray-100 p-4 rounded h-[200px] flex items-center justify-center" data-testid="active-step-display">
-          current active step is {{activeStep + 1}}
-        </div>
-      </div> 
-    `
-  }),
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement)
-
-    await step('Verify Step 1 (completed) shows check icon', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      const completedStep = stepElements[0] as HTMLElement
-      const checkIcon = completedStep.querySelector('.fa-circle-check')
-      await expect(checkIcon).toBeInTheDocument()
-    })
-
-    await step('Verify Step 2 (current) shows badge with number', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      const currentStep = stepElements[1] as HTMLElement
-      // Badge is rendered as a div with number content
-      const badgeContainer = currentStep.querySelector('.fz-stepper__circle')
-      await expect(badgeContainer).toBeInTheDocument()
-      await expect(badgeContainer).toHaveTextContent('2')
-    })
-
-    await step('Verify Step 3 (error) shows error icon', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      const errorStep = stepElements[2] as HTMLElement
-      const errorIcon = errorStep.querySelector('.fa-circle-exclamation')
-      await expect(errorIcon).toBeInTheDocument()
-    })
-
-    await step('Verify Step 4 (disabled) has disabled styling', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      const disabledStep = stepElements[3] as HTMLElement
-      await expect(disabledStep).toHaveClass('opacity-[.2]')
-    })
-
-    await step('Verify Step 5 (default) shows badge with number', async () => {
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      const defaultStep = stepElements[4] as HTMLElement
-      // Badge is rendered as a div with number content
-      const badgeContainer = defaultStep.querySelector('.fz-stepper__circle')
-      await expect(badgeContainer).toBeInTheDocument()
-      await expect(badgeContainer).toHaveTextContent('5')
-    })
-  }
-}
-
-export const MobileView: Story = {
-  args: {
-    steps,
-    forceMobile: true
-  },
-  decorators: [() => ({ template: '<div style="padding:20px;" class="h-screen"><story/></div>' })],
-  render: (args) => ({
-    components: { FzStepper },
-    setup() {
-      const activeStep = ref(1)
-      return {
-        args,
-        activeStep
-      }
-    },
-    template: `
-      <div class="w-full flex flex-col items-center">
-        <FzStepper v-bind="args" v-model:activeStep="activeStep" />
-        <div class="w-full mt-16 bg-gray-100 p-4 rounded h-[200px] flex items-center justify-center" data-testid="active-step-display">
-          current active step is {{activeStep + 1}}
-        </div>
-      </div> 
-    `
-  }),
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement)
-
-    await step('Verify mobile view renders with dropdown', async () => {
-      const stepper = canvasElement.querySelector('.fz-stepper')
-      await expect(stepper).toBeInTheDocument()
-      
-      // Mobile view should have dropdown
+    await step('Verify dropdown is visible', async () => {
       const dropdown = canvasElement.querySelector('.fz-stepper__dropdown')
       await expect(dropdown).toBeInTheDocument()
     })
 
-    await step('Verify current step title is displayed', async () => {
-      const currentStepTitle = canvas.getByText('Step 2')
-      await expect(currentStepTitle).toBeVisible()
+    await step('Verify active step title is displayed', async () => {
+      const canvas = within(canvasElement)
+      await expect(canvas.getByText('Documenti')).toBeVisible()
     })
 
-    await step('Verify current step description is displayed', async () => {
-      const currentStepDescription = canvas.getByText('Description 2')
-      await expect(currentStepDescription).toBeVisible()
-    })
-
-    await step('Verify dropdown can be opened', async () => {
-      const dropdownOpener = canvasElement.querySelector('.fz-stepper__dropdown')
-      const clickableArea = dropdownOpener?.querySelector('.cursor-pointer') as HTMLElement
-      
-      if (clickableArea) {
-        // Click to open dropdown
-        await userEvent.click(clickableArea)
-        
-        // Wait for dropdown content to appear (check for Step 3 text in document)
-        await waitFor(() => {
-          const bodyText = document.body.textContent || ''
-          expect(bodyText).toContain('Step 3')
-        }, { timeout: 1000 })
+    await step('Open dropdown and verify steps are listed', async () => {
+      const dropdown = canvasElement.querySelector('.fz-stepper__dropdown')
+      const opener = dropdown?.querySelector('.cursor-pointer') as HTMLElement
+      if (opener) {
+        await userEvent.click(opener)
+        await waitFor(
+          () => {
+            expect(document.body.textContent).toContain('Riepilogo')
+          },
+          { timeout: 1000 }
+        )
       }
-    })
-
-    await step('Verify dropdown shows all step options', async () => {
-      // Verify that all steps are available in the dropdown
-      const bodyText = document.body.textContent || ''
-      await expect(bodyText).toContain('Step 1')
-      await expect(bodyText).toContain('Step 2')
-      await expect(bodyText).toContain('Step 3')
-      await expect(bodyText).toContain('Step 4')
-      await expect(bodyText).toContain('Step 5')
     })
   }
 }
 
-export const KeyboardNavigation: Story = {
-  args: {
-    steps,
+export const MobileWithoutList: Story = {
+  args: { steps, hasStepperList: false },
+  decorators: defaultDecorator,
+  render: makeRender(1),
+  parameters: {
+    viewport: { defaultViewport: 'xs' }
   },
-  decorators: [() => ({ template: '<div style="padding:20px;" class="h-screen"><story/></div>' })],
-  render: (args) => ({
-    components: { FzStepper },
-    setup() {
-      const activeStep = ref(0)
-      return {
-        args,
-        activeStep
-      }
-    },
-    template: `
-      <div class="w-full flex flex-col items-center">
-        <FzStepper v-bind="args" v-model:activeStep="activeStep" />
-        <div class="w-full mt-16 bg-gray-100 p-4 rounded h-[200px] flex items-center justify-center" data-testid="active-step-display">
-          current active step is {{activeStep + 1}}
-        </div>
-      </div> 
-    `
-  }),
   play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement)
-
-    await step('Verify steps are clickable via keyboard simulation', async () => {
-      // Since stepper steps are divs (not buttons), they're not natively keyboard accessible
-      // However, we can verify that clicking works which simulates keyboard interaction
-      const stepElements = canvasElement.querySelectorAll('.fz-stepper__step')
-      const secondStep = stepElements[1] as HTMLElement
-      
-      // Simulate keyboard interaction by clicking (which is what keyboard events would trigger)
-      await userEvent.click(secondStep)
-      
-      await waitFor(() => {
-        const activeStepDisplay = canvas.getByTestId('active-step-display')
-        expect(activeStepDisplay).toHaveTextContent('current active step is 2')
-      }, { timeout: 1000 })
+    await step('Verify mobile layout renders', async () => {
+      await expect(canvasElement.querySelector('.fz-stepper.flex.flex-col')).toBeInTheDocument()
     })
 
-    await step('Verify step titles are accessible via text content', async () => {
-      // Verify that step content is accessible for screen readers
-      const step1 = canvas.getByText('Step 1')
-      await expect(step1).toBeVisible()
-      const step2 = canvas.getByText('Step 2')
-      await expect(step2).toBeVisible()
+    await step('Verify dropdown is NOT rendered', async () => {
+      await expect(canvasElement.querySelector('.fz-stepper__dropdown')).not.toBeInTheDocument()
+    })
+
+    await step('Verify active step is still displayed', async () => {
+      const canvas = within(canvasElement)
+      await expect(canvas.getByText('Documenti')).toBeVisible()
     })
   }
 }

--- a/apps/storybook/src/stories/navigation/Stepper.stories.ts
+++ b/apps/storybook/src/stories/navigation/Stepper.stories.ts
@@ -252,7 +252,7 @@ export const NoDescription: Story = {
 // ============================================
 
 export const MobileWithList: Story = {
-  args: { steps },
+  args: { steps, forceMobile: true },
   decorators: defaultDecorator,
   render: makeRender(1),
   parameters: {
@@ -291,7 +291,7 @@ export const MobileWithList: Story = {
 }
 
 export const MobileWithoutList: Story = {
-  args: { steps, hasStepperList: false },
+  args: { steps, hasStepperList: false, forceMobile: true },
   decorators: defaultDecorator,
   render: makeRender(1),
   parameters: {

--- a/apps/storybook/tailwind.config.js
+++ b/apps/storybook/tailwind.config.js
@@ -23,6 +23,7 @@ export default {
     './node_modules/@fiscozen/tab/src/**/*.{html,js,ts,vue}',
     './node_modules/@fiscozen/chat-container/src/**/*.{html,js,ts,vue}',
     './node_modules/@fiscozen/pagination/src/**/*.{html,js,ts,vue}',
-    './node_modules/@fiscozen/icons/src/**/*.{html,js,ts,vue}'
+    './node_modules/@fiscozen/icons/src/**/*.{html,js,ts,vue}',
+    './node_modules/@fiscozen/stepper/src/**/*.{html,js,ts,vue}'
   ]
 }

--- a/packages/badge/src/FzBadge.vue
+++ b/packages/badge/src/FzBadge.vue
@@ -6,7 +6,7 @@
       :variant="leftIconVariant"
       size="sm"
     />
-    <p :class="['text-[inherit] text-sm', { 'truncate': truncate }]">
+    <p :class="['text-[inherit] text-sm', { truncate: truncate }]">
       <slot></slot>
     </p>
     <FzIcon
@@ -80,6 +80,7 @@ const classes = computed(() => {
   if (effectiveVariant.value === "number") {
     baseClasses.push(
       "size-24", // Fixed 24x24px for number variant
+      "min-w-24", // Prevent flex shrink from collapsing width
       "rounded-full",
     );
   } else {
@@ -97,6 +98,6 @@ const classes = computed(() => {
 });
 
 const textClasses = computed(() => {
-  return ['text-[inherit] text-sm', { 'truncate': props.truncate }];
+  return ["text-[inherit] text-sm", { truncate: props.truncate }];
 });
 </script>

--- a/packages/badge/src/__tests__/__snapshots__/FzBadge.spec.ts.snap
+++ b/packages/badge/src/__tests__/__snapshots__/FzBadge.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzBadge > Snapshots > should have rounded-full class when default slot is a string with 1 character 1`] = `
-"<div class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white" title="1">
+"<div class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-500 text-core-white" title="1">
   <!--v-if-->
   <p class="text-[inherit] text-sm">1</p>
   <!--v-if-->
@@ -41,7 +41,7 @@ exports[`FzBadge > Snapshots > should match snapshot - large size 1`] = `
 `;
 
 exports[`FzBadge > Snapshots > should match snapshot - single character 1`] = `
-"<div class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white" title="1">
+"<div class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-500 text-core-white" title="1">
   <!--v-if-->
   <p class="text-[inherit] text-sm">1</p>
   <!--v-if-->

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -38,7 +38,7 @@
     "vue-tsc": "^2.2.12"
   },
   "dependencies": {
-    "@awesome.me/kit-8137893ad3": "^1.0.416",
+    "@awesome.me/kit-8137893ad3": "^1.0.417",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/vue-fontawesome": "^3.1.1"
   }

--- a/packages/stepper/src/FzStepper.vue
+++ b/packages/stepper/src/FzStepper.vue
@@ -1,152 +1,304 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
-import { FzStepperProps, FzStepProps } from './types'
+import { computed, ref } from "vue";
+import { FzStepperProps, FzStepProps } from "./types";
 import { useMediaQuery } from "@fiscozen/composables";
 import { breakpoints } from "@fiscozen/style";
 import { FzBadge } from "@fiscozen/badge";
 import { FzIcon } from "@fiscozen/icons";
-import { FzDropdown } from '@fiscozen/dropdown';
+import { FzDropdown } from "@fiscozen/dropdown";
 
 const props = withDefaults(defineProps<FzStepperProps>(), {
-    disableProgressBar: false,
-    forceMobile: false,
-})
+  hasStepbar: true,
+  hasStepperList: true,
+  environment: "frontoffice",
+  forceMobile: false,
+});
+
 const smOrSmaller = useMediaQuery(`(max-width: ${breakpoints.sm})`);
 
-const activeStep = defineModel<number>('activeStep', {
-    default: 0,
-})
+const activeStep = defineModel<number>("activeStep", {
+  default: 0,
+});
 
-const emit = defineEmits([])
+const isMobile = computed(() => smOrSmaller.value || props.forceMobile);
 
-const dropdownContainer = ref<HTMLElement | null>(null)
+const dropdownContainer = ref<HTMLElement | null>(null);
 const dropdownRect = computed(() => {
-    return dropdownContainer.value?.getBoundingClientRect()
-})
+  return dropdownContainer.value?.getBoundingClientRect();
+});
 
 const stepStatus = computed(() => {
-    return props.steps.map((step, index) => {
-        if (index === activeStep.value) {
-            return 'current'
-        } else if (step.status === 'error') {
-            return 'error'
-        } else if (step.status === 'completed') {
-            return 'completed'
-        } else {
-            return 'default'
-        }
-    })
-})
-
-const barClass = (step: FzStepProps, index: number) => ({
-    'bg-blue-500': stepStatus.value[index] === 'current',
-    'bg-semantic-error': stepStatus.value[index] === 'error',
-    'bg-grey-500': stepStatus.value[index] === 'completed',
-    'bg-grey-200': stepStatus.value[index] === 'default',
-});
-const badgeColor = computed(() => {
-    return stepStatus.value.map((status) => {
-        if (status === 'current') {
-            return 'blue'
-        } else if (status === 'error') {
-            return 'error'
-        } else if (status === 'completed') {
-            return 'dark'
-        } else {
-            return 'light'
-        }
-    })
-})
-const handleActionClick = (index: number) => {
-    if (props.steps[index].status === 'disabled') {
-        return
-    }
+  return props.steps.map((step, index) => {
     if (index === activeStep.value) {
-        return
+      return "current";
+    } else if (step.status === "error") {
+      return "error";
+    } else if (step.status === "completed") {
+      return "completed";
+    } else {
+      return "default";
     }
-    activeStep.value = index
-}
+  });
+});
+
+const barClass = (step: FzStepProps, index: number) => {
+  const status = stepStatus.value[index];
+  return [
+    "h-[4px] rounded-[4px] w-full mb-8",
+    {
+      "bg-blue-500": status === "current",
+      "bg-grey-500": status === "completed",
+      "bg-grey-200": status === "default",
+      "bg-semantic-error": status === "error",
+    },
+  ];
+};
+
+const badgeTone = computed(() => {
+  return stepStatus.value.map((status) => {
+    if (status === "current") {
+      return "blue";
+    } else if (status === "error") {
+      return "error";
+    } else if (status === "completed") {
+      return "dark";
+    } else {
+      return "light";
+    }
+  });
+});
+
+/** Icon name for completed/error states; undefined means show the step number instead. */
+const badgeIcon = computed(() => {
+  return stepStatus.value.map((status) => {
+    if (status === "completed") return "check";
+    if (status === "error") return "exclamation";
+    return undefined;
+  });
+});
+
+const handleActionClick = (index: number) => {
+  if (props.steps[index].status === "disabled") {
+    return;
+  }
+  if (index === activeStep.value) {
+    return;
+  }
+  activeStep.value = index;
+};
+
+const showDescription = (step: FzStepProps) =>
+  step.hasStepDescription !== false && !!step.description;
 </script>
 
 <template>
-    <div class="fz-stepper flex flex-row w-full gap-16" v-if="!smOrSmaller && !props.forceMobile">
-        <div @click="handleActionClick(index)" :class="['fz-stepper__step flex flex-col grow cursor-pointer', {'opacity-[.2] !cursor-not-allowed': step.status === 'disabled'}]"
-            v-for="(step, index) in props.steps">
-            <div :class="['fz-stepper__progress h-4 rounded-5 w-full mb-8', barClass(step, index)]" v-if="!disableProgressBar">
-            </div>
-            <div class="flex flex-row gap-8 items-start">
-                <div class="fz-stepper__circle flex items-center justify-center">
-                    <FzIcon v-if="stepStatus[index] === 'error'" name="circle-exclamation" variant="fas" size="lg"
-                        class="text-semantic-error" />
-                    <FzIcon v-else-if="stepStatus[index] === 'completed'" name="circle-check" variant="fas" size="lg"
-                        class="text-grey-500" />
-                    <div v-else class="size-[25px] flex justify-center items-center">
-                        <FzBadge size="sm" :color="badgeColor[index]">{{ index + 1 }}</FzBadge>
-                    </div>
-                </div>
-                <div class="flex-col">
-                    <div class="fz-stepper__title text-core-black font-medium">{{ step.title }}</div>
-                    <div class="fz-stepper__description mt-4 text-grey-500 text-sm">{{ step.description }}</div>
-                </div>
-            </div>
+  <!-- Desktop layout -->
+  <div class="fz-stepper flex flex-row gap-16" v-if="!isMobile">
+    <div
+      @click="handleActionClick(index)"
+      :class="[
+        'fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]',
+        { 'opacity-[.2] !cursor-not-allowed': step.status === 'disabled' },
+      ]"
+      v-for="(step, index) in props.steps"
+      :key="index"
+    >
+      <div
+        :class="['fz-stepper__progress', barClass(step, index)]"
+        v-if="hasStepbar"
+      ></div>
+      <div class="flex flex-row gap-8 items-start">
+        <div>
+          <FzBadge :tone="badgeTone[index]" variant="number">
+            <FzIcon
+              v-if="badgeIcon[index]"
+              :name="badgeIcon[index]!"
+              variant="fas"
+              size="sm"
+            />
+            <template v-else>{{ index + 1 }}</template>
+          </FzBadge>
         </div>
+        <div class="min-w-0 flex flex-col gap-[4px]">
+          <span
+            :class="[
+              'fz-stepper__title font-semibold block leading-[20px]',
+              stepStatus[index] === 'error'
+                ? 'text-semantic-error'
+                : 'text-core-black',
+              { truncate: step.isTextTruncated },
+            ]"
+          >
+            {{ step.title }}
+          </span>
+          <span
+            v-if="showDescription(step)"
+            v-small
+            v-color:grey
+            :class="[
+              'fz-stepper__description leading-[20px]',
+              { truncate: step.isTextTruncated },
+            ]"
+          >
+            {{ step.description }}
+          </span>
+        </div>
+      </div>
     </div>
-    <div class="fz-stepper flex flex-col w-full gap-8" v-if="smOrSmaller || props.forceMobile">
-        <div class="flex flex-row gap-8">
-            <div v-for="(step, index) in props.steps"
-                :class="['fz-stepper__progress h-4 rounded-5 w-full mb-8', barClass(step, index)]" v-if="!disableProgressBar">
-            </div>
-        </div>
-        <div class="flex flex-row gap-8 items-center" ref="dropdownContainer">
-            <div class="fz-stepper__circle flex items-center justify-center">
-                <FzIcon v-if="stepStatus[activeStep] === 'error'" name="circle-exclamation" variant="fas" size="lg"
-                    class="text-semantic-error" />
-                <FzIcon v-else-if="stepStatus[activeStep] === 'completed'" name="circle-check" variant="fas" size="lg"
-                    class="text-grey-500" />
-                <FzBadge v-else size="sm" :color="badgeColor[activeStep]">{{ activeStep + 1 }}</FzBadge>
-            </div>
-            <FzDropdown
-                :actions="props.steps.map((step, index) => ({
-                    label: step.title,
-                    type: 'action' as const,
-                }))"
-                align="right"
-                listClass="gap-8 !p-0 w-full"
-                class="fz-stepper__dropdown grow flex"
-                @fzaction:click="handleActionClick">
-                <template #opener="{ isOpen, open }">
-                    <div class="flex flex-col grow cursor-pointer" @click="open">
-                        <div class="flex flex-row size-full justify-between items-center cursor-pointer">
-                            <span class="font-medium text-core-black grow">{{ props.steps[activeStep].title }}</span>
-                            <FzIcon
-                                :name="isOpen ? 'angle-up' : 'angle-down'"
-                                size="lg"
-                                class="ml-4 cursor-pointer"
-                            ></FzIcon>
-                        </div>
-                        <span class="text-sm">{{ props.steps[activeStep].description }}</span>
-                    </div>
-                </template>
-                <template v-for="(step, index) in props.steps" #[`fzaction-item-${index}`]="{close}">
-                    <div :class="['flex flex-col grow cursor-pointer hover:bg-background-alice-blue px-16 py-6 min-w-sm', {
-                        'rounded border-2 border-solid border-blue-200': activeStep === index,
-                        '!cursor-not-allowed': step.status === 'disabled',
-                    }]"
-                    :style="{
-                        width: `${dropdownRect?.width}px`,
-                    }"
-                    @click="handleActionClick(index);close()">
-                        <span :class="['font-medium text-core-black grow', {'text-grey-200': step.status === 'disabled'}]">{{ step.title }}</span>
-                        <span :class="['text-sm', {'text-grey-200': step.status === 'disabled'}]">{{ step.description }}</span>
-                    </div>
-                </template>
-            </FzDropdown>
-        </div>
+  </div>
+
+  <!-- Mobile layout -->
+  <div class="fz-stepper flex flex-col w-full gap-8" v-if="isMobile">
+    <div class="flex flex-row gap-8" v-if="hasStepbar">
+      <div
+        v-for="(step, index) in props.steps"
+        :key="index"
+        :class="['fz-stepper__progress', barClass(step, index)]"
+      ></div>
     </div>
+
+    <!-- With step navigation dropdown -->
+    <div
+      class="flex flex-row gap-8 items-center"
+      ref="dropdownContainer"
+      v-if="hasStepperList"
+    >
+      <div>
+        <FzBadge :tone="badgeTone[activeStep]" variant="number">
+          <FzIcon
+            v-if="badgeIcon[activeStep]"
+            :name="badgeIcon[activeStep]!"
+            variant="fas"
+            size="sm"
+          />
+          <template v-else>{{ activeStep + 1 }}</template>
+        </FzBadge>
+      </div>
+      <FzDropdown
+        :actions="
+          props.steps.map((step, index) => ({
+            label: step.title,
+            type: 'action' as const,
+          }))
+        "
+        align="right"
+        listClass="gap-8 !p-0 w-full"
+        class="fz-stepper__dropdown grow flex"
+        @fzaction:click="handleActionClick"
+      >
+        <template #opener="{ isOpen, open }">
+          <div class="flex flex-col grow cursor-pointer" @click="open">
+            <div
+              class="flex flex-row size-full justify-between items-center cursor-pointer"
+            >
+              <span
+                :class="[
+                  'font-medium grow',
+                  stepStatus[activeStep] === 'error'
+                    ? 'text-semantic-error'
+                    : 'text-core-black',
+                  { truncate: props.steps[activeStep].isTextTruncated },
+                ]"
+                >{{ props.steps[activeStep].title }}</span
+              >
+              <FzIcon
+                :name="isOpen ? 'angle-up' : 'angle-down'"
+                size="lg"
+                class="ml-4"
+              ></FzIcon>
+            </div>
+            <span
+              v-if="showDescription(props.steps[activeStep])"
+              :class="[
+                'text-sm',
+                { truncate: props.steps[activeStep].isTextTruncated },
+              ]"
+              >{{ props.steps[activeStep].description }}</span
+            >
+          </div>
+        </template>
+        <template
+          v-for="(step, index) in props.steps"
+          #[`fzaction-item-${index}`]="{ close }"
+        >
+          <div
+            :class="[
+              'flex flex-col grow cursor-pointer hover:bg-background-alice-blue px-16 py-6 min-w-sm',
+              {
+                'rounded border-2 border-solid border-blue-200':
+                  activeStep === index,
+                '!cursor-not-allowed': step.status === 'disabled',
+              },
+            ]"
+            :style="{
+              width: `${dropdownRect?.width}px`,
+            }"
+            @click="
+              handleActionClick(index);
+              close();
+            "
+          >
+            <span
+              :class="[
+                'font-medium grow',
+                { 'text-grey-200': step.status === 'disabled' },
+                { truncate: step.isTextTruncated },
+              ]"
+              >{{ step.title }}</span
+            >
+            <span
+              v-if="showDescription(step)"
+              :class="[
+                'text-sm',
+                { 'text-grey-200': step.status === 'disabled' },
+                { truncate: step.isTextTruncated },
+              ]"
+              >{{ step.description }}</span
+            >
+          </div>
+        </template>
+      </FzDropdown>
+    </div>
+
+    <!-- Without step navigation (hasStepperList = false) -->
+    <div class="flex flex-row gap-8 items-center" v-else>
+      <div>
+        <FzBadge :tone="badgeTone[activeStep]" variant="number">
+          <FzIcon
+            v-if="badgeIcon[activeStep]"
+            :name="badgeIcon[activeStep]!"
+            variant="fas"
+            size="sm"
+          />
+          <template v-else>{{ activeStep + 1 }}</template>
+        </FzBadge>
+      </div>
+      <div class="flex flex-col grow min-w-0">
+        <span
+          :class="[
+            'font-medium',
+            stepStatus[activeStep] === 'error'
+              ? 'text-semantic-error'
+              : 'text-core-black',
+            { truncate: props.steps[activeStep].isTextTruncated },
+          ]"
+          >{{ props.steps[activeStep].title }}</span
+        >
+        <span
+          v-if="showDescription(props.steps[activeStep])"
+          :class="[
+            'text-sm',
+            { truncate: props.steps[activeStep].isTextTruncated },
+          ]"
+          >{{ props.steps[activeStep].description }}</span
+        >
+      </div>
+    </div>
+  </div>
 </template>
 
 <style scoped>
 :deep(.fz-stepper__dropdown .inline-flex) {
-    flex-grow: 1;
+  flex-grow: 1;
 }
 </style>

--- a/packages/stepper/src/FzStepper.vue
+++ b/packages/stepper/src/FzStepper.vue
@@ -39,14 +39,34 @@ const dropdownRect = computed(() =>
 
 const stepMeta = computed<StepMeta[]>(() =>
   props.steps.map((step, index) => {
-    const status: FzInternalStepStatus =
-      index === activeStep.value
-        ? "current"
-        : step.status === "error"
-          ? "error"
-          : step.status === "completed"
-            ? "completed"
-            : "default";
+    let status: FzInternalStepStatus;
+    if (index === activeStep.value) {
+      status = "current";
+    } else if (step.status === "error") {
+      status = "error";
+    } else if (step.status === "completed") {
+      status = "completed";
+    } else {
+      status = "default";
+    }
+
+    let tone: FzBadgeTone;
+    if (status === "current") {
+      tone = "blue";
+    } else if (status === "error") {
+      tone = "error";
+    } else if (status === "completed") {
+      tone = "dark";
+    } else {
+      tone = "light";
+    }
+
+    const icon =
+      status === "completed"
+        ? "check"
+        : status === "error"
+          ? "exclamation"
+          : undefined;
 
     return {
       status,
@@ -59,20 +79,8 @@ const stepMeta = computed<StepMeta[]>(() =>
           "bg-semantic-error": status === "error",
         },
       ],
-      tone:
-        status === "current"
-          ? "blue"
-          : status === "error"
-            ? "error"
-            : status === "completed"
-              ? "dark"
-              : "light",
-      icon:
-        status === "completed"
-          ? "check"
-          : status === "error"
-            ? "exclamation"
-            : undefined,
+      tone,
+      icon,
     };
   }),
 );

--- a/packages/stepper/src/FzStepper.vue
+++ b/packages/stepper/src/FzStepper.vue
@@ -4,8 +4,18 @@ import { FzStepperProps, FzStepProps } from "./types";
 import { useMediaQuery } from "@fiscozen/composables";
 import { breakpoints } from "@fiscozen/style";
 import { FzBadge } from "@fiscozen/badge";
+import type { FzBadgeTone } from "@fiscozen/badge";
 import { FzIcon } from "@fiscozen/icons";
 import { FzDropdown } from "@fiscozen/dropdown";
+
+type FzInternalStepStatus = "current" | "completed" | "error" | "default";
+
+type StepMeta = {
+  status: FzInternalStepStatus;
+  barClass: (string | Record<string, boolean>)[];
+  tone: FzBadgeTone;
+  icon?: string;
+};
 
 const props = withDefaults(defineProps<FzStepperProps>(), {
   hasStepbar: true,
@@ -23,67 +33,57 @@ const activeStep = defineModel<number>("activeStep", {
 const isMobile = computed(() => smOrSmaller.value || props.forceMobile);
 
 const dropdownContainer = ref<HTMLElement | null>(null);
-const dropdownRect = computed(() => {
-  return dropdownContainer.value?.getBoundingClientRect();
-});
+const dropdownRect = computed(() =>
+  dropdownContainer.value?.getBoundingClientRect(),
+);
 
-const stepStatus = computed(() => {
-  return props.steps.map((step, index) => {
-    if (index === activeStep.value) {
-      return "current";
-    } else if (step.status === "error") {
-      return "error";
-    } else if (step.status === "completed") {
-      return "completed";
-    } else {
-      return "default";
-    }
-  });
-});
+const stepMeta = computed<StepMeta[]>(() =>
+  props.steps.map((step, index) => {
+    const status: FzInternalStepStatus =
+      index === activeStep.value
+        ? "current"
+        : step.status === "error"
+          ? "error"
+          : step.status === "completed"
+            ? "completed"
+            : "default";
 
-const barClass = (step: FzStepProps, index: number) => {
-  const status = stepStatus.value[index];
-  return [
-    "h-[4px] rounded-[4px] w-full mb-8",
-    {
-      "bg-blue-500": status === "current",
-      "bg-grey-500": status === "completed",
-      "bg-grey-200": status === "default",
-      "bg-semantic-error": status === "error",
-    },
-  ];
-};
+    return {
+      status,
+      barClass: [
+        "h-[4px] rounded-[4px] w-full mb-8",
+        {
+          "bg-blue-500": status === "current",
+          "bg-grey-500": status === "completed",
+          "bg-grey-200": status === "default",
+          "bg-semantic-error": status === "error",
+        },
+      ],
+      tone:
+        status === "current"
+          ? "blue"
+          : status === "error"
+            ? "error"
+            : status === "completed"
+              ? "dark"
+              : "light",
+      icon:
+        status === "completed"
+          ? "check"
+          : status === "error"
+            ? "exclamation"
+            : undefined,
+    };
+  }),
+);
 
-const badgeTone = computed(() => {
-  return stepStatus.value.map((status) => {
-    if (status === "current") {
-      return "blue";
-    } else if (status === "error") {
-      return "error";
-    } else if (status === "completed") {
-      return "dark";
-    } else {
-      return "light";
-    }
-  });
-});
-
-/** Icon name for completed/error states; undefined means show the step number instead. */
-const badgeIcon = computed(() => {
-  return stepStatus.value.map((status) => {
-    if (status === "completed") return "check";
-    if (status === "error") return "exclamation";
-    return undefined;
-  });
-});
+const dropdownActions = computed(() =>
+  props.steps.map((step) => ({ label: step.title, type: "action" as const })),
+);
 
 const handleActionClick = (index: number) => {
-  if (props.steps[index].status === "disabled") {
-    return;
-  }
-  if (index === activeStep.value) {
-    return;
-  }
+  if (props.steps[index].status === "disabled") return;
+  if (index === activeStep.value) return;
   activeStep.value = index;
 };
 
@@ -104,26 +104,24 @@ const showDescription = (step: FzStepProps) =>
       :key="index"
     >
       <div
-        :class="['fz-stepper__progress', barClass(step, index)]"
+        :class="['fz-stepper__progress', stepMeta[index].barClass]"
         v-if="hasStepbar"
       ></div>
       <div class="flex flex-row gap-8 items-start">
-        <div>
-          <FzBadge :tone="badgeTone[index]" variant="number">
-            <FzIcon
-              v-if="badgeIcon[index]"
-              :name="badgeIcon[index]!"
-              variant="fas"
-              size="sm"
-            />
-            <template v-else>{{ index + 1 }}</template>
-          </FzBadge>
-        </div>
+        <FzBadge :tone="stepMeta[index].tone" variant="number">
+          <FzIcon
+            v-if="stepMeta[index].icon"
+            :name="stepMeta[index].icon!"
+            variant="fas"
+            size="sm"
+          />
+          <template v-else>{{ index + 1 }}</template>
+        </FzBadge>
         <div class="min-w-0 flex flex-col gap-[4px]">
           <span
             :class="[
               'fz-stepper__title font-semibold block leading-[20px]',
-              stepStatus[index] === 'error'
+              stepMeta[index].status === 'error'
                 ? 'text-semantic-error'
                 : 'text-core-black',
               { truncate: step.isTextTruncated },
@@ -153,7 +151,7 @@ const showDescription = (step: FzStepProps) =>
       <div
         v-for="(step, index) in props.steps"
         :key="index"
-        :class="['fz-stepper__progress', barClass(step, index)]"
+        :class="['fz-stepper__progress', stepMeta[index].barClass]"
       ></div>
     </div>
 
@@ -163,24 +161,17 @@ const showDescription = (step: FzStepProps) =>
       ref="dropdownContainer"
       v-if="hasStepperList"
     >
-      <div>
-        <FzBadge :tone="badgeTone[activeStep]" variant="number">
-          <FzIcon
-            v-if="badgeIcon[activeStep]"
-            :name="badgeIcon[activeStep]!"
-            variant="fas"
-            size="sm"
-          />
-          <template v-else>{{ activeStep + 1 }}</template>
-        </FzBadge>
-      </div>
+      <FzBadge :tone="stepMeta[activeStep].tone" variant="number">
+        <FzIcon
+          v-if="stepMeta[activeStep].icon"
+          :name="stepMeta[activeStep].icon!"
+          variant="fas"
+          size="sm"
+        />
+        <template v-else>{{ activeStep + 1 }}</template>
+      </FzBadge>
       <FzDropdown
-        :actions="
-          props.steps.map((step, index) => ({
-            label: step.title,
-            type: 'action' as const,
-          }))
-        "
+        :actions="dropdownActions"
         align="right"
         listClass="gap-8 !p-0 w-full"
         class="fz-stepper__dropdown grow flex"
@@ -194,7 +185,7 @@ const showDescription = (step: FzStepProps) =>
               <span
                 :class="[
                   'font-medium grow',
-                  stepStatus[activeStep] === 'error'
+                  stepMeta[activeStep].status === 'error'
                     ? 'text-semantic-error'
                     : 'text-core-black',
                   { truncate: props.steps[activeStep].isTextTruncated },
@@ -205,7 +196,7 @@ const showDescription = (step: FzStepProps) =>
                 :name="isOpen ? 'angle-up' : 'angle-down'"
                 size="lg"
                 class="ml-4"
-              ></FzIcon>
+              />
             </div>
             <span
               v-if="showDescription(props.steps[activeStep])"
@@ -262,22 +253,20 @@ const showDescription = (step: FzStepProps) =>
 
     <!-- Without step navigation (hasStepperList = false) -->
     <div class="flex flex-row gap-8 items-center" v-else>
-      <div>
-        <FzBadge :tone="badgeTone[activeStep]" variant="number">
-          <FzIcon
-            v-if="badgeIcon[activeStep]"
-            :name="badgeIcon[activeStep]!"
-            variant="fas"
-            size="sm"
-          />
-          <template v-else>{{ activeStep + 1 }}</template>
-        </FzBadge>
-      </div>
+      <FzBadge :tone="stepMeta[activeStep].tone" variant="number">
+        <FzIcon
+          v-if="stepMeta[activeStep].icon"
+          :name="stepMeta[activeStep].icon!"
+          variant="fas"
+          size="sm"
+        />
+        <template v-else>{{ activeStep + 1 }}</template>
+      </FzBadge>
       <div class="flex flex-col grow min-w-0">
         <span
           :class="[
             'font-medium',
-            stepStatus[activeStep] === 'error'
+            stepMeta[activeStep].status === 'error'
               ? 'text-semantic-error'
               : 'text-core-black',
             { truncate: props.steps[activeStep].isTextTruncated },

--- a/packages/stepper/src/FzStepper.vue
+++ b/packages/stepper/src/FzStepper.vue
@@ -61,12 +61,14 @@ const stepMeta = computed<StepMeta[]>(() =>
       tone = "light";
     }
 
-    const icon =
-      status === "completed"
-        ? "check"
-        : status === "error"
-          ? "exclamation"
-          : undefined;
+    let icon: string | undefined;
+    if (status === "completed") {
+      icon = "check";
+    } else if (status === "error") {
+      icon = "exclamation";
+    } else {
+      icon = undefined;
+    }
 
     return {
       status,

--- a/packages/stepper/src/FzStepper.vue
+++ b/packages/stepper/src/FzStepper.vue
@@ -1,21 +1,17 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { FzStepperProps, FzStepProps } from "./types";
+import {
+  FzStepperProps,
+  FzStepProps,
+  FzInternalStepStatus,
+  StepMeta,
+} from "./types";
+import type { FzBadgeTone } from "@fiscozen/badge";
 import { useMediaQuery } from "@fiscozen/composables";
 import { breakpoints } from "@fiscozen/style";
 import { FzBadge } from "@fiscozen/badge";
-import type { FzBadgeTone } from "@fiscozen/badge";
 import { FzIcon } from "@fiscozen/icons";
 import { FzDropdown } from "@fiscozen/dropdown";
-
-type FzInternalStepStatus = "current" | "completed" | "error" | "default";
-
-type StepMeta = {
-  status: FzInternalStepStatus;
-  barClass: (string | Record<string, boolean>)[];
-  tone: FzBadgeTone;
-  icon?: string;
-};
 
 const props = withDefaults(defineProps<FzStepperProps>(), {
   hasStepbar: true,

--- a/packages/stepper/src/FzStepper.vue
+++ b/packages/stepper/src/FzStepper.vue
@@ -108,10 +108,13 @@ const showDescription = (step: FzStepProps) =>
       ]"
       v-for="(step, index) in props.steps"
       :key="index"
+      :aria-current="index === activeStep ? 'step' : undefined"
+      :aria-disabled="step.status === 'disabled' ? 'true' : undefined"
     >
       <div
         :class="['fz-stepper__progress', stepMeta[index].barClass]"
         v-if="hasStepbar"
+        aria-hidden="true"
       ></div>
       <div class="flex flex-row gap-8 items-start">
         <FzBadge :tone="stepMeta[index].tone" variant="number">
@@ -153,7 +156,7 @@ const showDescription = (step: FzStepProps) =>
 
   <!-- Mobile layout -->
   <div class="fz-stepper flex flex-col w-full gap-8" v-if="isMobile">
-    <div class="flex flex-row gap-8" v-if="hasStepbar">
+    <div class="flex flex-row gap-8" v-if="hasStepbar" aria-hidden="true">
       <div
         v-for="(step, index) in props.steps"
         :key="index"
@@ -230,6 +233,8 @@ const showDescription = (step: FzStepProps) =>
             :style="{
               width: `${dropdownRect?.width}px`,
             }"
+            :aria-current="index === activeStep ? 'step' : undefined"
+            :aria-disabled="step.status === 'disabled' ? 'true' : undefined"
             @click="
               handleActionClick(index);
               close();

--- a/packages/stepper/src/__tests__/FzStepper.spec.ts
+++ b/packages/stepper/src/__tests__/FzStepper.spec.ts
@@ -1,65 +1,57 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { mount, VueWrapper } from '@vue/test-utils'
-import { FzStepper } from '..'
-import { FzStepperProps } from '../types'
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mount, VueWrapper } from "@vue/test-utils";
+import { FzStepper } from "..";
+import { FzStepperProps } from "../types";
 
 const mockSteps = [
   {
-    title: 'Step 1',
-    description: 'First step description',
-    status: undefined as const
+    title: "Step 1",
+    description: "First step description",
+    status: undefined as const,
   },
   {
-    title: 'Step 2',
-    description: 'Second step description',
-    status: 'completed' as const
+    title: "Step 2",
+    description: "Second step description",
+    status: "completed" as const,
   },
   {
-    title: 'Step 3',
-    description: 'Third step description',
-    status: 'error' as const
+    title: "Step 3",
+    description: "Third step description",
+    status: "error" as const,
   },
   {
-    title: 'Step 4',
-    description: 'Fourth step description',
-    status: 'disabled' as const
-  }
-]
+    title: "Step 4",
+    description: "Fourth step description",
+    status: "disabled" as const,
+  },
+];
 
-describe('FzStepper', () => {
-  let wrapper: VueWrapper
+describe("FzStepper", () => {
+  let wrapper: VueWrapper;
 
-  // Mock window.matchMedia for useMediaQuery composable
-  const originalMatchMedia = window.matchMedia
+  const originalMatchMedia = window.matchMedia;
 
   beforeEach(() => {
-    // Reset window width to desktop default
-    window.innerWidth = 1280
-    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
+    window.innerWidth = 1280;
+    vi.spyOn(window, "innerWidth", "get").mockReturnValue(1280);
 
-    // Mock IntersectionObserver for FzFloating component
     global.IntersectionObserver = class IntersectionObserver {
       constructor() {}
       observe() {}
       unobserve() {}
       disconnect() {}
-    } as any
+    } as any;
 
-    // Mock window.matchMedia for useMediaQuery composable
-    Object.defineProperty(window, 'matchMedia', {
+    Object.defineProperty(window, "matchMedia", {
       writable: true,
       configurable: true,
       value: vi.fn((query: string) => {
-        // Extract breakpoint value from query (e.g., "(max-width: 640px)")
-        const maxWidthMatch = query.match(/max-width:\s*(\d+)px/)
-        
-        let matches = false
-        
+        const maxWidthMatch = query.match(/max-width:\s*(\d+)px/);
+        let matches = false;
         if (maxWidthMatch) {
-          const maxWidth = parseInt(maxWidthMatch[1], 10)
-          matches = window.innerWidth <= maxWidth
+          const maxWidth = parseInt(maxWidthMatch[1], 10);
+          matches = window.innerWidth <= maxWidth;
         }
-        
         return {
           matches,
           media: query,
@@ -68,835 +60,478 @@ describe('FzStepper', () => {
           removeListener: vi.fn(),
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),
-          dispatchEvent: vi.fn()
-        }
-      })
-    })
-  })
+          dispatchEvent: vi.fn(),
+        };
+      }),
+    });
+  });
 
   afterEach(() => {
     if (wrapper) {
-      wrapper.unmount()
+      wrapper.unmount();
     }
-    window.matchMedia = originalMatchMedia
-    vi.restoreAllMocks()
-  })
+    window.matchMedia = originalMatchMedia;
+    vi.restoreAllMocks();
+  });
 
   // ============================================
   // RENDERING TESTS
   // ============================================
-  describe('Rendering', () => {
-    it('should render with default props', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      expect(wrapper.exists()).toBe(true)
-      expect(wrapper.find('.fz-stepper').exists()).toBe(true)
-    })
+  describe("Rendering", () => {
+    it("should render with default props", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      expect(wrapper.exists()).toBe(true);
+      expect(wrapper.find(".fz-stepper").exists()).toBe(true);
+    });
 
-    it('should render all steps', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      const steps = wrapper.findAll('.fz-stepper__step')
-      expect(steps.length).toBe(mockSteps.length)
-    })
+    it("should render all steps", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const steps = wrapper.findAll(".fz-stepper__step");
+      expect(steps.length).toBe(mockSteps.length);
+    });
 
-    it('should render step titles', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
+    it("should render step titles", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
       mockSteps.forEach((step) => {
-        expect(wrapper.text()).toContain(step.title)
-      })
-    })
+        expect(wrapper.text()).toContain(step.title);
+      });
+    });
 
-    it('should render step descriptions', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
+    it("should render step descriptions", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
       mockSteps.forEach((step) => {
         if (step.description) {
-          expect(wrapper.text()).toContain(step.description)
+          expect(wrapper.text()).toContain(step.description);
         }
-      })
-    })
+      });
+    });
 
-    it('should render progress bars by default', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      const progressBars = wrapper.findAll('.fz-stepper__progress')
-      expect(progressBars.length).toBeGreaterThan(0)
-    })
+    it("should render progress bars by default", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const progressBars = wrapper.findAll(".fz-stepper__progress");
+      expect(progressBars.length).toBeGreaterThan(0);
+    });
 
-    it('should not render progress bars when disableProgressBar is true', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps,
-        disableProgressBar: true
-      }
+    it("should not render progress bars when hasStepbar is false", () => {
       wrapper = mount(FzStepper, {
-        props
-      })
-      const progressBars = wrapper.findAll('.fz-stepper__progress')
-      expect(progressBars.length).toBe(0)
-    })
+        props: { steps: mockSteps, hasStepbar: false },
+      });
+      const progressBars = wrapper.findAll(".fz-stepper__progress");
+      expect(progressBars.length).toBe(0);
+    });
 
-    it('should render desktop layout by default', () => {
-      window.innerWidth = 1280
-      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
-      
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      // Desktop layout has flex-row
-      const desktopLayout = wrapper.find('.fz-stepper.flex.flex-row')
-      expect(desktopLayout.exists()).toBe(true)
-    })
+    it("should render desktop layout by default", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      expect(wrapper.find(".fz-stepper.flex.flex-row").exists()).toBe(true);
+    });
 
-    it('should render mobile layout when screen is small', () => {
-      window.innerWidth = 500
-      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(500)
-      
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
+    it("should render mobile layout when forceMobile is true", () => {
       wrapper = mount(FzStepper, {
-        props
-      })
-      // Mobile layout has flex-col
-      const mobileLayout = wrapper.find('.fz-stepper.flex.flex-col')
-      expect(mobileLayout.exists()).toBe(true)
-    })
-
-    it('should render mobile layout when forceMobile is true', () => {
-      window.innerWidth = 1280
-      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
-      
-      const props: FzStepperProps = {
-        steps: mockSteps,
-        forceMobile: true
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      // Mobile layout has flex-col
-      const mobileLayout = wrapper.find('.fz-stepper.flex.flex-col')
-      expect(mobileLayout.exists()).toBe(true)
-    })
-  })
+        props: { steps: mockSteps, forceMobile: true },
+      });
+      expect(wrapper.find(".fz-stepper.flex.flex-col").exists()).toBe(true);
+    });
+  });
 
   // ============================================
   // PROPS TESTS
   // ============================================
-  describe('Props', () => {
-    describe('steps prop', () => {
-      it('should render steps correctly', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        expect(wrapper.text()).toContain('Step 1')
-        expect(wrapper.text()).toContain('Step 2')
-        expect(wrapper.text()).toContain('Step 3')
-        expect(wrapper.text()).toContain('Step 4')
-      })
+  describe("Props", () => {
+    describe("hasStepbar", () => {
+      it("should show progress bars by default", () => {
+        wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+        expect(wrapper.findAll(".fz-stepper__progress").length).toBeGreaterThan(
+          0,
+        );
+      });
 
-      it('should handle empty steps array', () => {
-        const props: FzStepperProps = {
-          steps: []
-        }
+      it("should hide progress bars when hasStepbar is false", () => {
         wrapper = mount(FzStepper, {
-          props
-        })
-        expect(wrapper.exists()).toBe(true)
-        const steps = wrapper.findAll('.fz-stepper__step')
-        expect(steps.length).toBe(0)
-      })
+          props: { steps: mockSteps, hasStepbar: false },
+        });
+        expect(wrapper.findAll(".fz-stepper__progress").length).toBe(0);
+      });
+    });
 
-      it('should handle steps without descriptions', () => {
-        const stepsWithoutDescriptions = [
+    describe("environment", () => {
+      it("should default to frontoffice (blue active bar)", () => {
+        wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+        const progressBars = wrapper.findAll(".fz-stepper__progress");
+        // First step is current (activeStep = 0)
+        expect(progressBars[0].classes()).toContain("bg-blue-500");
+      });
+
+      it("should use blue bar for current step when environment is backoffice", () => {
+        wrapper = mount(FzStepper, {
+          props: { steps: mockSteps, environment: "backoffice" },
+        });
+        const progressBars = wrapper.findAll(".fz-stepper__progress");
+        // Bar is always blue regardless of environment
+        expect(progressBars[0].classes()).toContain("bg-blue-500");
+      });
+    });
+
+    describe("hasStepperList", () => {
+      it("should show the dropdown by default in mobile", () => {
+        wrapper = mount(FzStepper, {
+          props: { steps: mockSteps, forceMobile: true },
+        });
+        expect(wrapper.find(".fz-stepper__dropdown").exists()).toBe(true);
+      });
+
+      it("should hide dropdown and show static step when hasStepperList is false", () => {
+        wrapper = mount(FzStepper, {
+          props: { steps: mockSteps, forceMobile: true, hasStepperList: false },
+        });
+        expect(wrapper.find(".fz-stepper__dropdown").exists()).toBe(false);
+        // Active step title is still visible
+        expect(wrapper.text()).toContain(mockSteps[0].title);
+      });
+    });
+
+    describe("forceMobile (deprecated)", () => {
+      it("should use desktop layout by default on large screens", () => {
+        wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+        expect(wrapper.find(".fz-stepper.flex.flex-row").exists()).toBe(true);
+      });
+
+      it("should force mobile layout when forceMobile is true", () => {
+        wrapper = mount(FzStepper, {
+          props: { steps: mockSteps, forceMobile: true },
+        });
+        expect(wrapper.find(".fz-stepper.flex.flex-col").exists()).toBe(true);
+      });
+    });
+
+    describe("activeStep v-model", () => {
+      it("should default to step 0", () => {
+        wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+        expect(wrapper.vm.activeStep).toBe(0);
+      });
+
+      it("should update activeStep when changed", async () => {
+        wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+        wrapper.vm.activeStep = 2;
+        await wrapper.vm.$nextTick();
+        expect(wrapper.vm.activeStep).toBe(2);
+      });
+    });
+
+    describe("isTextTruncated per step", () => {
+      it("should apply truncate class to title when isTextTruncated is true", () => {
+        const steps = [
+          { title: "Step 1", description: "Desc 1", isTextTruncated: true },
+        ];
+        wrapper = mount(FzStepper, { props: { steps } });
+        const title = wrapper.find(".fz-stepper__title");
+        expect(title.classes()).toContain("truncate");
+      });
+
+      it("should not apply truncate class when isTextTruncated is false", () => {
+        const steps = [
+          { title: "Step 1", description: "Desc 1", isTextTruncated: false },
+        ];
+        wrapper = mount(FzStepper, { props: { steps } });
+        const title = wrapper.find(".fz-stepper__title");
+        expect(title.classes()).not.toContain("truncate");
+      });
+
+      it("should apply truncate class to description when isTextTruncated is true", () => {
+        const steps = [
+          { title: "Step 1", description: "Desc 1", isTextTruncated: true },
+        ];
+        wrapper = mount(FzStepper, { props: { steps } });
+        const desc = wrapper.find(".fz-stepper__description");
+        expect(desc.classes()).toContain("truncate");
+      });
+    });
+
+    describe("hasStepDescription per step", () => {
+      it("should show description by default when description is provided", () => {
+        wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+        expect(wrapper.text()).toContain("First step description");
+      });
+
+      it("should hide description when hasStepDescription is false", () => {
+        const steps = [
           {
-            title: 'Step 1',
-            status: undefined as const
+            title: "Step 1",
+            description: "Should be hidden",
+            hasStepDescription: false,
           },
+        ];
+        wrapper = mount(FzStepper, { props: { steps } });
+        expect(wrapper.text()).not.toContain("Should be hidden");
+      });
+
+      it("should show description when hasStepDescription is explicitly true", () => {
+        const steps = [
           {
-            title: 'Step 2',
-            status: undefined as const
-          }
-        ]
-        const props: FzStepperProps = {
-          steps: stepsWithoutDescriptions
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        expect(wrapper.text()).toContain('Step 1')
-        expect(wrapper.text()).toContain('Step 2')
-      })
-    })
-
-    describe('disableProgressBar prop', () => {
-      it('should show progress bars by default', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        const progressBars = wrapper.findAll('.fz-stepper__progress')
-        expect(progressBars.length).toBeGreaterThan(0)
-      })
-
-      it('should hide progress bars when disableProgressBar is true', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps,
-          disableProgressBar: true
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        const progressBars = wrapper.findAll('.fz-stepper__progress')
-        expect(progressBars.length).toBe(0)
-      })
-    })
-
-    describe('forceMobile prop', () => {
-      it('should use desktop layout by default on large screens', () => {
-        window.innerWidth = 1280
-        vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
-        
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        const desktopLayout = wrapper.find('.fz-stepper.flex.flex-row')
-        expect(desktopLayout.exists()).toBe(true)
-      })
-
-      it('should force mobile layout when forceMobile is true', () => {
-        window.innerWidth = 1280
-        vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
-        
-        const props: FzStepperProps = {
-          steps: mockSteps,
-          forceMobile: true
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        const mobileLayout = wrapper.find('.fz-stepper.flex.flex-col')
-        expect(mobileLayout.exists()).toBe(true)
-      })
-    })
-
-    describe('activeStep v-model', () => {
-      it('should default to step 0', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // First step should be active by default
-        expect(wrapper.vm.activeStep).toBe(0)
-      })
-
-      it('should update activeStep when changed', async () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        wrapper.vm.activeStep = 2
-        await wrapper.vm.$nextTick()
-        expect(wrapper.vm.activeStep).toBe(2)
-      })
-    })
-  })
+            title: "Step 1",
+            description: "Should be visible",
+            hasStepDescription: true,
+          },
+        ];
+        wrapper = mount(FzStepper, { props: { steps } });
+        expect(wrapper.text()).toContain("Should be visible");
+      });
+    });
+  });
 
   // ============================================
   // EVENTS TESTS
   // ============================================
-  describe('Events', () => {
-    it('should update activeStep when step is clicked', async () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      const steps = wrapper.findAll('.fz-stepper__step')
-      // Click on second step (index 1)
-      await steps[1].trigger('click')
-      await wrapper.vm.$nextTick()
-      expect(wrapper.vm.activeStep).toBe(1)
-    })
+  describe("Events", () => {
+    it("should update activeStep when step is clicked", async () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const steps = wrapper.findAll(".fz-stepper__step");
+      await steps[1].trigger("click");
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.activeStep).toBe(1);
+    });
 
-    it('should not update activeStep when clicking the current step', async () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      // activeStep defaults to 0
-      const steps = wrapper.findAll('.fz-stepper__step')
-      await steps[0].trigger('click')
-      await wrapper.vm.$nextTick()
-      // Should still be 0 (no change)
-      expect(wrapper.vm.activeStep).toBe(0)
-    })
+    it("should not update activeStep when clicking the current step", async () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const steps = wrapper.findAll(".fz-stepper__step");
+      await steps[0].trigger("click");
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.activeStep).toBe(0);
+    });
 
-    it('should not update activeStep when disabled step is clicked', async () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      const steps = wrapper.findAll('.fz-stepper__step')
-      // Step 4 (index 3) is disabled
-      const initialStep = wrapper.vm.activeStep
-      await steps[3].trigger('click')
-      await wrapper.vm.$nextTick()
-      // Should not change
-      expect(wrapper.vm.activeStep).toBe(initialStep)
-    })
+    it("should not update activeStep when disabled step is clicked", async () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const steps = wrapper.findAll(".fz-stepper__step");
+      const initialStep = wrapper.vm.activeStep;
+      await steps[3].trigger("click");
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.activeStep).toBe(initialStep);
+    });
 
-    it('should handle rapid step clicks', async () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      const steps = wrapper.findAll('.fz-stepper__step')
-      // Rapidly click multiple steps
-      await steps[1].trigger('click')
-      await wrapper.vm.$nextTick()
-      await steps[2].trigger('click')
-      await wrapper.vm.$nextTick()
-      // Should end up on the last clicked step
-      expect(wrapper.vm.activeStep).toBe(2)
-    })
-  })
+    it("should handle rapid step clicks", async () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const steps = wrapper.findAll(".fz-stepper__step");
+      await steps[1].trigger("click");
+      await wrapper.vm.$nextTick();
+      await steps[2].trigger("click");
+      await wrapper.vm.$nextTick();
+      // Step 2 (index 2) is error but still clickable
+      expect(wrapper.vm.activeStep).toBe(2);
+    });
+  });
 
   // ============================================
   // CSS CLASSES TESTS
   // ============================================
-  describe('CSS Classes', () => {
-    it('should apply static base classes', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      const stepper = wrapper.find('.fz-stepper')
-      expect(stepper.classes()).toContain('fz-stepper')
-      expect(stepper.classes()).toContain('flex')
-      expect(stepper.classes()).toContain('w-full')
-    })
+  describe("CSS Classes", () => {
+    it("should apply static base classes", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const stepper = wrapper.find(".fz-stepper");
+      expect(stepper.classes()).toContain("fz-stepper");
+      expect(stepper.classes()).toContain("flex");
+      expect(stepper.classes()).toContain("gap-16");
+    });
 
-    it('should apply desktop layout classes', () => {
-      window.innerWidth = 1280
-      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
-      
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      const stepper = wrapper.find('.fz-stepper.flex.flex-row')
-      expect(stepper.exists()).toBe(true)
-      expect(stepper.classes()).toContain('flex-row')
-      expect(stepper.classes()).toContain('gap-16')
-    })
+    it("should apply desktop layout classes", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const stepper = wrapper.find(".fz-stepper.flex.flex-row");
+      expect(stepper.exists()).toBe(true);
+      expect(stepper.classes()).toContain("gap-16");
+    });
 
-    it('should apply mobile layout classes', () => {
-      window.innerWidth = 500
-      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(500)
-      
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
+    it("should apply mobile layout classes when forceMobile", () => {
       wrapper = mount(FzStepper, {
-        props
-      })
-      const stepper = wrapper.find('.fz-stepper.flex.flex-col')
-      expect(stepper.exists()).toBe(true)
-      expect(stepper.classes()).toContain('flex-col')
-      expect(stepper.classes()).toContain('gap-8')
-    })
+        props: { steps: mockSteps, forceMobile: true },
+      });
+      const stepper = wrapper.find(".fz-stepper.flex.flex-col");
+      expect(stepper.exists()).toBe(true);
+      expect(stepper.classes()).toContain("gap-8");
+    });
 
-    it('should apply disabled state classes to disabled steps', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      const steps = wrapper.findAll('.fz-stepper__step')
-      // Step 4 (index 3) is disabled
-      const disabledStep = steps[3]
-      expect(disabledStep.classes()).toContain('opacity-[.2]')
-      expect(disabledStep.classes()).toContain('!cursor-not-allowed')
-    })
+    it("should apply disabled state classes to disabled steps", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const steps = wrapper.findAll(".fz-stepper__step");
+      const disabledStep = steps[3];
+      expect(disabledStep.classes()).toContain("opacity-[.2]");
+      expect(disabledStep.classes()).toContain("!cursor-not-allowed");
+    });
 
-    it('should apply progress bar classes based on step status', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
+    it("should apply blue progress bar for current step in frontoffice", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const progressBars = wrapper.findAll(".fz-stepper__progress");
+      expect(progressBars[0].classes()).toContain("bg-blue-500");
+    });
+
+    it("should apply blue progress bar for current step in backoffice", () => {
       wrapper = mount(FzStepper, {
-        props
-      })
-      const progressBars = wrapper.findAll('.fz-stepper__progress')
-      // First step is current (activeStep = 0)
-      expect(progressBars[0].classes()).toContain('bg-blue-500')
-      // Second step is completed
-      expect(progressBars[1].classes()).toContain('bg-grey-500')
-      // Third step is error
-      expect(progressBars[2].classes()).toContain('bg-semantic-error')
-      // Fourth step is default
-      expect(progressBars[3].classes()).toContain('bg-grey-200')
-    })
-  })
+        props: { steps: mockSteps, environment: "backoffice" },
+      });
+      const progressBars = wrapper.findAll(".fz-stepper__progress");
+      expect(progressBars[0].classes()).toContain("bg-blue-500");
+    });
+
+    it("should apply completed bar class", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const progressBars = wrapper.findAll(".fz-stepper__progress");
+      // Step 2 (index 1) is completed
+      expect(progressBars[1].classes()).toContain("bg-grey-500");
+    });
+
+    it("should apply solid error fill style for error progress bar", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const progressBars = wrapper.findAll(".fz-stepper__progress");
+      // Step 3 (index 2) is error
+      expect(progressBars[2].classes()).toContain("bg-semantic-error");
+      expect(progressBars[2].classes()).toContain("h-[4px]");
+    });
+
+    it("should apply default (grey-200) bar class for unvisited steps", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const progressBars = wrapper.findAll(".fz-stepper__progress");
+      // Step 4 (index 3) is disabled → default style
+      expect(progressBars[3].classes()).toContain("bg-grey-200");
+    });
+
+    it("should apply error text color to title when step is in error", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const titles = wrapper.findAll(".fz-stepper__title");
+      // Step 3 (index 2) is error
+      expect(titles[2].classes()).toContain("text-semantic-error");
+    });
+
+    it("should apply core-black text color to non-error step titles", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const titles = wrapper.findAll(".fz-stepper__title");
+      expect(titles[0].classes()).toContain("text-core-black");
+      expect(titles[1].classes()).toContain("text-core-black");
+    });
+  });
 
   // ============================================
   // ACCESSIBILITY TESTS
   // ============================================
-  describe('Accessibility', () => {
-    describe('ARIA attributes', () => {
-      it('should have aria-current="step" on current step (expected behavior)', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // Note: Current implementation doesn't add aria-current="step"
-        // This test documents expected accessibility behavior
-        // The current step (activeStep) should ideally have aria-current="step"
-        const steps = wrapper.findAll('.fz-stepper__step')
-        expect(steps.length).toBeGreaterThan(0)
-        // First step should be current (activeStep defaults to 0)
-        // In a proper implementation, steps[0] should have aria-current="step"
-      })
+  describe("Accessibility", () => {
+    it("should have accessible step labels", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      mockSteps.forEach((step) => {
+        expect(wrapper.text()).toContain(step.title);
+      });
+    });
 
-      it('should have aria-current="step" only on current step, not on other steps (expected behavior)', async () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
+    it("should have accessible step descriptions", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      mockSteps.forEach((step) => {
+        if (step.description) {
+          expect(wrapper.text()).toContain(step.description);
         }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // Change activeStep to 1
-        wrapper.vm.activeStep = 1
-        await wrapper.vm.$nextTick()
-        
-        const steps = wrapper.findAll('.fz-stepper__step')
-        // Note: Current implementation doesn't add aria-current="step"
-        // This test documents expected accessibility behavior
-        // Only steps[1] should have aria-current="step", others should not
-        expect(steps.length).toBeGreaterThan(1)
-      })
+      });
+    });
 
-      it('should have semantic HTML structure for stepper navigation (expected behavior)', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // Note: Current implementation uses div, but should ideally use nav with aria-label="Steps"
-        // This test documents expected accessibility behavior
-        const container = wrapper.find('.fz-stepper')
-        expect(container.exists()).toBe(true)
-      })
-
-      it('should have accessible step labels', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // Step titles should be visible and accessible
-        mockSteps.forEach((step) => {
-          expect(wrapper.text()).toContain(step.title)
-        })
-      })
-
-      it('should have accessible step descriptions', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // Step descriptions should be visible and accessible
-        mockSteps.forEach((step) => {
-          if (step.description) {
-            expect(wrapper.text()).toContain(step.description)
-          }
-        })
-      })
-
-      it('should indicate disabled steps are not interactive (expected behavior)', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        const steps = wrapper.findAll('.fz-stepper__step')
-        // Step 4 (index 3) is disabled
-        const disabledStep = steps[3]
-        // Note: Current implementation uses opacity and cursor classes
-        // Ideally should also have aria-disabled="true" for screen readers
-        expect(disabledStep.classes()).toContain('opacity-[.2]')
-        expect(disabledStep.classes()).toContain('!cursor-not-allowed')
-      })
-    })
-
-    describe('Keyboard navigation', () => {
-      it('should be keyboard accessible for step navigation (expected behavior)', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        const steps = wrapper.findAll('.fz-stepper__step')
-        // Note: Current implementation uses click handlers
-        // Ideally should support keyboard navigation (Tab, Enter, Space, Arrow keys)
-        // This test documents expected accessibility behavior
-        expect(steps.length).toBeGreaterThan(0)
-      })
-
-      it('should support Tab navigation between steps (expected behavior)', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // Note: Current implementation doesn't explicitly handle Tab navigation
-        // This test documents expected accessibility behavior
-        // Steps should be focusable and navigable with Tab key
-        const steps = wrapper.findAll('.fz-stepper__step')
-        expect(steps.length).toBeGreaterThan(0)
-      })
-
-      it('should support Enter/Space activation on steps (expected behavior)', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // Note: Current implementation only handles click events
-        // This test documents expected accessibility behavior
-        // Steps should be activatable with Enter or Space key
-        const steps = wrapper.findAll('.fz-stepper__step')
-        expect(steps.length).toBeGreaterThan(0)
-      })
-    })
-
-    describe('Screen reader support', () => {
-      it('should provide clear step status information (expected behavior)', () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // Note: Current implementation shows visual indicators (icons, badges)
-        // Ideally should also provide aria-live regions or aria-label with status
-        // This test documents expected accessibility behavior
-        expect(wrapper.text()).toContain('Step 1')
-        expect(wrapper.text()).toContain('Step 2')
-      })
-
-      it('should announce step changes to screen readers (expected behavior)', async () => {
-        const props: FzStepperProps = {
-          steps: mockSteps
-        }
-        wrapper = mount(FzStepper, {
-          props
-        })
-        // Change activeStep
-        wrapper.vm.activeStep = 2
-        await wrapper.vm.$nextTick()
-        // Note: Current implementation doesn't announce changes
-        // Ideally should use aria-live="polite" or similar to announce step changes
-        // This test documents expected accessibility behavior
-        expect(wrapper.vm.activeStep).toBe(2)
-      })
-    })
-  })
+    it("should indicate disabled steps via opacity and cursor classes", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      const steps = wrapper.findAll(".fz-stepper__step");
+      const disabledStep = steps[3];
+      expect(disabledStep.classes()).toContain("opacity-[.2]");
+      expect(disabledStep.classes()).toContain("!cursor-not-allowed");
+    });
+  });
 
   // ============================================
   // EDGE CASES
   // ============================================
-  describe('Edge Cases', () => {
-    it('should handle undefined steps gracefully', () => {
-      const props: Partial<FzStepperProps> = {
-        steps: undefined as any
-      }
-      // This should throw an error or handle gracefully
-      expect(() => {
-        wrapper = mount(FzStepper, {
-          props: props as FzStepperProps
-        })
-      }).not.toThrow()
-    })
+  describe("Edge Cases", () => {
+    it("should handle empty steps array", () => {
+      wrapper = mount(FzStepper, { props: { steps: [] } });
+      expect(wrapper.exists()).toBe(true);
+      expect(wrapper.findAll(".fz-stepper__step").length).toBe(0);
+    });
 
-    it('should handle empty steps array', () => {
-      const props: FzStepperProps = {
-        steps: []
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      expect(wrapper.exists()).toBe(true)
-      const steps = wrapper.findAll('.fz-stepper__step')
-      expect(steps.length).toBe(0)
-    })
-
-    it('should handle single step', () => {
+    it("should handle single step", () => {
       const singleStep = [
-        {
-          title: 'Only Step',
-          description: 'Single step description',
-          status: undefined as const
-        }
-      ]
-      const props: FzStepperProps = {
-        steps: singleStep
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      expect(wrapper.text()).toContain('Only Step')
-      const steps = wrapper.findAll('.fz-stepper__step')
-      expect(steps.length).toBe(1)
-    })
+        { title: "Only Step", description: "Single step description" },
+      ];
+      wrapper = mount(FzStepper, { props: { steps: singleStep } });
+      expect(wrapper.text()).toContain("Only Step");
+      expect(wrapper.findAll(".fz-stepper__step").length).toBe(1);
+    });
 
-    it('should handle many steps', () => {
-      const manySteps = Array.from({ length: 10 }, (_, i) => ({
-        title: `Step ${i + 1}`,
-        description: `Description ${i + 1}`,
-        status: undefined as const
-      }))
-      const props: FzStepperProps = {
-        steps: manySteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      const steps = wrapper.findAll('.fz-stepper__step')
-      expect(steps.length).toBe(10)
-    })
+    it("should handle steps without descriptions", () => {
+      const steps = [{ title: "Step 1" }, { title: "Step 2" }];
+      wrapper = mount(FzStepper, { props: { steps } });
+      expect(wrapper.text()).toContain("Step 1");
+      expect(wrapper.text()).toContain("Step 2");
+      expect(wrapper.findAll(".fz-stepper__description").length).toBe(0);
+    });
 
-    it('should handle activeStep beyond steps length', async () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      // Set activeStep to an index beyond steps length
-      wrapper.vm.activeStep = 100
-      await wrapper.vm.$nextTick()
-      // Should handle gracefully
-      expect(wrapper.vm.activeStep).toBe(100)
-    })
+    it("should handle activeStep beyond steps length", async () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      wrapper.vm.activeStep = 100;
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.activeStep).toBe(100);
+    });
 
-    it('should handle negative activeStep', async () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      wrapper.vm.activeStep = -1
-      await wrapper.vm.$nextTick()
-      // Should handle gracefully
-      expect(wrapper.vm.activeStep).toBe(-1)
-    })
-
-    it('should handle steps with very long titles', () => {
+    it("should handle steps with very long titles", () => {
       const longTitleSteps = [
-        {
-          title: 'A'.repeat(200),
-          description: 'Description',
-          status: undefined as const
-        }
-      ]
-      const props: FzStepperProps = {
-        steps: longTitleSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      expect(wrapper.text()).toContain('A'.repeat(200))
-    })
+        { title: "A".repeat(200), description: "Description" },
+      ];
+      wrapper = mount(FzStepper, { props: { steps: longTitleSteps } });
+      expect(wrapper.text()).toContain("A".repeat(200));
+    });
 
-    it('should handle steps with special characters in titles', () => {
-      const specialCharSteps = [
-        {
-          title: 'Step <>&"\'',
-          description: 'Description',
-          status: undefined as const
-        }
-      ]
-      const props: FzStepperProps = {
-        steps: specialCharSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      expect(wrapper.text()).toContain('Step')
-    })
+    it("should handle multiple stepper instances independently", () => {
+      const props: FzStepperProps = { steps: mockSteps };
+      const wrapper1 = mount(FzStepper, { props });
+      const wrapper2 = mount(FzStepper, { props });
 
-    it('should handle window resize events', async () => {
-      window.innerWidth = 1280
-      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
-      
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      
-      // Initially desktop layout
-      let desktopLayout = wrapper.find('.fz-stepper.flex.flex-row')
-      expect(desktopLayout.exists()).toBe(true)
-      
-      // Simulate window resize to mobile
-      window.innerWidth = 500
-      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(500)
-      
-      // Trigger resize event
-      window.dispatchEvent(new Event('resize'))
-      await wrapper.vm.$nextTick()
-      
-      // Note: useMediaQuery should react to resize, but may need additional handling
-      // This test documents expected behavior
-    })
+      wrapper1.vm.activeStep = 1;
+      expect(wrapper2.vm.activeStep).toBe(0);
 
-    it('should handle multiple stepper instances', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      const wrapper1 = mount(FzStepper, { props })
-      const wrapper2 = mount(FzStepper, { props })
-      
-      expect(wrapper1.exists()).toBe(true)
-      expect(wrapper2.exists()).toBe(true)
-      
-      // Each instance should have independent activeStep
-      wrapper1.vm.activeStep = 1
-      expect(wrapper2.vm.activeStep).toBe(0)
-      
-      wrapper1.unmount()
-      wrapper2.unmount()
-    })
-  })
+      wrapper1.unmount();
+      wrapper2.unmount();
+    });
+  });
 
   // ============================================
   // SNAPSHOTS
   // ============================================
-  describe('Snapshots', () => {
-    it('should match snapshot - default state', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
-      wrapper = mount(FzStepper, {
-        props
-      })
-      expect(wrapper.html()).toMatchSnapshot()
-    })
+  describe("Snapshots", () => {
+    it("should match snapshot - default state", () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      expect(wrapper.html()).toMatchSnapshot();
+    });
 
-    it('should match snapshot - with disableProgressBar', () => {
-      const props: FzStepperProps = {
-        steps: mockSteps,
-        disableProgressBar: true
-      }
+    it("should match snapshot - hasStepbar false", () => {
       wrapper = mount(FzStepper, {
-        props
-      })
-      expect(wrapper.html()).toMatchSnapshot()
-    })
+        props: { steps: mockSteps, hasStepbar: false },
+      });
+      expect(wrapper.html()).toMatchSnapshot();
+    });
 
-    it('should match snapshot - with forceMobile', () => {
-      window.innerWidth = 1280
-      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280)
-      
-      const props: FzStepperProps = {
-        steps: mockSteps,
-        forceMobile: true
-      }
+    it("should match snapshot - backoffice environment", () => {
       wrapper = mount(FzStepper, {
-        props
-      })
-      expect(wrapper.html()).toMatchSnapshot()
-    })
+        props: { steps: mockSteps, environment: "backoffice" },
+      });
+      expect(wrapper.html()).toMatchSnapshot();
+    });
 
-    it('should match snapshot - activeStep 2', async () => {
-      const props: FzStepperProps = {
-        steps: mockSteps
-      }
+    it("should match snapshot - forceMobile", () => {
       wrapper = mount(FzStepper, {
-        props
-      })
-      wrapper.vm.activeStep = 2
-      await wrapper.vm.$nextTick()
-      expect(wrapper.html()).toMatchSnapshot()
-    })
+        props: { steps: mockSteps, forceMobile: true },
+      });
+      expect(wrapper.html()).toMatchSnapshot();
+    });
 
-    it('should match snapshot - single step', () => {
-      const singleStep = [
-        {
-          title: 'Only Step',
-          description: 'Single step description',
-          status: undefined as const
-        }
-      ]
-      const props: FzStepperProps = {
-        steps: singleStep
-      }
+    it("should match snapshot - mobile without stepper list", () => {
       wrapper = mount(FzStepper, {
-        props
-      })
-      expect(wrapper.html()).toMatchSnapshot()
-    })
-  })
-})
+        props: { steps: mockSteps, forceMobile: true, hasStepperList: false },
+      });
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+
+    it("should match snapshot - activeStep 2", async () => {
+      wrapper = mount(FzStepper, { props: { steps: mockSteps } });
+      wrapper.vm.activeStep = 2;
+      await wrapper.vm.$nextTick();
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/stepper/src/__tests__/__snapshots__/FzStepper.spec.ts.snap
+++ b/packages/stepper/src/__tests__/__snapshots__/FzStepper.spec.ts.snap
@@ -1,235 +1,199 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
-"<div data-v-6183ce6d="" class="fz-stepper flex flex-row w-full gap-16">
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-grey-200"></div>
+"<!-- Desktop layout -->
+<div data-v-6183ce6d="" class="fz-stepper flex flex-row gap-16">
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center">
-        <div data-v-6183ce6d="" class="size-[25px] flex justify-center items-center">
-          <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="1">
-            <!--v-if-->
-            <p class="text-[inherit] text-sm">1</p>
-            <!--v-if-->
-          </div>
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm">1</p>
+          <!--v-if-->
         </div>
       </div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 1</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">First step description</div>
-      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 1</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">First step description</span></div>
     </div>
   </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-grey-500"></div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[25px] h-[25px] text-grey-500"><svg class="svg-inline--fa fa-circle-check fa-lg h-[20px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle-check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg></span></div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 2</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Second step description</div>
-      </div>
-    </div>
-  </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-blue-500"></div>
-    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center">
-        <div data-v-6183ce6d="" class="size-[25px] flex justify-center items-center">
-          <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="3">
-            <!--v-if-->
-            <p class="text-[inherit] text-sm">3</p>
-            <!--v-if-->
-          </div>
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
+          <!--v-if-->
         </div>
       </div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 3</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Third step description</div>
-      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 2</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Second step description</span></div>
     </div>
   </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer opacity-[.2] !cursor-not-allowed">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-grey-200"></div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center">
-        <div data-v-6183ce6d="" class="size-[25px] flex justify-center items-center">
-          <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="4">
-            <!--v-if-->
-            <p class="text-[inherit] text-sm">4</p>
-            <!--v-if-->
-          </div>
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm">3</p>
+          <!--v-if-->
         </div>
       </div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 4</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Fourth step description</div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
+    </div>
+  </div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm">4</p>
+          <!--v-if-->
+        </div>
       </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 4</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Fourth step description</span></div>
     </div>
   </div>
 </div>
+<!-- Mobile layout -->
+<!--v-if-->"
+`;
+
+exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 1`] = `
+"<!-- Desktop layout -->
+<div data-v-6183ce6d="" class="fz-stepper flex flex-row gap-16">
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm">1</p>
+          <!--v-if-->
+        </div>
+      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 1</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">First step description</span></div>
+    </div>
+  </div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
+          <!--v-if-->
+        </div>
+      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 2</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Second step description</span></div>
+    </div>
+  </div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-semantic-error-200 text-core-white">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-exclamation fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M96 64c0-17.7-14.3-32-32-32S32 46.3 32 64l0 256c0 17.7 14.3 32 32 32s32-14.3 32-32L96 64zM64 480a40 40 0 1 0 0-80 40 40 0 1 0 0 80z"></path></svg></span></p>
+          <!--v-if-->
+        </div>
+      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-semantic-error">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
+    </div>
+  </div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm">4</p>
+          <!--v-if-->
+        </div>
+      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 4</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Fourth step description</span></div>
+    </div>
+  </div>
+</div>
+<!-- Mobile layout -->
 <!--v-if-->"
 `;
 
 exports[`FzStepper > Snapshots > should match snapshot - default state 1`] = `
-"<div data-v-6183ce6d="" class="fz-stepper flex flex-row w-full gap-16">
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-blue-500"></div>
+"<!-- Desktop layout -->
+<div data-v-6183ce6d="" class="fz-stepper flex flex-row gap-16">
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center">
-        <div data-v-6183ce6d="" class="size-[25px] flex justify-center items-center">
-          <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="1">
-            <!--v-if-->
-            <p class="text-[inherit] text-sm">1</p>
-            <!--v-if-->
-          </div>
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm">1</p>
+          <!--v-if-->
         </div>
       </div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 1</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">First step description</div>
-      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 1</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">First step description</span></div>
     </div>
   </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-grey-500"></div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[25px] h-[25px] text-grey-500"><svg class="svg-inline--fa fa-circle-check fa-lg h-[20px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle-check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg></span></div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 2</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Second step description</div>
-      </div>
-    </div>
-  </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-semantic-error"></div>
-    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[25px] h-[25px] text-semantic-error"><svg class="svg-inline--fa fa-circle-exclamation fa-lg h-[20px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle-exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24l0 112c0 13.3-10.7 24-24 24s-24-10.7-24-24l0-112c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"></path></svg></span></div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 3</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Third step description</div>
-      </div>
-    </div>
-  </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer opacity-[.2] !cursor-not-allowed">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-grey-200"></div>
-    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center">
-        <div data-v-6183ce6d="" class="size-[25px] flex justify-center items-center">
-          <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="4">
-            <!--v-if-->
-            <p class="text-[inherit] text-sm">4</p>
-            <!--v-if-->
-          </div>
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
+          <!--v-if-->
         </div>
       </div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 4</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Fourth step description</div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 2</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Second step description</span></div>
+    </div>
+  </div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-semantic-error-200 text-core-white">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-exclamation fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M96 64c0-17.7-14.3-32-32-32S32 46.3 32 64l0 256c0 17.7 14.3 32 32 32s32-14.3 32-32L96 64zM64 480a40 40 0 1 0 0-80 40 40 0 1 0 0 80z"></path></svg></span></p>
+          <!--v-if-->
+        </div>
       </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-semantic-error">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
+    </div>
+  </div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm">4</p>
+          <!--v-if-->
+        </div>
+      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 4</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Fourth step description</span></div>
     </div>
   </div>
 </div>
+<!-- Mobile layout -->
 <!--v-if-->"
 `;
 
-exports[`FzStepper > Snapshots > should match snapshot - single step 1`] = `
-"<div data-v-6183ce6d="" class="fz-stepper flex flex-row w-full gap-16">
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-blue-500"></div>
-    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center">
-        <div data-v-6183ce6d="" class="size-[25px] flex justify-center items-center">
-          <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="1">
-            <!--v-if-->
-            <p class="text-[inherit] text-sm">1</p>
-            <!--v-if-->
-          </div>
-        </div>
-      </div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Only Step</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Single step description</div>
-      </div>
-    </div>
-  </div>
-</div>
-<!--v-if-->"
-`;
-
-exports[`FzStepper > Snapshots > should match snapshot - with disableProgressBar 1`] = `
-"<div data-v-6183ce6d="" class="fz-stepper flex flex-row w-full gap-16">
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <!--v-if-->
-    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center">
-        <div data-v-6183ce6d="" class="size-[25px] flex justify-center items-center">
-          <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="1">
-            <!--v-if-->
-            <p class="text-[inherit] text-sm">1</p>
-            <!--v-if-->
-          </div>
-        </div>
-      </div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 1</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">First step description</div>
-      </div>
-    </div>
-  </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <!--v-if-->
-    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[25px] h-[25px] text-grey-500"><svg class="svg-inline--fa fa-circle-check fa-lg h-[20px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle-check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"></path></svg></span></div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 2</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Second step description</div>
-      </div>
-    </div>
-  </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer">
-    <!--v-if-->
-    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[25px] h-[25px] text-semantic-error"><svg class="svg-inline--fa fa-circle-exclamation fa-lg h-[20px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle-exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zm0-384c13.3 0 24 10.7 24 24l0 112c0 13.3-10.7 24-24 24s-24-10.7-24-24l0-112c0-13.3 10.7-24 24-24zM224 352a32 32 0 1 1 64 0 32 32 0 1 1 -64 0z"></path></svg></span></div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 3</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Third step description</div>
-      </div>
-    </div>
-  </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col grow cursor-pointer opacity-[.2] !cursor-not-allowed">
-    <!--v-if-->
-    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center">
-        <div data-v-6183ce6d="" class="size-[25px] flex justify-center items-center">
-          <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="4">
-            <!--v-if-->
-            <p class="text-[inherit] text-sm">4</p>
-            <!--v-if-->
-          </div>
-        </div>
-      </div>
-      <div data-v-6183ce6d="" class="flex-col">
-        <div data-v-6183ce6d="" class="fz-stepper__title text-core-black font-medium">Step 4</div>
-        <div data-v-6183ce6d="" class="fz-stepper__description mt-4 text-grey-500 text-sm">Fourth step description</div>
-      </div>
-    </div>
-  </div>
-</div>
-<!--v-if-->"
-`;
-
-exports[`FzStepper > Snapshots > should match snapshot - with forceMobile 1`] = `
-"<!--v-if-->
+exports[`FzStepper > Snapshots > should match snapshot - forceMobile 1`] = `
+"<!-- Desktop layout -->
+<!--v-if-->
+<!-- Mobile layout -->
 <div data-v-6183ce6d="" class="fz-stepper flex flex-col w-full gap-8">
   <div data-v-6183ce6d="" class="flex flex-row gap-8">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-blue-500"></div>
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-grey-500"></div>
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-semantic-error"></div>
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-4 rounded-5 w-full mb-8 bg-grey-200"></div>
-  </div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
+  </div><!-- With step navigation dropdown -->
   <div data-v-6183ce6d="" class="flex flex-row gap-8 items-center">
-    <div data-v-6183ce6d="" class="fz-stepper__circle flex items-center justify-center">
-      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="1">
+    <div data-v-6183ce6d="">
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
         <!--v-if-->
         <p class="text-[inherit] text-sm">1</p>
         <!--v-if-->
@@ -238,13 +202,98 @@ exports[`FzStepper > Snapshots > should match snapshot - with forceMobile 1`] = 
     <div data-v-6183ce6d="" class="fz-stepper__dropdown grow flex">
       <div class="inline-flex w-full sm:w-auto">
         <div data-v-6183ce6d="" class="flex flex-col grow cursor-pointer">
-          <div data-v-6183ce6d="" class="flex flex-row size-full justify-between items-center cursor-pointer"><span data-v-6183ce6d="" class="font-medium text-core-black grow">Step 1</span><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[25px] h-[25px] ml-4 cursor-pointer"><svg class="svg-inline--fa fa-angle-down fa-lg h-[20px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="angle-down" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M241 369c-9.4 9.4-24.6 9.4-33.9 0L47 209c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l143 143L367 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9L241 369z"></path></svg></span></div><span data-v-6183ce6d="" class="text-sm">First step description</span>
+          <div data-v-6183ce6d="" class="flex flex-row size-full justify-between items-center cursor-pointer"><span data-v-6183ce6d="" class="font-medium grow text-core-black">Step 1</span><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[25px] h-[25px] ml-4"><svg class="svg-inline--fa fa-angle-down fa-lg h-[20px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="angle-down" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M241 369c-9.4 9.4-24.6 9.4-33.9 0L47 209c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l143 143L367 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9L241 369z"></path></svg></span></div><span data-v-6183ce6d="" class="text-sm">First step description</span>
         </div>
       </div>
       <!--v-if-->
       <!--teleport start-->
       <!--teleport end-->
     </div>
+  </div>
+</div>"
+`;
+
+exports[`FzStepper > Snapshots > should match snapshot - hasStepbar false 1`] = `
+"<!-- Desktop layout -->
+<div data-v-6183ce6d="" class="fz-stepper flex flex-row gap-16">
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <!--v-if-->
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm">1</p>
+          <!--v-if-->
+        </div>
+      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 1</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">First step description</span></div>
+    </div>
+  </div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <!--v-if-->
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
+          <!--v-if-->
+        </div>
+      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 2</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Second step description</span></div>
+    </div>
+  </div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+    <!--v-if-->
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-semantic-error-200 text-core-white">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-exclamation fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M96 64c0-17.7-14.3-32-32-32S32 46.3 32 64l0 256c0 17.7 14.3 32 32 32s32-14.3 32-32L96 64zM64 480a40 40 0 1 0 0-80 40 40 0 1 0 0 80z"></path></svg></span></p>
+          <!--v-if-->
+        </div>
+      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-semantic-error">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
+    </div>
+  </div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
+    <!--v-if-->
+    <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
+      <div data-v-6183ce6d="">
+        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+          <!--v-if-->
+          <p class="text-[inherit] text-sm">4</p>
+          <!--v-if-->
+        </div>
+      </div>
+      <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 4</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Fourth step description</span></div>
+    </div>
+  </div>
+</div>
+<!-- Mobile layout -->
+<!--v-if-->"
+`;
+
+exports[`FzStepper > Snapshots > should match snapshot - mobile without stepper list 1`] = `
+"<!-- Desktop layout -->
+<!--v-if-->
+<!-- Mobile layout -->
+<div data-v-6183ce6d="" class="fz-stepper flex flex-col w-full gap-8">
+  <div data-v-6183ce6d="" class="flex flex-row gap-8">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
+  </div><!-- With step navigation dropdown -->
+  <!-- Without step navigation (hasStepperList = false) -->
+  <div data-v-6183ce6d="" class="flex flex-row gap-8 items-center">
+    <div data-v-6183ce6d="">
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">1</p>
+        <!--v-if-->
+      </div>
+    </div>
+    <div data-v-6183ce6d="" class="flex flex-col grow min-w-0"><span data-v-6183ce6d="" class="font-medium text-core-black">Step 1</span><span data-v-6183ce6d="" class="text-sm">First step description</span></div>
   </div>
 </div>"
 `;

--- a/packages/stepper/src/__tests__/__snapshots__/FzStepper.spec.ts.snap
+++ b/packages/stepper/src/__tests__/__snapshots__/FzStepper.spec.ts.snap
@@ -6,12 +6,10 @@ exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm">1</p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">1</p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 1</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">First step description</span></div>
     </div>
@@ -19,12 +17,10 @@ exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-500 text-core-white">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 2</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Second step description</span></div>
     </div>
@@ -32,12 +28,10 @@ exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm">3</p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">3</p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
     </div>
@@ -45,12 +39,10 @@ exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm">4</p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">4</p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 4</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Fourth step description</span></div>
     </div>
@@ -66,12 +58,10 @@ exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm">1</p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">1</p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 1</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">First step description</span></div>
     </div>
@@ -79,12 +69,10 @@ exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-500 text-core-white">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 2</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Second step description</span></div>
     </div>
@@ -92,12 +80,10 @@ exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-semantic-error-200 text-core-white">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-exclamation fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M96 64c0-17.7-14.3-32-32-32S32 46.3 32 64l0 256c0 17.7 14.3 32 32 32s32-14.3 32-32L96 64zM64 480a40 40 0 1 0 0-80 40 40 0 1 0 0 80z"></path></svg></span></p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-semantic-error-200 text-core-white">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-exclamation fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M96 64c0-17.7-14.3-32-32-32S32 46.3 32 64l0 256c0 17.7 14.3 32 32 32s32-14.3 32-32L96 64zM64 480a40 40 0 1 0 0-80 40 40 0 1 0 0 80z"></path></svg></span></p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-semantic-error">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
     </div>
@@ -105,12 +91,10 @@ exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm">4</p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">4</p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 4</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Fourth step description</span></div>
     </div>
@@ -126,12 +110,10 @@ exports[`FzStepper > Snapshots > should match snapshot - default state 1`] = `
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm">1</p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">1</p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 1</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">First step description</span></div>
     </div>
@@ -139,12 +121,10 @@ exports[`FzStepper > Snapshots > should match snapshot - default state 1`] = `
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-500 text-core-white">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 2</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Second step description</span></div>
     </div>
@@ -152,12 +132,10 @@ exports[`FzStepper > Snapshots > should match snapshot - default state 1`] = `
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-semantic-error-200 text-core-white">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-exclamation fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M96 64c0-17.7-14.3-32-32-32S32 46.3 32 64l0 256c0 17.7 14.3 32 32 32s32-14.3 32-32L96 64zM64 480a40 40 0 1 0 0-80 40 40 0 1 0 0 80z"></path></svg></span></p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-semantic-error-200 text-core-white">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-exclamation fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M96 64c0-17.7-14.3-32-32-32S32 46.3 32 64l0 256c0 17.7 14.3 32 32 32s32-14.3 32-32L96 64zM64 480a40 40 0 1 0 0-80 40 40 0 1 0 0 80z"></path></svg></span></p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-semantic-error">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
     </div>
@@ -165,12 +143,10 @@ exports[`FzStepper > Snapshots > should match snapshot - default state 1`] = `
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm">4</p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">4</p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 4</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Fourth step description</span></div>
     </div>
@@ -192,12 +168,10 @@ exports[`FzStepper > Snapshots > should match snapshot - forceMobile 1`] = `
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
   </div><!-- With step navigation dropdown -->
   <div data-v-6183ce6d="" class="flex flex-row gap-8 items-center">
-    <div data-v-6183ce6d="">
-      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
-        <!--v-if-->
-        <p class="text-[inherit] text-sm">1</p>
-        <!--v-if-->
-      </div>
+    <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+      <!--v-if-->
+      <p class="text-[inherit] text-sm">1</p>
+      <!--v-if-->
     </div>
     <div data-v-6183ce6d="" class="fz-stepper__dropdown grow flex">
       <div class="inline-flex w-full sm:w-auto">
@@ -219,12 +193,10 @@ exports[`FzStepper > Snapshots > should match snapshot - hasStepbar false 1`] = 
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <!--v-if-->
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm">1</p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">1</p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 1</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">First step description</span></div>
     </div>
@@ -232,12 +204,10 @@ exports[`FzStepper > Snapshots > should match snapshot - hasStepbar false 1`] = 
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <!--v-if-->
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-500 text-core-white">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-500 text-core-white">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M438.6 105.4c12.5 12.5 12.5 32.8 0 45.3l-256 256c-12.5 12.5-32.8 12.5-45.3 0l-128-128c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0L160 338.7 393.4 105.4c12.5-12.5 32.8-12.5 45.3 0z"></path></svg></span></p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 2</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Second step description</span></div>
     </div>
@@ -245,12 +215,10 @@ exports[`FzStepper > Snapshots > should match snapshot - hasStepbar false 1`] = 
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
     <!--v-if-->
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-semantic-error-200 text-core-white">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-exclamation fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M96 64c0-17.7-14.3-32-32-32S32 46.3 32 64l0 256c0 17.7 14.3 32 32 32s32-14.3 32-32L96 64zM64 480a40 40 0 1 0 0-80 40 40 0 1 0 0 80z"></path></svg></span></p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-semantic-error-200 text-core-white">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm"><span data-v-6183ce6d="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px]"><svg class="svg-inline--fa fa-exclamation fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M96 64c0-17.7-14.3-32-32-32S32 46.3 32 64l0 256c0 17.7 14.3 32 32 32s32-14.3 32-32L96 64zM64 480a40 40 0 1 0 0-80 40 40 0 1 0 0 80z"></path></svg></span></p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-semantic-error">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
     </div>
@@ -258,12 +226,10 @@ exports[`FzStepper > Snapshots > should match snapshot - hasStepbar false 1`] = 
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
     <!--v-if-->
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
-      <div data-v-6183ce6d="">
-        <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
-          <!--v-if-->
-          <p class="text-[inherit] text-sm">4</p>
-          <!--v-if-->
-        </div>
+      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
+        <!--v-if-->
+        <p class="text-[inherit] text-sm">4</p>
+        <!--v-if-->
       </div>
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 4</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Fourth step description</span></div>
     </div>
@@ -286,12 +252,10 @@ exports[`FzStepper > Snapshots > should match snapshot - mobile without stepper 
   </div><!-- With step navigation dropdown -->
   <!-- Without step navigation (hasStepperList = false) -->
   <div data-v-6183ce6d="" class="flex flex-row gap-8 items-center">
-    <div data-v-6183ce6d="">
-      <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
-        <!--v-if-->
-        <p class="text-[inherit] text-sm">1</p>
-        <!--v-if-->
-      </div>
+    <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
+      <!--v-if-->
+      <p class="text-[inherit] text-sm">1</p>
+      <!--v-if-->
     </div>
     <div data-v-6183ce6d="" class="flex flex-col grow min-w-0"><span data-v-6183ce6d="" class="font-medium text-core-black">Step 1</span><span data-v-6183ce6d="" class="text-sm">First step description</span></div>
   </div>

--- a/packages/stepper/src/__tests__/__snapshots__/FzStepper.spec.ts.snap
+++ b/packages/stepper/src/__tests__/__snapshots__/FzStepper.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
 "<!-- Desktop layout -->
 <div data-v-6183ce6d="" class="fz-stepper flex flex-row gap-16">
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
         <!--v-if-->
@@ -15,7 +15,7 @@ exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
     </div>
   </div>
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-500 text-core-white">
         <!--v-if-->
@@ -25,8 +25,8 @@ exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 2</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Second step description</span></div>
     </div>
   </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]" aria-current="step">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
         <!--v-if-->
@@ -36,8 +36,8 @@ exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-core-black">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
     </div>
   </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed" aria-disabled="true">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
         <!--v-if-->
@@ -55,8 +55,8 @@ exports[`FzStepper > Snapshots > should match snapshot - activeStep 2 1`] = `
 exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 1`] = `
 "<!-- Desktop layout -->
 <div data-v-6183ce6d="" class="fz-stepper flex flex-row gap-16">
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]" aria-current="step">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
         <!--v-if-->
@@ -67,7 +67,7 @@ exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 
     </div>
   </div>
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-500 text-core-white">
         <!--v-if-->
@@ -78,7 +78,7 @@ exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 
     </div>
   </div>
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-semantic-error-200 text-core-white">
         <!--v-if-->
@@ -88,8 +88,8 @@ exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-semantic-error">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
     </div>
   </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed" aria-disabled="true">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
         <!--v-if-->
@@ -107,8 +107,8 @@ exports[`FzStepper > Snapshots > should match snapshot - backoffice environment 
 exports[`FzStepper > Snapshots > should match snapshot - default state 1`] = `
 "<!-- Desktop layout -->
 <div data-v-6183ce6d="" class="fz-stepper flex flex-row gap-16">
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]" aria-current="step">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
         <!--v-if-->
@@ -119,7 +119,7 @@ exports[`FzStepper > Snapshots > should match snapshot - default state 1`] = `
     </div>
   </div>
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-500 text-core-white">
         <!--v-if-->
@@ -130,7 +130,7 @@ exports[`FzStepper > Snapshots > should match snapshot - default state 1`] = `
     </div>
   </div>
   <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-semantic-error-200 text-core-white">
         <!--v-if-->
@@ -140,8 +140,8 @@ exports[`FzStepper > Snapshots > should match snapshot - default state 1`] = `
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-semantic-error">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
     </div>
   </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
-    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200"></div>
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed" aria-disabled="true">
+    <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-200" aria-hidden="true"></div>
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
         <!--v-if-->
@@ -161,7 +161,7 @@ exports[`FzStepper > Snapshots > should match snapshot - forceMobile 1`] = `
 <!--v-if-->
 <!-- Mobile layout -->
 <div data-v-6183ce6d="" class="fz-stepper flex flex-col w-full gap-8">
-  <div data-v-6183ce6d="" class="flex flex-row gap-8">
+  <div data-v-6183ce6d="" class="flex flex-row gap-8" aria-hidden="true">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>
@@ -190,7 +190,7 @@ exports[`FzStepper > Snapshots > should match snapshot - forceMobile 1`] = `
 exports[`FzStepper > Snapshots > should match snapshot - hasStepbar false 1`] = `
 "<!-- Desktop layout -->
 <div data-v-6183ce6d="" class="fz-stepper flex flex-row gap-16">
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]">
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px]" aria-current="step">
     <!--v-if-->
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="[object Object]">
@@ -223,7 +223,7 @@ exports[`FzStepper > Snapshots > should match snapshot - hasStepbar false 1`] = 
       <div data-v-6183ce6d="" class="min-w-0 flex flex-col gap-[4px]"><span data-v-6183ce6d="" class="fz-stepper__title font-semibold block leading-[20px] text-semantic-error">Step 3</span><span data-v-6183ce6d="" class="fz-stepper__description leading-[20px]">Third step description</span></div>
     </div>
   </div>
-  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed">
+  <div data-v-6183ce6d="" class="fz-stepper__step flex flex-col w-[156px] shrink-0 cursor-pointer py-[10px] opacity-[.2] !cursor-not-allowed" aria-disabled="true">
     <!--v-if-->
     <div data-v-6183ce6d="" class="flex flex-row gap-8 items-start">
       <div data-v-6183ce6d="" class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-grey-100 text-core-black" title="[object Object]">
@@ -244,7 +244,7 @@ exports[`FzStepper > Snapshots > should match snapshot - mobile without stepper 
 <!--v-if-->
 <!-- Mobile layout -->
 <div data-v-6183ce6d="" class="fz-stepper flex flex-col w-full gap-8">
-  <div data-v-6183ce6d="" class="flex flex-row gap-8">
+  <div data-v-6183ce6d="" class="flex flex-row gap-8" aria-hidden="true">
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-blue-500"></div>
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-grey-500"></div>
     <div data-v-6183ce6d="" class="fz-stepper__progress h-[4px] rounded-[4px] w-full mb-8 bg-semantic-error"></div>

--- a/packages/stepper/src/types.ts
+++ b/packages/stepper/src/types.ts
@@ -1,4 +1,15 @@
+import type { FzBadgeTone } from "@fiscozen/badge";
+
 type FzStepperEnvironment = "frontoffice" | "backoffice";
+
+type FzInternalStepStatus = "current" | "completed" | "error" | "default";
+
+type StepMeta = {
+  status: FzInternalStepStatus;
+  barClass: (string | Record<string, boolean>)[];
+  tone: FzBadgeTone;
+  icon?: string;
+};
 
 type FzStepperProps = {
   /**
@@ -57,4 +68,11 @@ type FzStepProps = {
   hasStepDescription?: boolean;
 };
 
-export { FzStepperProps, FzStepperEnvironment, FzStepStatus, FzStepProps };
+export {
+  FzStepperProps,
+  FzStepperEnvironment,
+  FzStepStatus,
+  FzStepProps,
+  FzInternalStepStatus,
+  StepMeta,
+};

--- a/packages/stepper/src/types.ts
+++ b/packages/stepper/src/types.ts
@@ -17,7 +17,7 @@ type FzStepperProps = {
    */
   hasStepperList?: boolean;
   /**
-   * Color environment. Controls the accent color for the active step.
+   * Visual environment. Reserved for future environment-specific styling.
    * @default 'frontoffice'
    */
   environment?: FzStepperEnvironment;

--- a/packages/stepper/src/types.ts
+++ b/packages/stepper/src/types.ts
@@ -1,31 +1,60 @@
+type FzStepperEnvironment = "frontoffice" | "backoffice";
+
 type FzStepperProps = {
   /**
-   *  step objects
+   * Step objects. Recommended maximum of 8 steps.
    */
   steps: FzStepProps[];
   /**
-   *  Disable stepper progress bar
+   * Show the progress bar above each step.
+   * @default true
    */
-  disableProgressBar?: boolean;
+  hasStepbar?: boolean;
   /**
-   * force the mobile version
+   * Show the step navigation dropdown in mobile view.
+   * When false, only the active step is displayed with no toggle.
+   * @default true
+   */
+  hasStepperList?: boolean;
+  /**
+   * Color environment. Controls the accent color for the active step.
+   * @default 'frontoffice'
+   */
+  environment?: FzStepperEnvironment;
+  /**
+   * @deprecated Use the responsive breakpoint behaviour instead.
+   * Forces the mobile layout regardless of screen size.
    */
   forceMobile?: boolean;
-}
-type FzStepStatus = 'completed' | 'error' | 'disabled'; 
+};
+
+type FzStepStatus = "completed" | "error" | "disabled";
+
 type FzStepProps = {
   /**
-   *  Title of the stepper
+   * Title of the step.
    */
   title: string;
   /**
-   *  Description of the stepper
+   * Description of the step.
    */
-  description?: string
+  description?: string;
   /**
-   *  Status of the stepper
+   * Status of the step.
+   * Note: 'current' is computed internally by the stepper based on activeStep and should not be passed.
    */
   status?: FzStepStatus;
-}
+  /**
+   * Truncate the title and description to a single line with ellipsis.
+   * @default false
+   */
+  isTextTruncated?: boolean;
+  /**
+   * Explicitly show or hide the description.
+   * When false, hides the description even if a description string is provided.
+   * @default true
+   */
+  hasStepDescription?: boolean;
+};
 
-export { FzStepperProps, FzStepStatus, FzStepProps };
+export { FzStepperProps, FzStepperEnvironment, FzStepStatus, FzStepProps };

--- a/packages/tab/src/__tests__/__snapshots__/FzTabs.spec.ts.snap
+++ b/packages/tab/src/__tests__/__snapshots__/FzTabs.spec.ts.snap
@@ -191,7 +191,7 @@ exports[`FzTabs > Snapshots > should match snapshot - with badgeContent 1`] = `
   <div class="flex flex-row">
     <div class="tab-container flex rounded-lg p-2 bg-grey-100 w-fit max-w-full w-full sm:w-auto flex-row overflow-x-auto"><button class="flex items-center rounded-md focus:z-10 w-auto text-md h-40 gap-8 py-8 px-12 bg-white text-blue-500 cursor-pointer" title="tab1" badgecontent="1">
         <!--v-if--><span class="text-ellipsis whitespace-nowrap overflow-hidden">tab1</span>
-        <div class="flex items-center justify-center truncate max-w-full gap-4 size-24 rounded-full bg-blue-500 text-core-white" title="1" environment="backoffice">
+        <div class="flex items-center justify-center truncate max-w-full gap-4 size-24 min-w-24 rounded-full bg-blue-500 text-core-white" title="1" environment="backoffice">
           <!--v-if-->
           <p class="text-[inherit] text-sm">1</p>
           <!--v-if-->

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
   apps/storybook:
     dependencies:
       '@awesome.me/kit-8137893ad3':
-        specifier: ^1.0.416
-        version: 1.0.416
+        specifier: ^1.0.417
+        version: 1.0.417
       '@fiscozen/action':
         specifier: workspace:^
         version: link:../../packages/action
@@ -1864,8 +1864,8 @@ importers:
   packages/icons:
     dependencies:
       '@awesome.me/kit-8137893ad3':
-        specifier: ^1.0.416
-        version: 1.0.416
+        specifier: ^1.0.417
+        version: 1.0.417
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.7.2
         version: 6.7.2
@@ -3630,8 +3630,8 @@ packages:
   '@asamuzakjp/dom-selector@2.0.2':
     resolution: {integrity: sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==}
 
-  '@awesome.me/kit-8137893ad3@1.0.416':
-    resolution: {integrity: sha512-DgZSOpABqrFXW2zGjqzfcrfjwB5NMh7+XYz0+SfPweAd8enViyj7sunmpesIoHF30Q5cBHwV3mW2trL7zJQMFw==}
+  '@awesome.me/kit-8137893ad3@1.0.417':
+    resolution: {integrity: sha512-43jzdhjcsuu6sMUu2axWLehIEFIbQPIHOEVBY0CewVq8TI9mvd0W4oE2S3UAbZjapo0OAxCgGSkXf/FLHuYnfA==}
     engines: {node: '>=16'}
 
   '@babel/code-frame@7.29.0':
@@ -8767,8 +8767,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.2.7:
-    resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
+  vue-component-type-helpers@3.2.8:
+    resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -8992,7 +8992,7 @@ snapshots:
       css-tree: 2.3.1
       is-potential-custom-element-name: 1.0.1
 
-  '@awesome.me/kit-8137893ad3@1.0.416':
+  '@awesome.me/kit-8137893ad3@1.0.417':
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
 
@@ -10044,7 +10044,7 @@ snapshots:
       storybook: 10.3.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@5.7.3)
-      vue-component-type-helpers: 3.2.7
+      vue-component-type-helpers: 3.2.8
 
   '@tato30/vue-pdf@2.0.2(vue@3.5.26(typescript@5.7.3))':
     dependencies:
@@ -14533,7 +14533,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.2.7: {}
+  vue-component-type-helpers@3.2.8: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@5.7.3)):
     dependencies:


### PR DESCRIPTION
## Summary

- Add `hasStepbar`, `hasStepperList`, `environment`, `isTextTruncated`, `hasStepDescription` props to `FzStepper`; deprecate `forceMobile`
- Fix visual alignment: 4px bar height, 156px step width, correct badge tones, error state title color, text gap
- Fix `FzBadge` number variant not rendering as a circle in flex containers by adding `min-w-24`
- Rewrite Storybook stories with full variant coverage and interaction tests; add MDX docs

## Test plan

- [x] Unit tests: 54/54 passing (`@fiscozen/stepper`), 38/38 (`@fiscozen/badge`)
- [x] Storybook play functions: 719/719 passing
- [x] Changesets added for `@fiscozen/badge` (patch) and `@fiscozen/stepper` (minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)