### PR TITLE
fix(FzTextarea): align label baselines with FzInput / FzSelect

### DIFF
--- a/.changeset/textarea-align-label-baselines.md
+++ b/.changeset/textarea-align-label-baselines.md
@@ -1,0 +1,18 @@
+---
+"@fiscozen/textarea": minor
+---
+
+Align label baselines with FzInput / FzSelect
+
+  - The `<label>` now renders as `font-normal text-base mb-0`, with
+    `text-grey-500` (default) and `text-grey-300` (disabled, readonly).
+    Same baseline as `FzInput` and `FzSelect` — consumers no longer need
+    a per-component-specific theme for the label.
+  - Visual change: label color moves from `text-core-black` (near black)
+    to `text-grey-500` (medium grey), and the `mb-0` baseline removes
+    any residual margin-bottom added by host CSS resets. Font-size stays
+    `text-base` in every context (the previous backoffice convention
+    based on the consumer `.fz-textarea-full` SCSS marker rendered the
+    label as `text-sm` — that override is now intentionally dropped).
+
+No API changes.

--- a/packages/textarea/src/FzTextarea.vue
+++ b/packages/textarea/src/FzTextarea.vue
@@ -180,8 +180,8 @@ if (props.autoHeight) {
 }
 
 const labelClasses = computed(() => [
-  'font-normal text-base',
-  props.disabled || props.readonly ? 'text-grey-300' : 'text-core-black'
+  'font-normal text-base mb-0',
+  props.disabled || props.readonly ? 'text-grey-300' : 'text-grey-500'
 ])
 
 const mapResizeToClass = {

--- a/packages/textarea/src/__tests__/FzTextarea.spec.ts
+++ b/packages/textarea/src/__tests__/FzTextarea.spec.ts
@@ -839,7 +839,7 @@ describe('FzTextarea', () => {
       expect(wrapper.find('textarea').classes()).toContain('pr-[38px]')
     })
 
-    it('should apply font-normal text-base to label', () => {
+    it('should apply font-normal text-base mb-0 to label (aligned with FzInput/FzSelect)', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
@@ -848,7 +848,8 @@ describe('FzTextarea', () => {
       const label = wrapper.find('label')
       expect(label.classes()).toContain('font-normal')
       expect(label.classes()).toContain('text-base')
-      expect(label.classes()).toContain('text-core-black')
+      expect(label.classes()).toContain('mb-0')
+      expect(label.classes()).toContain('text-grey-500')
     })
 
     it('should apply grey label when disabled or readonly', () => {
@@ -856,13 +857,13 @@ describe('FzTextarea', () => {
         props: { label: 'Test Label', disabled: true },
       })
       expect(disabledWrapper.find('label').classes()).toContain('text-grey-300')
-      expect(disabledWrapper.find('label').classes()).not.toContain('text-core-black')
+      expect(disabledWrapper.find('label').classes()).not.toContain('text-grey-500')
 
       const readonlyWrapper = mount(FzTextarea, {
         props: { label: 'Test Label', readonly: true },
       })
       expect(readonlyWrapper.find('label').classes()).toContain('text-grey-300')
-      expect(readonlyWrapper.find('label').classes()).not.toContain('text-core-black')
+      expect(readonlyWrapper.find('label').classes()).not.toContain('text-grey-500')
     })
 
     it('should apply font-normal text-base to help text', () => {
@@ -1356,4 +1357,5 @@ describe('FzTextarea', () => {
       })
     })
   })
+
 })

--- a/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
+++ b/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzTextarea > Snapshots > should match snapshot - autoHeight 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-auto-height-label" class="font-normal text-base text-core-black" for="snapshot-auto-height">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-auto-height-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-auto-height">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-auto-height" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize-x" rows="2" aria-required="false" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-auto-height-label" style="height: 2px; overflow-y: hidden;"></textarea>
     <!--v-if-->
   </div>
@@ -10,7 +10,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - autoHeight 1`] = `
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - default state 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-default-label" class="font-normal text-base text-core-black" for="snapshot-default">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-default-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-default">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-default" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize" rows="2" aria-required="false" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-default-label"></textarea>
     <!--v-if-->
   </div>
@@ -19,7 +19,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - default state 1`] = `
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - disabled state 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full cursor-not-allowed"><label id="snapshot-disabled-label" class="font-normal text-base text-grey-300" for="snapshot-disabled">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full cursor-not-allowed"><label id="snapshot-disabled-label" class="font-normal text-base mb-0 text-grey-300" for="snapshot-disabled">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-disabled" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] bg-grey-100 border-grey-100 text-grey-300 cursor-not-allowed resize" disabled="" rows="2" aria-required="false" aria-invalid="false" aria-disabled="true" aria-labelledby="snapshot-disabled-label"></textarea>
     <!--v-if-->
   </div>
@@ -28,7 +28,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - disabled state 1`] = `
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - error state 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-error-label" class="font-normal text-base text-core-black" for="snapshot-error">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-error-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-error">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-error" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-semantic-error-200 focus:border-semantic-error-300 bg-core-white text-core-black cursor-text resize" rows="2" aria-required="false" aria-invalid="true" aria-disabled="false" aria-labelledby="snapshot-error-label" aria-describedby="snapshot-error-error"></textarea>
     <!--v-if-->
   </div>
@@ -46,7 +46,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - error state 1`] = `
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - error with disabled 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full cursor-not-allowed"><label id="snapshot-error-disabled-label" class="font-normal text-base text-grey-300" for="snapshot-error-disabled">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full cursor-not-allowed"><label id="snapshot-error-disabled-label" class="font-normal text-base mb-0 text-grey-300" for="snapshot-error-disabled">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-error-disabled" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-semantic-error-200 focus:border-semantic-error-300 bg-core-white text-core-black cursor-text resize" disabled="" rows="2" aria-required="false" aria-invalid="true" aria-disabled="true" aria-labelledby="snapshot-error-disabled-label" aria-describedby="snapshot-error-disabled-error"></textarea>
     <!--v-if-->
   </div>
@@ -64,7 +64,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - error with disabled 1`
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - help with disabled 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full cursor-not-allowed"><label id="snapshot-help-disabled-label" class="font-normal text-base text-grey-300" for="snapshot-help-disabled">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full cursor-not-allowed"><label id="snapshot-help-disabled-label" class="font-normal text-base mb-0 text-grey-300" for="snapshot-help-disabled">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-help-disabled" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] bg-grey-100 border-grey-100 text-grey-300 cursor-not-allowed resize" disabled="" rows="2" aria-required="false" aria-invalid="false" aria-disabled="true" aria-labelledby="snapshot-help-disabled-label" aria-describedby="snapshot-help-disabled-help"></textarea>
     <!--v-if-->
   </div><span id="snapshot-help-disabled-help" class="font-normal text-base text-grey-300">Help text</span>
@@ -72,7 +72,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - help with disabled 1`]
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - large size 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-lg-label" class="font-normal text-base text-core-black" for="snapshot-lg">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-lg-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-lg">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-lg" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize" rows="2" aria-required="false" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-lg-label"></textarea>
     <!--v-if-->
   </div>
@@ -81,7 +81,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - large size 1`] = `
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - readonly state 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full cursor-not-allowed"><label id="snapshot-readonly-label" class="font-normal text-base text-grey-300" for="snapshot-readonly">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full cursor-not-allowed"><label id="snapshot-readonly-label" class="font-normal text-base mb-0 text-grey-300" for="snapshot-readonly">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-readonly" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] bg-grey-100 border-grey-100 text-grey-300 cursor-not-allowed resize" rows="2" readonly="" aria-required="false" aria-invalid="false" aria-disabled="true" aria-labelledby="snapshot-readonly-label"></textarea>
     <!--v-if-->
   </div>
@@ -90,7 +90,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - readonly state 1`] = `
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - required with help 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-required-help-label" class="font-normal text-base text-core-black" for="snapshot-required-help">Test Label *</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-required-help-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-required-help">Test Label *</label>
   <div class="relative w-full"><textarea id="snapshot-required-help" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize" required="" rows="2" aria-required="true" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-required-help-label" aria-describedby="snapshot-required-help-help"></textarea>
     <!--v-if-->
   </div><span id="snapshot-required-help-help" class="font-normal text-base text-grey-500">Mandatory field</span>
@@ -98,7 +98,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - required with help 1`]
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - small size 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-sm-label" class="font-normal text-base text-core-black" for="snapshot-sm">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-sm-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-sm">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-sm" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize" rows="2" aria-required="false" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-sm-label"></textarea>
     <!--v-if-->
   </div>
@@ -107,20 +107,20 @@ exports[`FzTextarea > Snapshots > should match snapshot - small size 1`] = `
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - valid state 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-valid-label" class="font-normal text-base text-core-black" for="snapshot-valid">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-valid-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-valid">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-valid" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize pr-[38px]" rows="2" aria-required="false" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-valid-label"></textarea><span role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px] text-semantic-success absolute right-10 top-10" aria-hidden="true"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"></path></svg></span></div>
   <!--v-if-->
 </div>"
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - with all props and slots 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-all-label" class="font-normal text-base text-core-black" for="snapshot-all">Test Label *</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-all-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-all">Test Label *</label>
   <div class="relative w-full"><textarea id="snapshot-all" name="test-name" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize-y pr-[38px]" placeholder="Enter text" required="" rows="5" cols="50" minlength="10" maxlength="100" aria-required="true" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-all-label" aria-describedby="snapshot-all-help"></textarea><span role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px] text-semantic-success absolute right-10 top-10" aria-hidden="true"><svg class="svg-inline--fa fa-check fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M441 103c9.4 9.4 9.4 24.6 0 33.9L177 401c-9.4 9.4-24.6 9.4-33.9 0L7 265c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l119 119L407 103c9.4-9.4 24.6-9.4 33.9 0z"></path></svg></span></div><span id="snapshot-all-help" class="font-normal text-base text-grey-500">Help text</span>
 </div>"
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - with help text slot 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-help-label" class="font-normal text-base text-core-black" for="snapshot-help">Test Label</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-help-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-help">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-help" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize" rows="2" aria-required="false" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-help-label" aria-describedby="snapshot-help-help"></textarea>
     <!--v-if-->
   </div><span id="snapshot-help-help" class="font-normal text-base text-grey-500">This is helpful text</span>
@@ -128,7 +128,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - with help text slot 1`
 `;
 
 exports[`FzTextarea > Snapshots > should match snapshot - with required 1`] = `
-"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-required-label" class="font-normal text-base text-core-black" for="snapshot-required">Test Label *</label>
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-required-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-required">Test Label *</label>
   <div class="relative w-full"><textarea id="snapshot-required" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize" required="" rows="2" aria-required="true" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-required-label"></textarea>
     <!--v-if-->
   </div>


### PR DESCRIPTION
[Chromatic](https://fix-textarea--65e5d7f524a5908cb4d75bd7.chromatic.com/?path=/story/form-fztextarea--default)

## Cosa

Il `<label>` di `FzTextarea` è ora identico a quello di `FzInput` e `FzSelect`:

- Classi: `font-normal text-base mb-0`
- Color default: `text-grey-500`
- Color disabled/readonly: `text-grey-300`

Niente più theme per-componente sulla label, niente più prop `environment` solo per la label (sarebbe stata API morta dato che ora il pattern è uniforme).

**Cambio visivo per i consumer attuali:**
- Color label: da `text-core-black` (nero pieno) a `text-grey-500` (grigio medio).
- `mb-0` baseline azzera il margin-bottom che alcuni host CSS reset aggiungono di default.
- Font-size resta `text-base` in ogni contesto. La convenzione BO che applicava `text-sm` tramite il marker shim consumer `.fz-textarea-full` è intenzionalmente dropped — la label torna a 16px allineata al resto della famiglia DS form.

Nessuna API cambia (la prop pubblica `environment` non viene aggiunta, e nulla viene rimosso).

## Cosa fare in app dopo il rilascio di `@fiscozen/textarea@3.1.0`

1. Bump `@fiscozen/textarea` in `backoffice/package.json` (`^3.0.1` → `^3.1.0`) e `frontoffice/package.json` (`3.0.0` pin esatto → `^3.1.0`, caret pin).
2. Droppare interamente `vue_common/src/scss/fz-ds/_fz-textarea.scss`. Rimuovere l'`@use 'fz-textarea'` da `_main.scss`.
3. Sui 29 file BO con `class="fz-textarea-full"` (lista in `ds-roadmap/04-fz-textarea.md`), rimuovere il marker dalla `class` di `<FzTextarea>`. Il container e il textarea sono già `w-full` di default — nessun behavior dimensionale cambia.
4. Smoke browser su qualche pagina FzTextarea BO (es. `ApprovalRejectModal`, `TaskCreate`, `WelfareCertification`, `EstateForm`, `ServiceRefundingModal`) e FO: confermare che la label è grigio medio (#6e777e), `text-base`, senza margin sotto. Il body textarea e gli stati di error/disabled/required restano invariati.