### PR TITLE
feat(FzCardList): re-export FzActionProps and FzBadgeTone from the package entry

### DIFF
--- a/.changeset/card-list-reexport-types.md
+++ b/.changeset/card-list-reexport-types.md
@@ -1,0 +1,10 @@
+---
+"@fiscozen/card-list": patch
+---
+
+Re-export `FzActionProps` and `FzBadgeTone` from the package entry
+
+  - `@fiscozen/card-list` now re-exports `FzActionProps` (originally from `@fiscozen/action`) and `FzBadgeTone` (originally from `@fiscozen/badge`). Both types are part of the public surface of `FzCardList` (used in `FzCardListItemProps.actions` and `FzCardListItemProps.badge`).
+  - Consumers can now import everything from the single package entry, without adding `@fiscozen/action` or `@fiscozen/badge` as direct dependencies just to obtain typings.
+
+No behavior change.

--- a/packages/card-list/src/__tests__/reexports.spec.ts
+++ b/packages/card-list/src/__tests__/reexports.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+// Importing from "..", which resolves to ../index.ts — the same barrel
+// consumers reach via `@fiscozen/card-list`. If FzActionProps or
+// FzBadgeTone disappear from that barrel, `vue-tsc --noEmit` (run as
+// part of the build) fails on this file.
+import {
+  FzCardList,
+  FzCardListItem,
+  type FzActionProps,
+  type FzBadgeTone,
+  type FzCardListItemProps,
+} from "..";
+
+describe("Public type re-exports", () => {
+  it("exposes FzActionProps from @fiscozen/card-list", () => {
+    const action: FzActionProps = {
+      type: "action",
+      variant: "textLeft",
+      label: "Open",
+    };
+    expect(action.label).toBe("Open");
+  });
+
+  it("exposes FzBadgeTone from @fiscozen/card-list", () => {
+    const tone: FzBadgeTone = "success";
+    expect(tone).toBe("success");
+  });
+
+  it("exposes the existing FzCardListItemProps via re-export of types.ts", () => {
+    const item: FzCardListItemProps = {
+      title: "Sample",
+    };
+    expect(item.title).toBe("Sample");
+  });
+
+  it("exposes the component default exports", () => {
+    expect(FzCardList).toBeDefined();
+    expect(FzCardListItem).toBeDefined();
+  });
+});

--- a/packages/card-list/src/index.ts
+++ b/packages/card-list/src/index.ts
@@ -1,3 +1,8 @@
 export { default as FzCardList } from "./FzCardList.vue";
 export { default as FzCardListItem } from "./FzCardListItem.vue";
 export type * from "./types";
+
+// Re-export types used in the public surface of FzCardList so consumers
+// don't need to depend on @fiscozen/action or @fiscozen/badge just for typing.
+export type { FzActionProps } from "@fiscozen/action";
+export type { FzBadgeTone } from "@fiscozen/badge";


### PR DESCRIPTION
## Cosa

`@fiscozen/card-list` ora re-esporta `FzActionProps` (originale `@fiscozen/action`) e `FzBadgeTone` (originale `@fiscozen/badge`) dal suo entry point. Entrambi i tipi sono parte della superficie pubblica di `FzCardList`:

- `FzActionProps` finisce in `FzCardListItemProps.actions` e nella firma di `fzaction:click`.
- `FzBadgeTone` finisce in `FzCardListItemProps.badge`.

Prima:

```ts
import { FzCardList, type FzCardListItem } from '@fiscozen/card-list'
import type { FzActionProps } from '@fiscozen/action'
import type { FzBadgeTone } from '@fiscozen/badge'
```

Dopo:

```ts
import {
  FzCardList,
  type FzCardListItem,
  type FzActionProps,
  type FzBadgeTone,
} from '@fiscozen/card-list'
```

Nessun cambio di behavior. I tipi originali rimangono dichiarati in `@fiscozen/action` / `@fiscozen/badge` (questo è solo un re-export).

## Cosa fare in app dopo il rilascio di `@fiscozen/card-list@1.0.4`

1. Bump `@fiscozen/card-list` da `^1.0.3` a `^1.0.4` in `frontoffice/package.json` (caret pin). Solo FO usa il pacchetto.
2. Cleanup import (opzionale, DX): nei 4 file FO che usano `<FzCardList>` con `actions`, accorpare l'import in un'unica riga da `@fiscozen/card-list`:
   - `frontoffice/src/components/customers/Customers.vue`
   - `frontoffice/src/components/messages/Messages.vue`
   - `frontoffice/src/components/providers/Providers.vue`
   - `frontoffice/src/components/documents/Documents.vue`