### PR TITLE
fix(progress): make animation CSS custom property assertions minification-safe

### DIFF
--- a/apps/storybook/src/stories/progress/Progress.stories.ts
+++ b/apps/storybook/src/stories/progress/Progress.stories.ts
@@ -51,9 +51,12 @@ const Default: Story = {
       const container = canvasElement.querySelector('.fz-progress') as HTMLElement | null
       await expect(container).toBeTruthy()
       const styles = window.getComputedStyle(container!)
-      await expect(styles.getPropertyValue('--fa-animation-duration').trim()).toBe('0.86s')
-      await expect(styles.getPropertyValue('--fa-animation-timing').trim()).toBe(
-        'cubic-bezier(0.4, 0.15, 0.6, 0.85)'
+      // CSS minification strips leading zeros (0.86s → .86s), so compare numerically
+      await expect(
+        parseFloat(styles.getPropertyValue('--fa-animation-duration').trim())
+      ).toBeCloseTo(0.86)
+      await expect(styles.getPropertyValue('--fa-animation-timing').trim()).toMatch(
+        /cubic-bezier\(0?\.4,\s*0?\.15,\s*0?\.6,\s*0?\.85\)/
       )
     })
 


### PR DESCRIPTION
## Summary

- `getPropertyValue()` on CSS custom properties returns the value verbatim from the stylesheet, not normalized by the browser
- The production build (used by Chromatic) minifies CSS, stripping leading zeros: `0.86s` → `.86s` and `cubic-bezier(0.4, ...)` → `cubic-bezier(.4, ...)`
- The test was comparing exact strings against the unminified form, so it passed locally (dev server, no minification) but failed in Chromatic (built Storybook)

## Fix

In `Progress.stories.ts`, replaced exact string assertions with minification-safe alternatives:
- `--fa-animation-duration`: use `parseFloat` + `toBeCloseTo` to compare numerically
- `--fa-animation-timing`: use a regex that accepts both `0?.4` forms

## Test plan

- [x] `pnpm test:storybook` — all 719 tests pass locally
- [ ] Chromatic build should now pass the `FzProgress` interaction tests