### PR TITLE
feat(LIB-1901): additive modernization of FzNavbar (v0.2.0)

### DIFF
--- a/.changeset/lib-1901-navbar-additive-modernization.md
+++ b/.changeset/lib-1901-navbar-additive-modernization.md
@@ -1,0 +1,15 @@
+---
+"@fiscozen/navbar": minor
+---
+
+Additive modernization of FzNavbar (no required consumer changes):
+
+- Add `mobileBreakpoint` prop (number or `${number}px`) — replaces the need for consumers to mutate `@fiscozen/style`'s imported `breakpoints` object to align the navbar with their desktop threshold. The legacy `breakpoints` prop is deprecated and now emits a dev-mode warning when used.
+- Add `position` prop (`'static' | 'fixed' | 'sticky'`) — replaces the `class="fixed top-0 left-0"` pattern consumers use at the call site.
+- Add `respectSafeArea` prop (default `false`) — when enabled, adds `env(safe-area-inset-*)` to top/left/right padding for devices with notches. Honors the `--safe-area-inset-*` CSS-variable fallback used by Capacitor / Cordova apps.
+- Add v-model support on `isMenuOpen` — the existing prop + `fznavbar:menuButtonClick` event continue to work; consumers can opt in to `v-model:isMenuOpen` for cleaner two-way binding.
+- Add `#menu-button` slot with scope `{ isOpen, toggle }` — lets consumers replace the default `FzIconButton` hamburger on mobile.
+- Expose layout values as CSS custom properties on the root (`--fz-navbar-padding`, `--fz-navbar-shadow`, `--fz-navbar-height`, `--fz-navbar-width`, `--fz-navbar-brand-gap`, `--fz-navbar-actions-gap`, `--fz-navbar-z-index`, `--fz-navbar-bg`). Defaults match the previous Tailwind utility values, so visual behavior is unchanged. Consumers can override per-instance via inline style without `!important` resets.
+- Add Bootstrap interop hardening — root `<header>` carries `box-border`, `m-0`, `border-0` so the component renders identically with or without `tailwindcss-scoped-preflight` (`.twp`) scoping.
+- Bug fix: on mobile, both `#notifications` and `#user-menu` slots render simultaneously when both are provided. The previous mutually-exclusive behavior was a hard-coded limitation.
+- Default alignment fix: the root `<header>` and the inner navigation / actions flex containers now use `items-center`, so slot content with mixed heights (icon, button, avatar) sits visually centered along the cross-axis. Frontoffice previously worked around this on mobile by adding `items-center` at the call site.

--- a/apps/storybook/src/stories/navigation/Navbar.stories.ts
+++ b/apps/storybook/src/stories/navigation/Navbar.stories.ts
@@ -1,100 +1,108 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { ref } from 'vue'
 import { expect, userEvent, within, fn } from 'storybook/test'
 
-import { FzNavbar, FzNavbarProps } from '@fiscozen/navbar'
+import { FzNavbar } from '@fiscozen/navbar'
 import { FzIcon } from '@fiscozen/icons'
 import { FzNavlink } from '@fiscozen/navlink'
 import { FzIconButton } from '@fiscozen/button'
 import { FzAvatar } from '@fiscozen/avatar'
 
-// More on how to set up stories at: https://storybook.js.org/docs/writing-stories
 const meta = {
   title: 'Navigation/FzNavbar',
   component: FzNavbar,
-  // This component will have an automatically generated docsPage entry: https://storybook.js.org/docs/writing-docs/autodocs
   tags: ['autodocs'],
-  argTypes: {},
-  args: {}
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'Layout direction of the navbar.'
+    },
+    position: {
+      control: 'select',
+      options: ['static', 'fixed', 'sticky'],
+      description: 'CSS positioning strategy applied to the root `<header>`.'
+    },
+    mobileBreakpoint: {
+      control: { type: 'number', min: 320, max: 1920, step: 10 },
+      description:
+        'Width (px) at and above which the desktop layout renders. Below this value the compact mobile layout is used.'
+    },
+    respectSafeArea: {
+      control: 'boolean',
+      description:
+        'When `true`, the navbar adds `env(safe-area-inset-*)` to top/left/right padding for devices with a notch / dynamic island.'
+    },
+    isMenuOpen: {
+      control: 'boolean',
+      description: 'Mobile menu open state. Supports `v-model:isMenuOpen` for two-way binding.'
+    },
+    breakpoints: { table: { disable: true } }
+  },
+  args: {
+    variant: 'horizontal',
+    position: 'static',
+    respectSafeArea: false,
+    isMenuOpen: false,
+    onFznavbarMenuButtonClick: fn()
+  }
 } satisfies Meta<typeof FzNavbar>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
+const FULL_NAVBAR_TEMPLATE = `
+  <FzNavbar v-bind="args" @fznavbar:menuButtonClick="args.onFznavbarMenuButtonClick">
+    <template #brand-logo>
+      <FzIcon name="fiscozen" variant="fak" size="xl" class="text-core-black text-[32px] !w-[40px] ml-[-4px] cursor-pointer" />
+    </template>
+    <template #navigation>
+      <FzNavlink label="Fatture" />
+      <FzNavlink label="Spese" />
+      <FzNavlink label="Corrispettivi" />
+      <FzNavlink label="Adempimenti" />
+      <FzNavlink label="Documenti" />
+    </template>
+    <template #notifications>
+      <FzIconButton iconName="bell" variant="notification" tooltip="notifications" />
+    </template>
+    <template #user-menu>
+      <FzAvatar firstName="Mario" lastName="Rossi" />
+    </template>
+  </FzNavbar>
+`
+
 export const Horizontal: Story = {
-  args: {
-    onFznavbarMenuButtonClick: fn()
-  },
-  render: (args: FzNavbarProps) => ({
+  render: (args) => ({
     setup() {
       return { args }
     },
     components: { FzNavbar, FzIcon, FzNavlink, FzIconButton, FzAvatar },
-    template: `
-      <FzNavbar variant="horizontal" @fznavbar:menuButtonClick="args.onFznavbarMenuButtonClick">
-        <template #brand-logo="{isMobile}">
-          <FzIcon name="fiscozen" variant="fak" size="xl" class="text-core-black text-[32px] !w-[40px] ml-[-4px] cursor-pointer" /> 
-        </template>
-
-        <template #navigation>
-          <FzNavlink label="Fatture" /> 
-          <FzNavlink label="Spese" /> 
-          <FzNavlink label="Corrispettivi" /> 
-          <FzNavlink label="Adempimenti" /> 
-          <FzNavlink label="Documenti" /> 
-          <FzNavlink label="Dichiarazione" /> 
-        </template>
-        
-        <template #notifications="{isHorizontal, isVertical, isMobile}">
-          <FzIconButton  iconName="bell" variant="notification" tooltip="notifications" :disabled="false" />
-        </template>
-        <template #user-menu="{isHorizontal, isVertical, isMobile}">
-          <FzAvatar v-if="isVertical" src="consultant.jpg" />
-          <FzAvatar v-if="isHorizontal && !isMobile" firstName="Mario" lastName="Rossi" />
-        </template>
-      </FzNavbar>
-    `
+    template: FULL_NAVBAR_TEMPLATE
   }),
   play: async ({ args, canvasElement, step }) => {
     const canvas = within(canvasElement)
-    
-    await step('Verify navbar renders correctly', async () => {
+
+    await step('Verify navbar renders as a semantic <header>', async () => {
       const header = canvas.getByRole('banner')
       await expect(header).toBeInTheDocument()
-      await expect(header).toBeVisible()
-    })
-    
-    await step('Verify brand logo is present', async () => {
-      // Check for SVG element (icon) or div containing icon
-      const logo = canvasElement.querySelector('svg') || canvasElement.querySelector('div.flex.items-center')
-      await expect(logo).toBeTruthy()
-    })
-    
-    await step('Verify navigation links are present', async () => {
-      const fattureButton = canvas.getByRole('button', { name: /fatture/i })
-      await expect(fattureButton).toBeInTheDocument()
-      
-      const speseButton = canvas.getByRole('button', { name: /spese/i })
-      await expect(speseButton).toBeInTheDocument()
-    })
-    
-    await step('Verify semantic HTML structure', async () => {
-      const header = canvas.getByRole('banner')
       await expect(header.tagName.toLowerCase()).toBe('header')
     })
-    
-    await step('Verify keyboard navigation', async () => {
-      // Tab to first navigation button
-      await userEvent.tab()
-      const firstButton = canvas.getByRole('button', { name: /fatture/i })
-      await expect(document.activeElement).toBe(firstButton)
+
+    await step('Verify navigation links are present', async () => {
+      await expect(canvas.getByRole('button', { name: /fatture/i })).toBeInTheDocument()
+      await expect(canvas.getByRole('button', { name: /spese/i })).toBeInTheDocument()
     })
-    
-    await step('Verify menu button click handler (if menu button is visible)', async () => {
-      // Menu button is only visible on mobile, so check if it exists
-      const menuButton = canvasElement.querySelector('button[aria-label*="menu"], button[aria-label*="Menu"]')
+
+    await step('Verify keyboard navigation', async () => {
+      await userEvent.tab()
+      await expect(document.activeElement).toBe(canvas.getByRole('button', { name: /fatture/i }))
+    })
+
+    await step('Verify mobile menu button click handler is wired (if visible)', async () => {
+      const menuButton = canvasElement.querySelector('button[aria-label*="menu" i]')
       if (menuButton) {
         await userEvent.click(menuButton as HTMLElement)
-        // ROBUST CHECK: Verify handler WAS called
         await expect(args.onFznavbarMenuButtonClick).toHaveBeenCalled()
       }
     })
@@ -102,34 +110,187 @@ export const Horizontal: Story = {
 }
 
 export const Vertical: Story = {
-  render: (args: FzNavbarProps) => ({
+  args: {
+    variant: 'vertical'
+  },
+  decorators: [() => ({ template: '<div class="h-screen m-0"><story /></div>' })],
+  render: (args) => ({
     setup() {
       return { args }
     },
     components: { FzNavbar, FzIcon, FzNavlink, FzIconButton, FzAvatar },
     template: `
-      <div class="h-screen m-0">
-        <FzNavbar variant="vertical">
-          <template #brand-logo="{isMobile}">
-            <FzIcon name="fiscozen" variant="fak" size="xl" class="text-core-black text-[32px] !w-[40px] ml-[-4px] cursor-pointer" /> 
-          </template>
+      <FzNavbar v-bind="args" @fznavbar:menuButtonClick="args.onFznavbarMenuButtonClick">
+        <template #brand-logo>
+          <FzIcon name="fiscozen" variant="fak" size="xl" class="text-core-black text-[32px] !w-[40px] ml-[-4px] cursor-pointer" />
+        </template>
+        <template #navigation>
+          <FzNavlink iconName="suitcase" />
+          <FzNavlink iconName="folder-user" />
+          <FzNavlink iconName="credit-card" />
+          <FzNavlink iconName="cart-shopping" />
+          <FzNavlink iconName="calendar-lines" />
+          <FzNavlink iconName="file-check" />
+          <FzNavlink iconName="gear" />
+        </template>
+        <template #user-menu>
+          <FzAvatar firstName="Consultant" lastName="User" />
+        </template>
+      </FzNavbar>
+    `
+  }),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
 
-          <template #navigation>
-            <FzNavlink iconName="suitcase" /> 
-            <FzNavlink iconName="folder-user" /> 
-            <FzNavlink iconName="credit-card" /> 
-            <FzNavlink iconName="cart-shopping" /> 
-            <FzNavlink iconName="calendar-lines" /> 
-            <FzNavlink iconName="file-check" /> 
-            <FzNavlink iconName="gear" /> 
-            <FzNavlink iconName="screwdriver-wrench" /> 
+    await step('Verify vertical navbar renders as a semantic <header>', async () => {
+      const header = canvas.getByRole('banner')
+      await expect(header).toBeInTheDocument()
+      await expect(header.tagName.toLowerCase()).toBe('header')
+    })
+
+    await step('Verify icon-only navigation links are present', async () => {
+      const navLinks = canvasElement.querySelectorAll('a[href], button')
+      await expect(navLinks.length).toBeGreaterThan(0)
+    })
+  }
+}
+
+export const Positioned: Story = {
+  args: {
+    position: 'fixed'
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use the `position` control to switch between `static`, `fixed`, and `sticky`. Scroll the page to verify the navbar stays in place when fixed or sticky.'
+      }
+    }
+  },
+  render: (args) => ({
+    setup() {
+      return { args }
+    },
+    components: { FzNavbar, FzIcon, FzNavlink, FzIconButton, FzAvatar },
+    template: `
+      <div class="h-screen relative">
+        ${FULL_NAVBAR_TEMPLATE}
+        <main class="pt-[240px] p-12">
+          <p>This page is intentionally tall so you can scroll and confirm the navbar's positioning behavior.</p>
+          <div class="h-[1200px]"></div>
+        </main>
+      </div>
+    `
+  }),
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify positioning class reflects the prop', async () => {
+      const header = canvas.getByRole('banner')
+      if (args.position === 'fixed') {
+        await expect(header.classList.contains('fz-navbar--fixed')).toBe(true)
+      } else if (args.position === 'sticky') {
+        await expect(header.classList.contains('fz-navbar--sticky')).toBe(true)
+      }
+    })
+  }
+}
+
+export const Customized: Story = {
+  args: {
+    respectSafeArea: true
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Layout values are exposed as CSS custom properties on the root (`--fz-navbar-padding`, `--fz-navbar-shadow`, `--fz-navbar-height`, `--fz-navbar-bg`, …). Override per-instance via inline `style` to slim the navbar without `!important` resets.'
+      }
+    }
+  },
+  render: (args) => ({
+    setup() {
+      return { args }
+    },
+    components: { FzNavbar, FzIcon, FzNavlink, FzIconButton, FzAvatar },
+    template: `
+      <FzNavbar
+        v-bind="args"
+        style="
+          --fz-navbar-padding: 12px;
+          --fz-navbar-shadow: none;
+          --fz-navbar-height: 56px;
+          --fz-navbar-brand-gap: 24px;
+          --fz-navbar-actions-gap: 12px;
+          --fz-navbar-bg: #f9fafb;
+        "
+        @fznavbar:menuButtonClick="args.onFznavbarMenuButtonClick">
+        <template #brand-logo>
+          <FzIcon name="fiscozen" variant="fak" size="xl" class="text-core-black text-[24px] !w-[28px] cursor-pointer" />
+        </template>
+        <template #navigation>
+          <FzNavlink label="Fatture" />
+          <FzNavlink label="Spese" />
+        </template>
+        <template #notifications>
+          <FzIconButton iconName="bell" variant="notification" tooltip="notifications" />
+        </template>
+        <template #user-menu>
+          <FzAvatar firstName="Mario" lastName="Rossi" />
+        </template>
+      </FzNavbar>
+    `
+  }),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    await step('Verify navbar renders with the customization applied', async () => {
+      const header = canvas.getByRole('banner')
+      await expect(header).toBeInTheDocument()
+    })
+  }
+}
+
+export const MobileMenu: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`isMenuOpen` supports two-way binding via `v-model:isMenuOpen`. The default mobile hamburger can be replaced via the `#menu-button` slot, which exposes `{ isOpen, toggle }` as scope. This story forces the mobile layout via `mobileBreakpoint: 9999` so the slot is always visible regardless of viewport.'
+      }
+    }
+  },
+  argTypes: {
+    isMenuOpen: { table: { disable: true } },
+    mobileBreakpoint: { table: { disable: true } }
+  },
+  render: () => ({
+    setup() {
+      const isMenuOpen = ref(false)
+      return { isMenuOpen }
+    },
+    components: { FzNavbar, FzIcon, FzIconButton, FzAvatar },
+    template: `
+      <div>
+        <p class="mb-12 p-12">
+          Menu is <strong>{{ isMenuOpen ? 'open' : 'closed' }}</strong> (driven by v-model).
+        </p>
+        <FzNavbar variant="horizontal" :mobileBreakpoint="9999" v-model:isMenuOpen="isMenuOpen">
+          <template #menu-button="{ isOpen, toggle }">
+            <button
+              class="px-12 py-6 rounded bg-blue-500 text-white text-sm"
+              :aria-expanded="isOpen"
+              @click="toggle">
+              {{ isOpen ? 'Close' : 'Open' }} menu
+            </button>
           </template>
-          
-          <template #notifications="{isHorizontal, isVertical, isMobile}">
-            <FzIconButton v-if="!isVertical" iconName="bell" variant="notification" tooltip="notifications" :disabled="false" />
+          <template #brand-logo>
+            <FzIcon name="fiscozen" variant="fak" size="xl" class="text-core-black text-[24px] !w-[28px]" />
+          </template>
+          <template #notifications>
+            <FzIconButton iconName="message" variant="invisible" tooltip="chat" />
           </template>
           <template #user-menu>
-            <FzAvatar firstName="Consultant" lastName="User" src="consultant.jpg" />
+            <FzAvatar firstName="Mario" lastName="Rossi" />
           </template>
         </FzNavbar>
       </div>
@@ -137,81 +298,48 @@ export const Vertical: Story = {
   }),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
-    
-    await step('Verify vertical navbar renders correctly', async () => {
-      const header = canvas.getByRole('banner')
-      await expect(header).toBeInTheDocument()
-      await expect(header).toBeVisible()
+
+    await step('Verify custom menu button renders inside the navbar', async () => {
+      const button = canvas.getByRole('button', { name: /open menu/i })
+      await expect(button).toBeInTheDocument()
     })
-    
-    await step('Verify brand logo is present', async () => {
-      // Check for SVG element (icon) or div containing icon
-      const logo = canvasElement.querySelector('svg') || canvasElement.querySelector('div.flex.items-center')
-      await expect(logo).toBeTruthy()
-    })
-    
-    await step('Verify navigation links are present', async () => {
-      // Vertical navbar uses icon-only navlinks, so we check for links by their presence
-      const navLinks = canvasElement.querySelectorAll('a[href], button')
-      await expect(navLinks.length).toBeGreaterThan(0)
-    })
-    
-    await step('Verify semantic HTML structure', async () => {
-      const header = canvas.getByRole('banner')
-      await expect(header.tagName.toLowerCase()).toBe('header')
-    })
-    
-    await step('Verify keyboard navigation', async () => {
-      const header = canvas.getByRole('banner')
-      // Tab to first focusable element
-      await userEvent.tab()
-      // Focus should be on a navigation element
-      const activeElement = document.activeElement
-      await expect(activeElement).toBeInTheDocument()
-      await expect(header.contains(activeElement) || activeElement === header).toBe(true)
+
+    await step('Verify clicking the custom button toggles the v-model state', async () => {
+      const button = canvas.getByRole('button', { name: /open menu/i })
+      await userEvent.click(button)
+      await expect(canvas.getByRole('button', { name: /close menu/i })).toBeInTheDocument()
     })
   }
 }
 
-
-export const CustomBreakpoints: Story = {
-  render: (args: FzNavbarProps) => ({
-    setup() {
-      const breakpoints = {
-        lg: '1200px' as `${number}px`,
-        md: '900px' as `${number}px`,
-        sm: '600px' as `${number}px`
+export const BootstrapInterop: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Smoke test for consumers that scope Tailwind Preflight to a `.twp` wrapper because Bootstrap is still present globally (see `tailwindcss-scoped-preflight`). The navbar adds `box-border`, `m-0`, `border-0` to its root to render identically with or without the wrapper.'
       }
-      args.breakpoints = breakpoints;
+    }
+  },
+  render: (args) => ({
+    setup() {
       return { args }
     },
     components: { FzNavbar, FzIcon, FzNavlink, FzIconButton, FzAvatar },
     template: `
-      <FzNavbar variant="horizontal" :breakpoints="args.breakpoints">
-        <template #brand-logo="{isMobile}">
-          <FzIcon name="fiscozen" variant="fak" size="xl" class="text-core-black text-[32px] !w-[40px] ml-[-4px] cursor-pointer" /> 
-        </template>
-      </FzNavbar>
+      <div class="twp">
+        ${FULL_NAVBAR_TEMPLATE}
+        <main class="p-12">
+          <p>The navbar above sits inside a <code>.twp</code> wrapper. The component must render identically with or without it.</p>
+        </main>
+      </div>
     `
   }),
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
-    
-    await step('Verify navbar with custom breakpoints renders', async () => {
+    await step('Verify navbar renders inside a .twp wrapper', async () => {
       const header = canvas.getByRole('banner')
-      await expect(header).toBeInTheDocument()
-      await expect(header).toBeVisible()
-    })
-    
-    await step('Verify brand logo is present', async () => {
-      // Check for SVG element (icon) or div containing icon
-      const logo = canvasElement.querySelector('svg') || canvasElement.querySelector('div.flex.items-center')
-      await expect(logo).toBeTruthy()
-    })
-    
-    await step('Verify semantic HTML structure', async () => {
-      const header = canvas.getByRole('banner')
-      await expect(header.tagName.toLowerCase()).toBe('header')
+      await expect(header.closest('.twp')).not.toBeNull()
     })
   }
 }

--- a/packages/navbar/src/FzNavbar.vue
+++ b/packages/navbar/src/FzNavbar.vue
@@ -7,29 +7,59 @@ import { useBreakpoints } from '@fiscozen/composables'
 
 const props = withDefaults(defineProps<FzNavbarProps>(), {
   variant: 'horizontal',
-  breakpoints: undefined
+  breakpoints: undefined,
+  mobileBreakpoint: undefined,
+  position: 'static',
+  respectSafeArea: false
 })
 
+const emit = defineEmits<FzNavbarEmits>()
+
+if (props.breakpoints !== undefined) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[FzNavbar] The `breakpoints` prop is deprecated and will be removed in a future major. Use `mobileBreakpoint` instead.'
+  )
+}
+
 const computedBreakpoints = computed(() => {
+  if (props.mobileBreakpoint !== undefined) {
+    const value =
+      typeof props.mobileBreakpoint === 'number'
+        ? (`${props.mobileBreakpoint}px` as `${number}px`)
+        : props.mobileBreakpoint
+    return { ...breakpoints, lg: value }
+  }
   return {
     ...breakpoints,
     ...(props.breakpoints ?? {})
   }
 })
 
-const emit = defineEmits<FzNavbarEmits>()
-
 const { isGreater } = useBreakpoints(computedBreakpoints.value)
 const isGreaterThanLg = isGreater('lg')
 const isMobile = computed(() => !isGreaterThanLg.value)
-const isVertical = computed(() => Boolean(props.variant === 'vertical'))
-const isHorizontal = computed(() => Boolean(props.variant === 'horizontal'))
+const isVertical = computed(() => props.variant === 'vertical')
+const isHorizontal = computed(() => props.variant === 'horizontal')
+
+const localMenuOpen = computed<boolean | undefined>({
+  get: () => props.isMenuOpen,
+  set: (value) => emit('update:isMenuOpen', Boolean(value))
+})
+
+function handleMenuButtonClick() {
+  localMenuOpen.value = !localMenuOpen.value
+  emit('fznavbar:menuButtonClick')
+}
 </script>
 
 <template>
   <header
-    class="z-10 flex p-12 shadow"
+    class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow"
     :class="{
+      'fz-navbar--fixed': position === 'fixed',
+      'fz-navbar--sticky': position === 'sticky',
+      'fz-navbar--safe-area': respectSafeArea,
       'justify-between': isMobile,
       'h-full w-56 flex-col': isVertical && !isMobile,
       'h-56 w-full': isHorizontal || isMobile
@@ -39,11 +69,14 @@ const isHorizontal = computed(() => Boolean(props.variant === 'horizontal'))
       <div :class="{ 'mr-32': isHorizontal, 'mb-32': isVertical }">
         <slot name="brand-logo" :isMobile :isHorizontal :isVertical></slot>
       </div>
-      <div class="flex gap-4" :class="{ 'flex-row': isHorizontal, 'flex-col': isVertical }">
+      <div
+        class="flex items-center gap-4"
+        :class="{ 'flex-row': isHorizontal, 'flex-col': isVertical }"
+      >
         <slot name="navigation" :isVertical :isHorizontal :isMobile></slot>
       </div>
       <div
-        class="flex gap-16"
+        class="flex items-center gap-16"
         :class="{ 'ml-auto flex-row': isHorizontal, 'mt-auto flex-col': isVertical }"
       >
         <slot name="notifications" :isHorizontal :isVertical :isMobile></slot>
@@ -51,25 +84,87 @@ const isHorizontal = computed(() => Boolean(props.variant === 'horizontal'))
       </div>
     </template>
     <template v-else>
-      <FzIconButton
-        :iconName="isMenuOpen ? 'xmark' : 'bars'"
-        variant="secondary"
-        tooltip="menu"
-        @click="emit('fznavbar:menuButtonClick')"
-      />
+      <slot name="menu-button" :isOpen="Boolean(localMenuOpen)" :toggle="handleMenuButtonClick">
+        <FzIconButton
+          :iconName="localMenuOpen ? 'xmark' : 'bars'"
+          variant="secondary"
+          tooltip="menu"
+          @click="handleMenuButtonClick"
+        />
+      </slot>
       <div>
         <slot name="brand-logo" :isMobile :isHorizontal :isVertical></slot>
       </div>
-      <div>
-        <slot
-          :name="isHorizontal ? 'notifications' : 'user-menu'"
-          :isHorizontal
-          :isVertical
-          :isMobile
-        ></slot>
+      <div class="flex items-center gap-16">
+        <slot name="notifications" :isHorizontal :isVertical :isMobile></slot>
+        <slot name="user-menu" :isHorizontal :isMobile :isVertical></slot>
       </div>
     </template>
   </header>
 </template>
 
-<style></style>
+<style>
+/*
+ * CSS custom properties — defaults match the previous Tailwind utility values
+ * (p-12 = 3rem, shadow, z-10, h-56/w-56 = 14rem, mr-32/mb-32 = 8rem, gap-16 = 4rem).
+ * Consumers can override per-instance via inline style or scoped CSS to slim
+ * the navbar without having to rely on `!important` resets.
+ */
+
+.fz-navbar {
+  z-index: var(--fz-navbar-z-index, 10);
+  padding: var(--fz-navbar-padding, 3rem);
+  box-shadow: var(
+    --fz-navbar-shadow,
+    0 1px 3px 0 rgb(0 0 0 / 0.1),
+    0 1px 2px -1px rgb(0 0 0 / 0.1)
+  );
+  background: var(--fz-navbar-bg, transparent);
+}
+
+.fz-navbar.h-56 {
+  height: var(--fz-navbar-height, 14rem);
+}
+
+.fz-navbar.w-56 {
+  width: var(--fz-navbar-width, 14rem);
+}
+
+.fz-navbar > .mr-32 {
+  margin-right: var(--fz-navbar-brand-gap, 8rem);
+}
+
+.fz-navbar > .mb-32 {
+  margin-bottom: var(--fz-navbar-brand-gap, 8rem);
+}
+
+.fz-navbar > .gap-16 {
+  gap: var(--fz-navbar-actions-gap, 4rem);
+}
+
+.fz-navbar--fixed {
+  position: fixed;
+  top: 0;
+  left: 0;
+}
+
+.fz-navbar--sticky {
+  position: sticky;
+  top: 0;
+}
+
+.fz-navbar--safe-area {
+  padding-top: calc(
+    var(--fz-navbar-padding, 3rem) +
+      max(env(safe-area-inset-top, 0px), var(--safe-area-inset-top, 0px))
+  );
+  padding-left: calc(
+    var(--fz-navbar-padding, 3rem) +
+      max(env(safe-area-inset-left, 0px), var(--safe-area-inset-left, 0px))
+  );
+  padding-right: calc(
+    var(--fz-navbar-padding, 3rem) +
+      max(env(safe-area-inset-right, 0px), var(--safe-area-inset-right, 0px))
+  );
+}
+</style>

--- a/packages/navbar/src/__tests__/FzNavbar.spec.ts
+++ b/packages/navbar/src/__tests__/FzNavbar.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount, VueWrapper } from '@vue/test-utils'
 import FzNavbar from '../FzNavbar.vue'
 import { FzIconButton } from '@fiscozen/button'
+import { breakpoints } from '@fiscozen/style'
 
 const navigation = `
   <div class="link">one</div>
@@ -845,6 +846,279 @@ describe('FzNavbar', () => {
       })
 
       expect(wrapper.html()).toMatchSnapshot()
+    })
+  })
+
+  // ============================================
+  // v0.2.0 — ADDITIVE API
+  // ============================================
+  describe('mobileBreakpoint prop', () => {
+    it('should accept a numeric value', () => {
+      wrapper = mount(FzNavbar, {
+        props: {
+          variant: 'horizontal',
+          mobileBreakpoint: 1200
+        }
+      })
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should accept a pixel-string value', () => {
+      wrapper = mount(FzNavbar, {
+        props: {
+          variant: 'horizontal',
+          mobileBreakpoint: '1200px'
+        }
+      })
+      expect(wrapper.exists()).toBe(true)
+    })
+
+    it('should not mutate the imported @fiscozen/style breakpoints object', () => {
+      const before = { ...breakpoints }
+      mount(FzNavbar, {
+        props: {
+          variant: 'horizontal',
+          mobileBreakpoint: 1400
+        }
+      })
+      expect(breakpoints).toEqual(before)
+    })
+
+    it('should take precedence over the legacy `breakpoints` prop when both are provided', () => {
+      wrapper = mount(FzNavbar, {
+        props: {
+          variant: 'horizontal',
+          breakpoints: { lg: '900px' },
+          mobileBreakpoint: 1500
+        }
+      })
+      expect(wrapper.exists()).toBe(true)
+    })
+  })
+
+  describe('position prop', () => {
+    it('should not add positioning classes by default', () => {
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal' }
+      })
+      const header = wrapper.find('header')
+      expect(header.classes()).not.toContain('fz-navbar--fixed')
+      expect(header.classes()).not.toContain('fz-navbar--sticky')
+    })
+
+    it('should add the fixed-position class when position="fixed"', () => {
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal', position: 'fixed' }
+      })
+      expect(wrapper.find('header').classes()).toContain('fz-navbar--fixed')
+    })
+
+    it('should add the sticky-position class when position="sticky"', () => {
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal', position: 'sticky' }
+      })
+      expect(wrapper.find('header').classes()).toContain('fz-navbar--sticky')
+    })
+  })
+
+  describe('respectSafeArea prop', () => {
+    it('should not add the safe-area class by default', () => {
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal' }
+      })
+      expect(wrapper.find('header').classes()).not.toContain('fz-navbar--safe-area')
+    })
+
+    it('should add the safe-area class when respectSafeArea is true', () => {
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal', respectSafeArea: true }
+      })
+      expect(wrapper.find('header').classes()).toContain('fz-navbar--safe-area')
+    })
+  })
+
+  describe('v-model:isMenuOpen', () => {
+    it('should emit update:isMenuOpen when the default menu button is clicked', async () => {
+      window.innerWidth = 1023
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1023)
+
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal', isMenuOpen: false }
+      })
+      await wrapper.vm.$nextTick()
+      const menuButton = wrapper.findComponent(FzIconButton)
+      const buttonElement = menuButton.find('button')
+      await (buttonElement.exists() ? buttonElement : menuButton).trigger('click')
+
+      const updates = wrapper.emitted('update:isMenuOpen')
+      expect(updates).toBeTruthy()
+      expect(updates![0]).toEqual([true])
+    })
+
+    it('should emit `false` when toggling from an open state', async () => {
+      window.innerWidth = 1023
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1023)
+
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal', isMenuOpen: true }
+      })
+      await wrapper.vm.$nextTick()
+      const menuButton = wrapper.findComponent(FzIconButton)
+      const buttonElement = menuButton.find('button')
+      await (buttonElement.exists() ? buttonElement : menuButton).trigger('click')
+
+      const updates = wrapper.emitted('update:isMenuOpen')
+      expect(updates).toBeTruthy()
+      expect(updates![0]).toEqual([false])
+    })
+
+    it('should still emit fznavbar:menuButtonClick alongside update:isMenuOpen', async () => {
+      window.innerWidth = 1023
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1023)
+
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal', isMenuOpen: false }
+      })
+      await wrapper.vm.$nextTick()
+      const menuButton = wrapper.findComponent(FzIconButton)
+      const buttonElement = menuButton.find('button')
+      await (buttonElement.exists() ? buttonElement : menuButton).trigger('click')
+
+      expect(wrapper.emitted('fznavbar:menuButtonClick')).toHaveLength(1)
+      expect(wrapper.emitted('update:isMenuOpen')).toHaveLength(1)
+    })
+  })
+
+  describe('menu-button slot', () => {
+    it('should render the default FzIconButton when the slot is not provided', async () => {
+      window.innerWidth = 1023
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1023)
+
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal' }
+      })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.findComponent(FzIconButton).exists()).toBe(true)
+    })
+
+    it('should replace the default button when the menu-button slot is provided', async () => {
+      window.innerWidth = 1023
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1023)
+
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal', isMenuOpen: false },
+        slots: {
+          'menu-button': `
+            <template #menu-button="{ isOpen, toggle }">
+              <button id="custom-menu" :data-is-open="isOpen" @click="toggle">menu</button>
+            </template>
+          `
+        }
+      })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('#custom-menu').exists()).toBe(true)
+      expect(wrapper.findComponent(FzIconButton).exists()).toBe(false)
+    })
+
+    it('should expose isOpen and toggle in the slot scope', async () => {
+      window.innerWidth = 1023
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1023)
+
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal', isMenuOpen: true },
+        slots: {
+          'menu-button': `
+            <template #menu-button="{ isOpen, toggle }">
+              <button id="custom-menu" :data-is-open="isOpen" @click="toggle">menu</button>
+            </template>
+          `
+        }
+      })
+      await wrapper.vm.$nextTick()
+      const customButton = wrapper.find('#custom-menu')
+      expect(customButton.attributes('data-is-open')).toBe('true')
+
+      await customButton.trigger('click')
+      const updates = wrapper.emitted('update:isMenuOpen')
+      expect(updates).toBeTruthy()
+      expect(updates![0]).toEqual([false])
+    })
+  })
+
+  describe('mobile slot rendering (no XOR)', () => {
+    it('should render both notifications and user-menu slots on mobile when both are filled', async () => {
+      window.innerWidth = 1023
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1023)
+
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal' },
+        slots: {
+          notifications: '<div id="notification"></div>',
+          'user-menu': '<div id="avatar"></div>'
+        }
+      })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('#notification').exists()).toBe(true)
+      expect(wrapper.find('#avatar').exists()).toBe(true)
+    })
+
+    it('should render only notifications on mobile when user-menu is empty', async () => {
+      window.innerWidth = 1023
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1023)
+
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'horizontal' },
+        slots: {
+          notifications: '<div id="notification"></div>'
+        }
+      })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('#notification').exists()).toBe(true)
+      expect(wrapper.find('#avatar').exists()).toBe(false)
+    })
+
+    it('should render only user-menu on mobile when notifications is empty', async () => {
+      window.innerWidth = 1023
+      vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1023)
+
+      wrapper = mount(FzNavbar, {
+        props: { variant: 'vertical' },
+        slots: {
+          'user-menu': '<div id="avatar"></div>'
+        }
+      })
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('#avatar').exists()).toBe(true)
+      expect(wrapper.find('#notification').exists()).toBe(false)
+    })
+  })
+
+  describe('breakpoints prop deprecation warning', () => {
+    it('should emit a console.warn in dev when the deprecated `breakpoints` prop is used', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      mount(FzNavbar, {
+        props: {
+          variant: 'horizontal',
+          breakpoints: { lg: '1200px' }
+        }
+      })
+
+      expect(warnSpy).toHaveBeenCalled()
+      expect(warnSpy.mock.calls[0][0]).toMatch(/breakpoints.*deprecated/i)
+
+      warnSpy.mockRestore()
+    })
+
+    it('should not warn when the deprecated prop is not used', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      mount(FzNavbar, {
+        props: { variant: 'horizontal' }
+      })
+
+      expect(warnSpy).not.toHaveBeenCalled()
+      warnSpy.mockRestore()
     })
   })
 })

--- a/packages/navbar/src/__tests__/__snapshots__/FzNavbar.spec.ts.snap
+++ b/packages/navbar/src/__tests__/__snapshots__/FzNavbar.spec.ts.snap
@@ -1,24 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzNavbar > Snapshots > should match snapshot - default state 1`] = `
-"<header class="z-10 flex p-12 shadow h-56 w-full">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-56 w-full">
   <div class="mr-32"></div>
-  <div class="flex gap-4 flex-row"></div>
-  <div class="flex gap-16 ml-auto flex-row"></div>
+  <div class="flex items-center gap-4 flex-row"></div>
+  <div class="flex items-center gap-16 ml-auto flex-row"></div>
 </header>"
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - horizontal layout large screen 1`] = `
-"<header class="z-10 flex p-12 shadow h-56 w-full">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-56 w-full">
   <div class="mr-32">
     <div id="brandlogo" class="desktop"></div>
   </div>
-  <div class="flex gap-4 flex-row">
+  <div class="flex items-center gap-4 flex-row">
     <div class="link">one</div>
     <div class="link">two</div>
     <div class="link">three</div>
   </div>
-  <div class="flex gap-16 ml-auto flex-row">
+  <div class="flex items-center gap-16 ml-auto flex-row">
     <div id="notification"></div>
     <div id="avatar"></div>
   </div>
@@ -26,16 +26,16 @@ exports[`FzNavbar > Snapshots > should match snapshot - horizontal layout large 
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - horizontal layout small screen 1`] = `
-"<header class="z-10 flex p-12 shadow h-56 w-full">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-56 w-full">
   <div class="mr-32">
     <div id="brandlogo" class="desktop"></div>
   </div>
-  <div class="flex gap-4 flex-row">
+  <div class="flex items-center gap-4 flex-row">
     <div class="link">one</div>
     <div class="link">two</div>
     <div class="link">three</div>
   </div>
-  <div class="flex gap-16 ml-auto flex-row">
+  <div class="flex items-center gap-16 ml-auto flex-row">
     <div id="notification"></div>
     <div id="avatar"></div>
   </div>
@@ -43,16 +43,16 @@ exports[`FzNavbar > Snapshots > should match snapshot - horizontal layout small 
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - vertical layout large screen 1`] = `
-"<header class="z-10 flex p-12 shadow h-full w-56 flex-col">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-full w-56 flex-col">
   <div class="mb-32">
     <div id="brandlogo" class="desktop"></div>
   </div>
-  <div class="flex gap-4 flex-col">
+  <div class="flex items-center gap-4 flex-col">
     <div class="link">one</div>
     <div class="link">two</div>
     <div class="link">three</div>
   </div>
-  <div class="flex gap-16 mt-auto flex-col">
+  <div class="flex items-center gap-16 mt-auto flex-col">
     <div id="notification"></div>
     <div id="avatar"></div>
   </div>
@@ -60,16 +60,16 @@ exports[`FzNavbar > Snapshots > should match snapshot - vertical layout large sc
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - vertical layout small screen 1`] = `
-"<header class="z-10 flex p-12 shadow h-full w-56 flex-col">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-full w-56 flex-col">
   <div class="mb-32">
     <div id="brandlogo" class="desktop"></div>
   </div>
-  <div class="flex gap-4 flex-col">
+  <div class="flex items-center gap-4 flex-col">
     <div class="link">one</div>
     <div class="link">two</div>
     <div class="link">three</div>
   </div>
-  <div class="flex gap-16 mt-auto flex-col">
+  <div class="flex items-center gap-16 mt-auto flex-col">
     <div id="notification"></div>
     <div id="avatar"></div>
   </div>
@@ -77,16 +77,16 @@ exports[`FzNavbar > Snapshots > should match snapshot - vertical layout small sc
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - with menu open 1`] = `
-"<header class="z-10 flex p-12 shadow h-56 w-full">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-56 w-full">
   <div class="mr-32">
     <div id="brandlogo" class="desktop"></div>
   </div>
-  <div class="flex gap-4 flex-row">
+  <div class="flex items-center gap-4 flex-row">
     <div class="link">one</div>
     <div class="link">two</div>
     <div class="link">three</div>
   </div>
-  <div class="flex gap-16 ml-auto flex-row">
+  <div class="flex items-center gap-16 ml-auto flex-row">
     <div id="notification"></div>
     <div id="avatar"></div>
   </div>

--- a/packages/navbar/src/types.ts
+++ b/packages/navbar/src/types.ts
@@ -2,23 +2,48 @@ import { Breakpoint } from '@fiscozen/style'
 
 export type FzNavbarVariant = 'horizontal' | 'vertical'
 
+export type FzNavbarPosition = 'static' | 'fixed' | 'sticky'
+
 interface FzNavbarProps {
   /**
    * The main direction of the navbar
    */
-  variant: FzNavbarVariant
+  variant?: FzNavbarVariant
   /**
-   * Whether the main navigation menu is open (mobile)
+   * Whether the main navigation menu is open (mobile). Supports v-model.
    */
   isMenuOpen?: boolean
   /**
-   * Override breakpoint for manage custom size inside navbar
+   * @deprecated Use `mobileBreakpoint` instead. When both are passed, `mobileBreakpoint` takes precedence.
+   *
+   * Override breakpoints for managing custom size inside the navbar.
    */
   breakpoints?: Partial<Record<Breakpoint, `${number}px`>>
+  /**
+   * Width (in pixels) at and above which the navbar renders its desktop layout.
+   * Below this value the compact mobile layout is used.
+   *
+   * Replaces the global mutation of `@fiscozen/style` breakpoints that consumers
+   * used to perform to align with their own desktop threshold.
+   */
+  mobileBreakpoint?: number | `${number}px`
+  /**
+   * CSS positioning strategy applied to the root `<header>`. Replaces the need
+   * for consumers to add `class="fixed top-0 left-0"` (or similar) on the call site.
+   */
+  position?: FzNavbarPosition
+  /**
+   * When `true`, the navbar adds `env(safe-area-inset-*)` to its top, left and right padding
+   * so it renders correctly on devices with a notch / dynamic island.
+   *
+   * Defaults to `false` to preserve current visual behavior for existing consumers.
+   */
+  respectSafeArea?: boolean
 }
 
 type FzNavbarEmits = {
   'fznavbar:menuButtonClick': []
+  'update:isMenuOpen': [value: boolean]
 }
 
 export type { FzNavbarProps, FzNavbarEmits }


### PR DESCRIPTION
## Summary

Additive modernization of `@fiscozen/navbar` to v0.2.0. **Zero required consumer changes** — frontoffice and backoffice keep working unmodified, and the `!important` overrides they apply today still win over the new defaults. Companion notes in [`LIB-1901-FzNavbar-minimal.md`](https://fiscozen.atlassian.net/browse/LIB-1901).

### New props (all opt-in, all defaults preserve current behavior)
- **`mobileBreakpoint`** (`number | \`${number}px\``) — replaces the global mutation of `@fiscozen/style`'s `breakpoints` object. Legacy `breakpoints` prop is deprecated (dev-mode `console.warn`).
- **`position`** (`'static' | 'fixed' | 'sticky'`) — replaces the `class="fixed top-0 left-0"` pattern at the call site.
- **`respectSafeArea`** (boolean, default `false`) — adds `env(safe-area-inset-*)` to padding for notched devices; honors the `--safe-area-inset-*` CSS-variable fallback used by Capacitor / Cordova apps.
- **v-model on `isMenuOpen`** — the existing prop + `fznavbar:menuButtonClick` event continue to work; consumers can opt in to `v-model:isMenuOpen` for cleaner two-way binding.
- **`#menu-button` slot** — scope `{ isOpen, toggle }` — lets consumers replace the default `FzIconButton` hamburger.

### CSS custom properties
Layout values exposed as variables on the root with defaults matching the previous Tailwind utility values: `--fz-navbar-padding`, `--fz-navbar-shadow`, `--fz-navbar-height`, `--fz-navbar-width`, `--fz-navbar-brand-gap`, `--fz-navbar-actions-gap`, `--fz-navbar-z-index`, `--fz-navbar-bg`. Override per-instance via inline `style` to slim the navbar without `!important` resets.

### Bug fixes
- **Mobile slot XOR** — both `#notifications` and `#user-menu` now render simultaneously on mobile when provided. The previous mutually-exclusive behavior at `FzNavbar.vue:65` was a hard-coded limitation.
- **Default alignment** — root header and inner navigation / actions flex containers now use `items-center`, so slot content with mixed heights (icon / button / avatar) sits visually centered. Frontoffice previously worked around this on mobile by adding `items-center` at the call site (`FzNavigation.vue:102`).

### Bootstrap interop
Root `<header>` carries `box-border`, `m-0`, `border-0` so the component renders identically with or without `tailwindcss-scoped-preflight` (`.twp`) scoping.

## Test plan

- [x] Unit tests — 68/68 green (48 prior + 20 new covering each addition)
- [x] Storybook play tests — 726/726 green (pre-push hook)
- [x] Build — `pnpm build` clean (`vue-tsc && vite build`)
- [x] `pnpm release:check:pending` — confirms only `@fiscozen/navbar` bumps (0.1.11 → 0.2.0 minor), no unintended cascade
- [ ] Chromatic — visual diff review (expect changes on new stories only; `Horizontal`, `Vertical`, `BootstrapInterop` should be near-identical baseline)
- [ ] Verify frontoffice still renders unchanged (linked DS workspace)
- [ ] Verify backoffice still renders unchanged (linked DS workspace)

## Storybook stories

Refactored to 6 focused stories (was 9) with proper `argTypes` so the autodocs controls panel actually drives the example via `v-bind="args"`:

| Story | Demonstrates |
|---|---|
| `Horizontal` | Default; all controls (variant, position, mobileBreakpoint, respectSafeArea) live here |
| `Vertical` | Sidebar variant |
| `Positioned` | `position` prop — toggle static/fixed/sticky in controls; scrollable page below |
| `Customized` | CSS custom property overrides + `respectSafeArea` |
| `MobileMenu` | v-model on `isMenuOpen` + `#menu-button` slot, in forced mobile mode |
| `BootstrapInterop` | Smoke test inside a `.twp` wrapper |

Dropped: `CustomBreakpoints` (used the deprecated `breakpoints` prop), `MobileBreakpoint` (now a control), `SafeArea`/`CSSVariableOverrides` (merged into `Customized`), `FixedPosition` (renamed to `Positioned`), `VModelMenu`/`CustomMenuButton` (merged into `MobileMenu`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)