### PR TITLE
fix(FzSelect): allow space in filterable input (HD-23713) and align DS baselines

### DIFF
--- a/.changeset/select-hd-23713-space-and-ds-baselines.md
+++ b/.changeset/select-hd-23713-space-and-ds-baselines.md
@@ -1,0 +1,10 @@
+---
+"@fiscozen/select": patch
+---
+
+Fix HD-23713 (space-strip in filterable mode) and align DS baselines
+
+  - 🚨 HD-23713: in `filterable` mode the search input now accepts space characters. `event.preventDefault()` in `handleOptionsKeydown` for the `Enter`/`Space` cases is now guarded by the `focusedIndex >= 0` check, so when the input is focused with no option highlighted the Space keystroke is no longer swallowed.
+  - Pair `border-1` with `border-solid` on the opener button so the 1px border renders correctly in host environments without a global Tailwind preflight.
+  - Apply `text-core-black` on the floating root so descendant text inherits the design's neutral colour instead of an ambient host colour.
+  - Align `FzSelectLabel` styling to `FzInput`: `font-normal text-base mb-0` (identical for `frontoffice` and `backoffice`), preserving the existing `text-grey-500` / `text-grey-300` disabled-readonly mapping.

--- a/apps/storybook/src/stories/form/Select.stories.ts
+++ b/apps/storybook/src/stories/form/Select.stories.ts
@@ -708,6 +708,71 @@ export const FilterableSelect: SelectStory = {
   }
 }
 
+export const HD23713SpaceInFilter: SelectStory = {
+  render: (args) => ({
+    components: { FzSelect },
+    setup() {
+      const model = ref<string>()
+      return { args, model }
+    },
+    template: `<div class="p-8 relative" style='width:300px'>
+                  <FzSelect v-bind="args" v-model="model" />
+                </div>`
+  }),
+  args: {
+    label: 'Search',
+    placeholder: 'Type to search...',
+    filterable: true,
+    options: [
+      { value: '1', label: 'foo' },
+      { value: '2', label: 'bar' },
+      { value: '3', label: 'baz' }
+    ]
+  },
+  decorators: [
+    () => ({
+      template: `<div style="width:100vw;height:100vh;"><story/></div>`
+    })
+  ],
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step(
+      "HD-23713: Space keydown is not preventDefault'ed when no option is focused",
+      async () => {
+        const opener = canvas.getByRole('button', { name: /search/i })
+        await userEvent.click(opener)
+
+        await waitFor(
+          () => {
+            const input = document.querySelector('input[type="text"]') as HTMLInputElement
+            expect(input).toBeInTheDocument()
+            expect(input).toBeVisible()
+          },
+          { timeout: 1000 }
+        )
+
+        const input = document.querySelector('input[type="text"]') as HTMLInputElement
+        input.focus()
+
+        // Pre-fix: handleOptionsKeydown called event.preventDefault() unconditionally
+        // on Space, so the browser never inserted the space into the input.
+        // Post-fix: the preventDefault is guarded by focusedIndex >= 0, so with
+        // no option focused the event flows through to the browser untouched.
+        const spaceEvent = new KeyboardEvent('keydown', {
+          key: ' ',
+          bubbles: true,
+          cancelable: true
+        })
+        input.dispatchEvent(spaceEvent)
+
+        await expect(spaceEvent.defaultPrevented).toBe(false)
+        await expect(opener).toHaveAttribute('aria-expanded', 'true')
+      }
+    )
+  }
+}
+
 export const RemoteLoading: SelectStory = {
   render: (args) => ({
     components: { FzSelect },

--- a/packages/select/src/FzSelect.vue
+++ b/packages/select/src/FzSelect.vue
@@ -702,8 +702,8 @@ const handleOptionsKeydown = (event: KeyboardEvent) => {
 
     case "Enter":
     case " ":
-      event.preventDefault();
       if (focusedIndex.value >= 0 && focusedIndex.value < selectable.length) {
+        event.preventDefault();
         handleSelect(selectable[focusedIndex.value]);
       }
       break;
@@ -1126,7 +1126,7 @@ defineExpose({
     :position="position ?? 'auto-vertical-start'"
     :teleport="teleport"
     :useViewport="true"
-    class="flex flex-col gap-8 overflow-visible"
+    class="flex flex-col gap-8 overflow-visible text-core-black"
     contentClass="z-70"
     @fzfloating:setPosition="calculateMaxHeight"
   >

--- a/packages/select/src/__tests__/FzSelect.spec.ts
+++ b/packages/select/src/__tests__/FzSelect.spec.ts
@@ -3096,4 +3096,156 @@ describe("FzSelect", () => {
       });
     });
   });
+
+  describe("HD-23713: Space in filterable mode", () => {
+    it("does not preventDefault Space when filterable input is focused with no option focused", async () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: "",
+          filterable: true,
+          options: [
+            { value: "1", label: "foo bar" },
+            { value: "2", label: "foo baz" },
+          ],
+        },
+        attachTo: document.body,
+      });
+
+      const button = wrapper.find('button[test-id="fzselect-opener"]');
+      await button.trigger("click");
+      await wrapper.vm.$nextTick();
+
+      // In filterable mode, focusedIndex is -1 when input is focused
+      expect(wrapper.vm.focusedIndex).toBe(-1);
+
+      const input = wrapper.find('input[type="text"]')
+        .element as HTMLInputElement;
+      const spaceEvent = new KeyboardEvent("keydown", {
+        key: " ",
+        bubbles: true,
+        cancelable: true,
+      });
+      input.dispatchEvent(spaceEvent);
+      await wrapper.vm.$nextTick();
+
+      // The fix: preventDefault must NOT be called when focusedIndex < 0,
+      // so the browser is free to insert the space into the input.
+      expect(spaceEvent.defaultPrevented).toBe(false);
+      // Dropdown remains open, no selection emitted
+      expect(wrapper.vm.isOpen).toBe(true);
+      expect(wrapper.emitted("update:modelValue")).toBeFalsy();
+
+      wrapper.unmount();
+    });
+
+    it("still selects focused option on Space in filterable mode after ArrowDown", async () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: "",
+          filterable: true,
+          options: [
+            { value: "1", label: "foo bar" },
+            { value: "2", label: "foo baz" },
+          ],
+        },
+        attachTo: document.body,
+      });
+
+      const button = wrapper.find('button[test-id="fzselect-opener"]');
+      await button.trigger("click");
+      await wrapper.vm.$nextTick();
+
+      const input = wrapper.find('input[type="text"]');
+      await input.trigger("keydown", { key: "ArrowDown" });
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.focusedIndex).toBe(0);
+
+      const spaceEvent = new KeyboardEvent("keydown", {
+        key: " ",
+        bubbles: true,
+        cancelable: true,
+      });
+      (input.element as HTMLInputElement).dispatchEvent(spaceEvent);
+      await wrapper.vm.$nextTick();
+
+      // With an option focused, preventDefault fires and selection happens
+      expect(spaceEvent.defaultPrevented).toBe(true);
+      expect(wrapper.emitted("update:modelValue")).toBeTruthy();
+      expect(wrapper.emitted("update:modelValue")![0]).toEqual(["1"]);
+
+      wrapper.unmount();
+    });
+  });
+
+  describe("DS-GAP baselines", () => {
+    it("applies text-core-black on the floating container", () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: "",
+          options: [
+            { value: "1", label: "Option 1" },
+            { value: "2", label: "Option 2" },
+          ],
+        },
+      });
+      expect(wrapper.html()).toContain("text-core-black");
+      wrapper.unmount();
+    });
+
+    it("applies font-normal text-base mb-0 on the label, identical in both environments", () => {
+      const fo = mount(FzSelect, {
+        props: {
+          modelValue: "",
+          label: "My label",
+          environment: "frontoffice",
+          options: [
+            { value: "1", label: "Option 1" },
+            { value: "2", label: "Option 2" },
+          ],
+        },
+      });
+      const foLabel = fo.find("label");
+      expect(foLabel.exists()).toBe(true);
+      expect(foLabel.classes()).toEqual(
+        expect.arrayContaining([
+          "font-normal",
+          "text-base",
+          "mb-0",
+          "text-grey-500",
+        ]),
+      );
+      fo.unmount();
+
+      const bo = mount(FzSelect, {
+        props: {
+          modelValue: "",
+          label: "My label",
+          environment: "backoffice",
+          options: [
+            { value: "1", label: "Option 1" },
+            { value: "2", label: "Option 2" },
+          ],
+        },
+      });
+      const boLabel = bo.find("label");
+      expect(boLabel.classes()).toEqual(foLabel.classes());
+      bo.unmount();
+    });
+
+    it("pairs border-1 with border-solid on the opener", () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: "",
+          options: [
+            { value: "1", label: "Option 1" },
+            { value: "2", label: "Option 2" },
+          ],
+        },
+      });
+      const button = wrapper.find('button[test-id="fzselect-opener"]');
+      expect(button.classes()).toContain("border-1");
+      expect(button.classes()).toContain("border-solid");
+      wrapper.unmount();
+    });
+  });
 });

--- a/packages/select/src/components/FzSelectButton.vue
+++ b/packages/select/src/components/FzSelectButton.vue
@@ -58,7 +58,7 @@ const showNormalPlaceholder = computed(() => {
 });
 
 const staticPickerClass =
-  "flex justify-between items-center px-10 bg-core-white rounded border-1 border-grey-200 w-full gap-8 text-left relative outline-none focus:outline-none";
+  "flex justify-between items-center px-10 bg-core-white rounded border-1 border-solid border-grey-200 w-full gap-8 text-left relative outline-none focus:outline-none";
 
 const environmentPickerClasses = {
   backoffice: "h-32 text-base",

--- a/packages/select/src/components/FzSelectLabel.vue
+++ b/packages/select/src/components/FzSelectLabel.vue
@@ -12,10 +12,10 @@ import type { FzSelectLabelProps } from "./types";
 
 const props = defineProps<FzSelectLabelProps>();
 
-const baseTextClasses = "text-base leading-5";
+const baseTextClasses = "font-normal text-base";
 
 const labelClass = computed(() => {
-  const baseClasses = [baseTextClasses];
+  const baseClasses = [baseTextClasses, "mb-0"];
 
   switch (true) {
     case props.disabled:


### PR DESCRIPTION
[Chromatic](https://fix-fz-select--65e5d7f524a5908cb4d75bd7.chromatic.com/?path=/story/form-fzselect--select)

## Cosa

🚨 Fix [HD-23713](https://fiscozen.atlassian.net/browse/HD-23713): il carattere Space nell'input filterable di `<FzSelect>` era strippato (es. `"foo bar"` → `"foobar"`) perché `event.preventDefault()` in `handleOptionsKeydown` veniva chiamato fuori dall'if-guard `focusedIndex >= 0`. Spostato dentro l'if-guard.

Allineamento DS-GAP intrinseci: `text-core-black` sulla root, pair `border-1 border-solid` sul button opener, `FzSelectLabel` allineata a `FzInput` (`font-normal text-base mb-0`, identica per BO e FO, nessuna prop `environment` aggiunta).

## Cosa fare in app dopo il rilascio di `@fiscozen/select@3.1.4`

1. Bump `@fiscozen/select` `^3.1.3` → `^3.1.4` in `backoffice/package.json` e `frontoffice/package.json` (caret pin).
2. In `vue_common/src/scss/fz-ds/_fz-select.scss` rimuovere:
   - L9 `text-core-black` su `.fz-select`
   - L17-19 Pattern A `.fz-select .border-1 { border-style: solid }`
   - L28 `label { margin-bottom: 0 !important }`
3. **NON rimuovere** L39-41 `body:has(...) { overflow: hidden }` — il body overflow lock NON è stato portato upstream (decisione di scope: side-effect globale, non intrinseco al DS).
4. Smoke browser HD-23713: aprire `subscription/SubscriptionWizardStep3.vue` (campo "Cerca commercialista"), aprire dropdown, digitare una query con spazio → il filtro deve mostrare i risultati con lo spazio preservato.

[HD-23713]: https://fiscozen.atlassian.net/browse/HD-23713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ