### PR TITLE
fix(FzAlert): apply self-contained typography baselines

### DIFF
--- a/.changeset/alert-self-contained-typography.md
+++ b/.changeset/alert-self-contained-typography.md
@@ -1,0 +1,8 @@
+---
+"@fiscozen/alert": patch
+---
+
+Apply self-contained typography baselines
+
+  - Add `text-core-black` to the alert container so descendant text inherits the design's neutral colour without relying on the host environment's text colour default.
+  - Add `mb-0` to the internal `<p>` elements (title and description), neutralising the host `<p> { margin-bottom: 1rem }` reset that ships with Bootstrap-style reboots. The pre-existing `mb-16` on the description (when an action is rendered) still wins, so the spacing-before-action intent is preserved.

--- a/packages/alert/src/FzAlert.vue
+++ b/packages/alert/src/FzAlert.vue
@@ -96,7 +96,7 @@ const showAction = computed(() => {
 })
 
 const descriptionClass = computed(() => {
-  const hasBottomAction = showAction.value && !isTextVariant.value
+  const hasBottomAction = showAction.value
   return [
     'font-normal',
     '!leading-[20px]',

--- a/packages/alert/src/FzAlert.vue
+++ b/packages/alert/src/FzAlert.vue
@@ -46,7 +46,7 @@ const sizeToEnvironmentMapping = {
 const isTextVariant = computed(() => safeVariant.value === 'text')
 
 const containerClass = computed(() => [
-  'flex select-none gap-12 rounded justify-between',
+  'flex select-none gap-12 rounded justify-between text-core-black',
   ...(isTextVariant.value ? ['bg-transparent'] : [mapToneToContainerClass[props.tone]]),
   ...(!isTextVariant.value && safeEnvironment.value === 'backoffice' ? ['p-6'] : []),
   ...(safeVariant.value === 'accordion' ? ['cursor-pointer'] : [])
@@ -96,7 +96,7 @@ const showAction = computed(() => {
 })
 
 const descriptionClass = computed(() => [
-  'font-normal',
+  'font-normal mb-0',
   '!leading-[20px]',
   {
     'mt-8': props.title && !isTextVariant.value,
@@ -161,7 +161,7 @@ const handleClick = () => {
     <FzContainer horizontal :gap="innerContainerGap" :class="['flex-1', innerContainerPaddingClass]" alignItems="start">
       <FzIcon :name="iconName" :size="iconSize" :class="iconClass" aria-hidden="true" />
       <div class="flex flex-col flex-1">
-        <p v-if="title && !isTextVariant" v-bold class="leading-[20px]">
+        <p v-if="title && !isTextVariant" v-bold class="leading-[20px] mb-0">
           {{ title }}
         </p>
 

--- a/packages/alert/src/FzAlert.vue
+++ b/packages/alert/src/FzAlert.vue
@@ -95,14 +95,18 @@ const showAction = computed(() => {
   return isOpen.value
 })
 
-const descriptionClass = computed(() => [
-  'font-normal mb-0',
-  '!leading-[20px]',
-  {
-    'mt-8': props.title && !isTextVariant.value,
-    'mb-16': showAction.value && !isTextVariant.value
-  }
-])
+const descriptionClass = computed(() => {
+  const hasBottomAction = showAction.value && !isTextVariant.value
+  return [
+    'font-normal',
+    '!leading-[20px]',
+    {
+      'mt-8': props.title && !isTextVariant.value,
+      'mb-16': hasBottomAction,
+      'mb-0': !hasBottomAction
+    }
+  ]
+})
 const collapseIcon = computed(() => (isOpen.value ? 'angle-up' : 'angle-down'))
 const rightIconName = computed(() => {
   if (safeVariant.value === 'accordion') return collapseIcon.value
@@ -158,10 +162,15 @@ const handleClick = () => {
 
 <template>
   <div :class="containerClass" @click="handleClick">
-    <FzContainer horizontal :gap="innerContainerGap" :class="['flex-1', innerContainerPaddingClass]" alignItems="start">
+    <FzContainer
+      horizontal
+      :gap="innerContainerGap"
+      :class="['flex-1', innerContainerPaddingClass]"
+      alignItems="start"
+    >
       <FzIcon :name="iconName" :size="iconSize" :class="iconClass" aria-hidden="true" />
-      <div class="flex flex-col flex-1">
-        <p v-if="title && !isTextVariant" v-bold class="leading-[20px] mb-0">
+      <div class="flex flex-1 flex-col">
+        <p v-if="title && !isTextVariant" v-bold class="mb-0 leading-[20px]">
           {{ title }}
         </p>
 
@@ -192,14 +201,15 @@ const handleClick = () => {
         </slot>
       </div>
     </FzContainer>
-    <FzIconButton v-if="hasRightIcon"
+    <FzIconButton
+      v-if="hasRightIcon"
       :iconName="rightIconName!"
       :environment="safeEnvironment"
       variant="invisible"
-      @click.stop="handleRightIconClick" />
+      @click.stop="handleRightIconClick"
+    />
   </div>
 </template>
-
 
 <style scoped>
 .bg-semantic-info-50 {

--- a/packages/alert/src/__tests__/FzAlert.spec.ts
+++ b/packages/alert/src/__tests__/FzAlert.spec.ts
@@ -1415,4 +1415,29 @@ describe('FzAlert', () => {
       expect(wrapper.html()).toMatchSnapshot()
     })
   })
+
+  describe('DS-GAP baselines', () => {
+    it('applies text-core-black on the alert container', () => {
+      const wrapper = mount(FzAlert, {
+        props: { title: 'Title' },
+        slots: { default: 'Body' },
+      })
+      const root = wrapper.find('.flex.select-none')
+      expect(root.exists()).toBe(true)
+      expect(root.classes()).toContain('text-core-black')
+    })
+
+    it('applies mb-0 to the internal <p> elements (title + description)', () => {
+      const wrapper = mount(FzAlert, {
+        props: { title: 'Title' },
+        slots: { default: 'Body text' },
+      })
+      const paragraphs = wrapper.findAll('p')
+      expect(paragraphs.length).toBeGreaterThanOrEqual(2)
+      for (const p of paragraphs) {
+        expect(p.classes()).toContain('mb-0')
+      }
+    })
+  })
+
 })

--- a/packages/alert/src/__tests__/FzAlert.spec.ts
+++ b/packages/alert/src/__tests__/FzAlert.spec.ts
@@ -137,16 +137,19 @@ describe('FzAlert', () => {
         ['danger', 'triangle-exclamation', 'text-semantic-error'],
         ['warning', 'triangle-exclamation', 'text-semantic-warning'],
         ['success', 'circle-check', 'text-semantic-success']
-      ])('should apply correct icon and classes for %s tone', (tone, expectedIcon, expectedClass) => {
-        wrapper = mount(FzAlert, {
-          props: {
-            tone: tone as any
-          }
-        })
-        const icon = wrapper.findComponent({ name: 'FzIcon' })
-        expect(icon.props('name')).toBe(expectedIcon)
-        expect(icon.classes()).toContain(expectedClass)
-      })
+      ])(
+        'should apply correct icon and classes for %s tone',
+        (tone, expectedIcon, expectedClass) => {
+          wrapper = mount(FzAlert, {
+            props: {
+              tone: tone as any
+            }
+          })
+          const icon = wrapper.findComponent({ name: 'FzIcon' })
+          expect(icon.props('name')).toBe(expectedIcon)
+          expect(icon.classes()).toContain(expectedClass)
+        }
+      )
 
       it.each([
         ['info', 'bg-semantic-info-50', 'border-semantic-info'],
@@ -746,7 +749,7 @@ describe('FzAlert', () => {
       expect(iconButtons.length).toBe(1)
       const dismissButton = iconButtons[0]
       expect(dismissButton.exists()).toBe(true)
-      
+
       // Trigger click event on the button element
       const buttonElement = dismissButton.find('button')
       if (buttonElement.exists()) {
@@ -755,7 +758,7 @@ describe('FzAlert', () => {
         // Fallback: trigger directly on component
         await dismissButton.trigger('click')
       }
-      
+
       expect(wrapper.emitted('fzAlert:dismiss')).toHaveLength(1)
     })
 
@@ -771,11 +774,11 @@ describe('FzAlert', () => {
         }
       })
       expect(wrapper.text()).toContain('Description')
-      
+
       const container = wrapper.find('div')
       await container.trigger('click')
       await nextTick()
-      
+
       expect(wrapper.text()).not.toContain('Description')
     })
 
@@ -791,11 +794,11 @@ describe('FzAlert', () => {
         }
       })
       expect(wrapper.text()).not.toContain('Description')
-      
+
       const toggleButton = wrapper.findAllComponents({ name: 'FzIconButton' })[0]
       await toggleButton.trigger('click')
       await nextTick()
-      
+
       expect(wrapper.text()).toContain('Description')
     })
 
@@ -813,9 +816,9 @@ describe('FzAlert', () => {
       const button = wrapper.findComponent({ name: 'FzButton' })
       const clickEvent = new MouseEvent('click', { bubbles: true })
       const stopPropagationSpy = vi.spyOn(clickEvent, 'stopPropagation')
-      
+
       await button.trigger('click', { event: clickEvent })
-      
+
       // The event handler calls stopPropagation, so accordion should not toggle
       expect(wrapper.text()).toContain('Description')
     })
@@ -974,10 +977,10 @@ describe('FzAlert', () => {
           }
         })
         const container = wrapper.find('div')
-        
+
         await container.trigger('click')
         await nextTick()
-        
+
         const ariaExpanded = container.attributes('aria-expanded')
         if (ariaExpanded) {
           expect(ariaExpanded).toBe('false')
@@ -1050,10 +1053,10 @@ describe('FzAlert', () => {
           }
         })
         const container = wrapper.find('div')
-        
+
         await container.trigger('keydown', { key: 'Enter' })
         await nextTick()
-        
+
         // Note: Component may need keyboard handler implementation
         // This test documents expected behavior
       })
@@ -1070,10 +1073,10 @@ describe('FzAlert', () => {
           }
         })
         const container = wrapper.find('div')
-        
+
         await container.trigger('keydown', { key: ' ' })
         await nextTick()
-        
+
         // Note: Component may need keyboard handler implementation
         // This test documents expected behavior
       })
@@ -1183,18 +1186,18 @@ describe('FzAlert', () => {
           default: 'Description'
         }
       })
-      
+
       const container = wrapper.find('div')
-      
+
       // Toggle multiple times rapidly
       await container.trigger('click')
       await nextTick()
       expect(wrapper.text()).not.toContain('Description') // Closed after 1 click
-      
+
       await container.trigger('click')
       await nextTick()
       expect(wrapper.text()).toContain('Description') // Open after 2 clicks
-      
+
       await container.trigger('click')
       await nextTick()
       expect(wrapper.text()).not.toContain('Description') // Closed after 3 clicks
@@ -1242,7 +1245,8 @@ describe('FzAlert', () => {
           buttonActionLabel: 'Button action here'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1256,7 +1260,8 @@ describe('FzAlert', () => {
           buttonActionLabel: 'Button action here'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1270,7 +1275,8 @@ describe('FzAlert', () => {
           buttonActionLabel: 'Button action here'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1284,7 +1290,8 @@ describe('FzAlert', () => {
           buttonActionLabel: 'Button action here'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1298,7 +1305,8 @@ describe('FzAlert', () => {
           buttonActionLabel: 'Button action here'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1313,7 +1321,8 @@ describe('FzAlert', () => {
           buttonActionLabel: 'Button action here'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1327,7 +1336,8 @@ describe('FzAlert', () => {
           isDismissible: true
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1344,7 +1354,8 @@ describe('FzAlert', () => {
           linkActionLocation: '/example'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         },
         global: {
           plugins: [router]
@@ -1365,7 +1376,8 @@ describe('FzAlert', () => {
           linkActionTarget: '_blank'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         },
         global: {
           plugins: [router]
@@ -1382,7 +1394,8 @@ describe('FzAlert', () => {
           environment: 'backoffice'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1395,7 +1408,8 @@ describe('FzAlert', () => {
           variant: 'text'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1409,7 +1423,8 @@ describe('FzAlert', () => {
           environment: 'backoffice'
         },
         slots: {
-          default: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+          default:
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -1420,17 +1435,17 @@ describe('FzAlert', () => {
     it('applies text-core-black on the alert container', () => {
       const wrapper = mount(FzAlert, {
         props: { title: 'Title' },
-        slots: { default: 'Body' },
+        slots: { default: 'Body' }
       })
       const root = wrapper.find('.flex.select-none')
       expect(root.exists()).toBe(true)
       expect(root.classes()).toContain('text-core-black')
     })
 
-    it('applies mb-0 to the internal <p> elements (title + description)', () => {
+    it('applies mb-0 to the internal <p> elements when no action is rendered', () => {
       const wrapper = mount(FzAlert, {
-        props: { title: 'Title' },
-        slots: { default: 'Body text' },
+        props: { title: 'Title', showButtonAction: false },
+        slots: { default: 'Body text' }
       })
       const paragraphs = wrapper.findAll('p')
       expect(paragraphs.length).toBeGreaterThanOrEqual(2)
@@ -1438,6 +1453,15 @@ describe('FzAlert', () => {
         expect(p.classes()).toContain('mb-0')
       }
     })
-  })
 
+    it('preserves mb-16 on the description when an action is rendered', () => {
+      const wrapper = mount(FzAlert, {
+        props: { title: 'Title', buttonActionLabel: 'OK' },
+        slots: { default: 'Body' }
+      })
+      const description = wrapper.findAll('p')[1]
+      expect(description.classes()).toContain('mb-16')
+      expect(description.classes()).not.toContain('mb-0')
+    })
+  })
 })

--- a/packages/alert/src/__tests__/FzAlert.spec.ts
+++ b/packages/alert/src/__tests__/FzAlert.spec.ts
@@ -1434,7 +1434,7 @@ describe('FzAlert', () => {
   describe('DS-GAP baselines', () => {
     it('applies text-core-black on the alert container', () => {
       const wrapper = mount(FzAlert, {
-        props: { title: 'Title' },
+        props: { tone: 'info', title: 'Title' },
         slots: { default: 'Body' }
       })
       const root = wrapper.find('.flex.select-none')
@@ -1444,7 +1444,7 @@ describe('FzAlert', () => {
 
     it('applies mb-0 to the internal <p> elements when no action is rendered', () => {
       const wrapper = mount(FzAlert, {
-        props: { title: 'Title', showButtonAction: false },
+        props: { tone: 'info', title: 'Title', showButtonAction: false },
         slots: { default: 'Body text' }
       })
       const paragraphs = wrapper.findAll('p')
@@ -1456,7 +1456,7 @@ describe('FzAlert', () => {
 
     it('preserves mb-16 on the description when an action is rendered', () => {
       const wrapper = mount(FzAlert, {
-        props: { title: 'Title', buttonActionLabel: 'OK' },
+        props: { tone: 'info', title: 'Title', buttonActionLabel: 'OK' },
         slots: { default: 'Body' }
       })
       const description = wrapper.findAll('p')[1]

--- a/packages/alert/src/__tests__/__snapshots__/FzAlert.spec.ts.snap
+++ b/packages/alert/src/__tests__/__snapshots__/FzAlert.spec.ts.snap
@@ -1,11 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzAlert > Snapshots > should match snapshot - accordion variant 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-info-50 border-semantic-info cursor-pointer">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info cursor-pointer">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -22,11 +22,11 @@ exports[`FzAlert > Snapshots > should match snapshot - accordion variant 1`] = `
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - backoffice environment 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-info-50 border-semantic-info p-6">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info p-6">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-6"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-32 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]"></div>
@@ -41,11 +41,11 @@ exports[`FzAlert > Snapshots > should match snapshot - backoffice environment 1`
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - danger alert 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-error-50 border-semantic-error">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-error-50 border-semantic-error">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-triangle-exclamation h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="triangle-exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M248.4 84.3c1.6-2.7 4.5-4.3 7.6-4.3s6 1.6 7.6 4.3L461.9 410c1.4 2.3 2.1 4.9 2.1 7.5c0 8-6.5 14.5-14.5 14.5l-387 0c-8 0-14.5-6.5-14.5-14.5c0-2.7 .7-5.3 2.1-7.5L248.4 84.3zm-41-25L9.1 385c-6 9.8-9.1 21-9.1 32.5C0 452 28 480 62.5 480l387 0c34.5 0 62.5-28 62.5-62.5c0-11.5-3.2-22.7-9.1-32.5L304.6 59.3C294.3 42.4 275.9 32 256 32s-38.3 10.4-48.6 27.3zM288 368a32 32 0 1 0 -64 0 32 32 0 1 0 64 0zm-8-184c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 96c0 13.3 10.7 24 24 24s24-10.7 24-24l0-96z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -60,11 +60,11 @@ exports[`FzAlert > Snapshots > should match snapshot - danger alert 1`] = `
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - dismissible alert 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-info-50 border-semantic-info">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]"></div>
@@ -81,11 +81,11 @@ exports[`FzAlert > Snapshots > should match snapshot - dismissible alert 1`] = `
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - error alert 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-error-50 border-semantic-error">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-error-50 border-semantic-error">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -100,11 +100,11 @@ exports[`FzAlert > Snapshots > should match snapshot - error alert 1`] = `
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - external link with target 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-info-50 border-semantic-info">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default">
         <!--v-if--><a data-v-9babd5cc="" href="/example" class="border-1 border-transparent inline-block text-base leading-base focus:outline-none focus:border-solid focus:no-underline text-blue-500 hover:text-blue-600 hover:underline focus:text-blue-600 focus:border-blue-600" target="_blank">This is a link</a>
       </div>
@@ -115,11 +115,11 @@ exports[`FzAlert > Snapshots > should match snapshot - external link with target
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - info alert 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-info-50 border-semantic-info">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -134,11 +134,11 @@ exports[`FzAlert > Snapshots > should match snapshot - info alert 1`] = `
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - success alert 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-success-50 border-semantic-success">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-success-50 border-semantic-success">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-success" aria-hidden="true"><svg class="svg-inline--fa fa-circle-check h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-111 111-47-47c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l64 64c9.4 9.4 24.6 9.4 33.9 0L369 209z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -153,11 +153,11 @@ exports[`FzAlert > Snapshots > should match snapshot - success alert 1`] = `
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - text variant 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-transparent">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
       <!--v-if-->
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px]">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px]">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <!--v-if-->
     </div>
   </div>
@@ -166,11 +166,11 @@ exports[`FzAlert > Snapshots > should match snapshot - text variant 1`] = `
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - text variant backoffice 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-transparent">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
       <!--v-if-->
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px]">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px]">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <!--v-if-->
     </div>
   </div>
@@ -179,11 +179,11 @@ exports[`FzAlert > Snapshots > should match snapshot - text variant backoffice 1
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - warning alert 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-warning-50 border-semantic-warning">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-warning-50 border-semantic-warning">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-warning" aria-hidden="true"><svg class="svg-inline--fa fa-triangle-exclamation h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="triangle-exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M248.4 84.3c1.6-2.7 4.5-4.3 7.6-4.3s6 1.6 7.6 4.3L461.9 410c1.4 2.3 2.1 4.9 2.1 7.5c0 8-6.5 14.5-14.5 14.5l-387 0c-8 0-14.5-6.5-14.5-14.5c0-2.7 .7-5.3 2.1-7.5L248.4 84.3zm-41-25L9.1 385c-6 9.8-9.1 21-9.1 32.5C0 452 28 480 62.5 480l387 0c34.5 0 62.5-28 62.5-62.5c0-11.5-3.2-22.7-9.1-32.5L304.6 59.3C294.3 42.4 275.9 32 256 32s-38.3 10.4-48.6 27.3zM288 368a32 32 0 1 0 -64 0 32 32 0 1 0 64 0zm-8-184c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 96c0 13.3 10.7 24 24 24s24-10.7 24-24l0-96z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -198,11 +198,11 @@ exports[`FzAlert > Snapshots > should match snapshot - warning alert 1`] = `
 `;
 
 exports[`FzAlert > Snapshots > should match snapshot - with link action 1`] = `
-"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between bg-semantic-info-50 border-semantic-info">
+"<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
     <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px]">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default">
         <!--v-if--><a data-v-9babd5cc="" href="/example" class="border-1 border-transparent inline-block text-base leading-base focus:outline-none focus:border-solid focus:no-underline text-blue-500 hover:text-blue-600 hover:underline focus:text-blue-600 focus:border-blue-600">This is a link</a>
       </div>

--- a/packages/alert/src/__tests__/__snapshots__/FzAlert.spec.ts.snap
+++ b/packages/alert/src/__tests__/__snapshots__/FzAlert.spec.ts.snap
@@ -3,9 +3,9 @@
 exports[`FzAlert > Snapshots > should match snapshot - accordion variant 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info cursor-pointer">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -24,9 +24,9 @@ exports[`FzAlert > Snapshots > should match snapshot - accordion variant 1`] = `
 exports[`FzAlert > Snapshots > should match snapshot - backoffice environment 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info p-6">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-6"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-32 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]"></div>
@@ -43,9 +43,9 @@ exports[`FzAlert > Snapshots > should match snapshot - backoffice environment 1`
 exports[`FzAlert > Snapshots > should match snapshot - danger alert 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-error-50 border-semantic-error">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-triangle-exclamation h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="triangle-exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M248.4 84.3c1.6-2.7 4.5-4.3 7.6-4.3s6 1.6 7.6 4.3L461.9 410c1.4 2.3 2.1 4.9 2.1 7.5c0 8-6.5 14.5-14.5 14.5l-387 0c-8 0-14.5-6.5-14.5-14.5c0-2.7 .7-5.3 2.1-7.5L248.4 84.3zm-41-25L9.1 385c-6 9.8-9.1 21-9.1 32.5C0 452 28 480 62.5 480l387 0c34.5 0 62.5-28 62.5-62.5c0-11.5-3.2-22.7-9.1-32.5L304.6 59.3C294.3 42.4 275.9 32 256 32s-38.3 10.4-48.6 27.3zM288 368a32 32 0 1 0 -64 0 32 32 0 1 0 64 0zm-8-184c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 96c0 13.3 10.7 24 24 24s24-10.7 24-24l0-96z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -62,9 +62,9 @@ exports[`FzAlert > Snapshots > should match snapshot - danger alert 1`] = `
 exports[`FzAlert > Snapshots > should match snapshot - dismissible alert 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]"></div>
@@ -83,9 +83,9 @@ exports[`FzAlert > Snapshots > should match snapshot - dismissible alert 1`] = `
 exports[`FzAlert > Snapshots > should match snapshot - error alert 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-error-50 border-semantic-error">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -102,9 +102,9 @@ exports[`FzAlert > Snapshots > should match snapshot - error alert 1`] = `
 exports[`FzAlert > Snapshots > should match snapshot - external link with target 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default">
         <!--v-if--><a data-v-9babd5cc="" href="/example" class="border-1 border-transparent inline-block text-base leading-base focus:outline-none focus:border-solid focus:no-underline text-blue-500 hover:text-blue-600 hover:underline focus:text-blue-600 focus:border-blue-600" target="_blank">This is a link</a>
       </div>
@@ -117,9 +117,9 @@ exports[`FzAlert > Snapshots > should match snapshot - external link with target
 exports[`FzAlert > Snapshots > should match snapshot - info alert 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -136,9 +136,9 @@ exports[`FzAlert > Snapshots > should match snapshot - info alert 1`] = `
 exports[`FzAlert > Snapshots > should match snapshot - success alert 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-success-50 border-semantic-success">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-success" aria-hidden="true"><svg class="svg-inline--fa fa-circle-check h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-check" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-111 111-47-47c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l64 64c9.4 9.4 24.6 9.4 33.9 0L369 209z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -155,9 +155,9 @@ exports[`FzAlert > Snapshots > should match snapshot - success alert 1`] = `
 exports[`FzAlert > Snapshots > should match snapshot - text variant 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
       <!--v-if-->
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px]">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <!--v-if-->
     </div>
   </div>
@@ -168,9 +168,9 @@ exports[`FzAlert > Snapshots > should match snapshot - text variant 1`] = `
 exports[`FzAlert > Snapshots > should match snapshot - text variant backoffice 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[15px] h-[15px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info fa-sm h-[12px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
       <!--v-if-->
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px]">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mb-0">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <!--v-if-->
     </div>
   </div>
@@ -181,9 +181,9 @@ exports[`FzAlert > Snapshots > should match snapshot - text variant backoffice 1
 exports[`FzAlert > Snapshots > should match snapshot - warning alert 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-warning-50 border-semantic-warning">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-warning" aria-hidden="true"><svg class="svg-inline--fa fa-triangle-exclamation h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="triangle-exclamation" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M248.4 84.3c1.6-2.7 4.5-4.3 7.6-4.3s6 1.6 7.6 4.3L461.9 410c1.4 2.3 2.1 4.9 2.1 7.5c0 8-6.5 14.5-14.5 14.5l-387 0c-8 0-14.5-6.5-14.5-14.5c0-2.7 .7-5.3 2.1-7.5L248.4 84.3zm-41-25L9.1 385c-6 9.8-9.1 21-9.1 32.5C0 452 28 480 62.5 480l387 0c34.5 0 62.5-28 62.5-62.5c0-11.5-3.2-22.7-9.1-32.5L304.6 59.3C294.3 42.4 275.9 32 256 32s-38.3 10.4-48.6 27.3zM288 368a32 32 0 1 0 -64 0 32 32 0 1 0 64 0zm-8-184c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 96c0 13.3 10.7 24 24 24s24-10.7 24-24l0-96z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><button data-v-9babd5cc="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200">
           <!--v-if-->
           <div class="truncate font-normal !text-[16px] !leading-[20px]">Button action here</div>
@@ -200,9 +200,9 @@ exports[`FzAlert > Snapshots > should match snapshot - warning alert 1`] = `
 exports[`FzAlert > Snapshots > should match snapshot - with link action 1`] = `
 "<div data-v-9babd5cc="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9babd5cc="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
-    <div data-v-9babd5cc="" class="flex flex-col flex-1">
-      <p data-v-9babd5cc="" class="leading-[20px] mb-0">Title here</p>
-      <p data-v-9babd5cc="" class="font-normal mb-0 !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <div data-v-9babd5cc="" class="flex flex-1 flex-col">
+      <p data-v-9babd5cc="" class="mb-0 leading-[20px]">Title here</p>
+      <p data-v-9babd5cc="" class="font-normal !leading-[20px] mt-8 mb-16">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       <div data-v-da7f5873="" data-v-9babd5cc="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default">
         <!--v-if--><a data-v-9babd5cc="" href="/example" class="border-1 border-transparent inline-block text-base leading-base focus:outline-none focus:border-solid focus:no-underline text-blue-500 hover:text-blue-600 hover:underline focus:text-blue-600 focus:border-blue-600">This is a link</a>
       </div>

--- a/packages/appointments/src/__tests__/__snapshots__/FzAppointments.spec.ts.snap
+++ b/packages/appointments/src/__tests__/__snapshots__/FzAppointments.spec.ts.snap
@@ -128,11 +128,11 @@ exports[`FzAppointments > Snapshots > should match snapshot - no slots available
 <!--v-if--></button>
 <!--v-if--></span></div><!-- Info text -->
 <p class="text-grey-500">30 minuti a partire dalle</p><!-- Time slots or alert -->
-<div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between bg-semantic-info-50 border-semantic-info">
+<div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
     <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
-      <p data-v-9bf2fc2e="" class="leading-[20px]">No slots</p>
-      <p data-v-9bf2fc2e="" class="font-normal !leading-[20px] mt-8">No available slots</p>
+      <p data-v-9bf2fc2e="" class="leading-[20px] mb-0">No slots</p>
+      <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px] mt-8">No available slots</p>
       <!--v-if-->
     </div>
   </div>

--- a/packages/appointments/src/__tests__/__snapshots__/FzAppointments.spec.ts.snap
+++ b/packages/appointments/src/__tests__/__snapshots__/FzAppointments.spec.ts.snap
@@ -130,9 +130,9 @@ exports[`FzAppointments > Snapshots > should match snapshot - no slots available
 <p class="text-grey-500">30 minuti a partire dalle</p><!-- Time slots or alert -->
 <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-semantic-info-50 border-semantic-info">
   <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-start layout-default flex-1 p-12"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info" aria-hidden="true"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span>
-    <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
-      <p data-v-9bf2fc2e="" class="leading-[20px] mb-0">No slots</p>
-      <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px] mt-8">No available slots</p>
+    <div data-v-9bf2fc2e="" class="flex flex-1 flex-col">
+      <p data-v-9bf2fc2e="" class="mb-0 leading-[20px]">No slots</p>
+      <p data-v-9bf2fc2e="" class="font-normal !leading-[20px] mt-8 mb-0">No available slots</p>
       <!--v-if-->
     </div>
   </div>

--- a/packages/checkbox/src/__tests__/__snapshots__/FzCheckbox.spec.ts.snap
+++ b/packages/checkbox/src/__tests__/__snapshots__/FzCheckbox.spec.ts.snap
@@ -191,11 +191,11 @@ exports[`FzCheckbox > Snapshots > should match snapshot - error state 1`] = `
       FzAlert with type="error" and announce prop
       would automatically get role="alert" and aria-live="assertive"
   -->
-  <div data-v-9bf2fc2e="" data-v-79ecb611="" class="flex select-none gap-12 rounded justify-between bg-transparent" id="fz-checkbox-100000000001-2a84k-error" role="alert" aria-live="assertive" aria-atomic="true">
+  <div data-v-9bf2fc2e="" data-v-79ecb611="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="fz-checkbox-100000000001-2a84k-error" role="alert" aria-live="assertive" aria-atomic="true">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
       <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px]">Error message</p>
+        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">Error message</p>
         <!--v-if-->
       </div>
     </div>

--- a/packages/checkbox/src/__tests__/__snapshots__/FzCheckbox.spec.ts.snap
+++ b/packages/checkbox/src/__tests__/__snapshots__/FzCheckbox.spec.ts.snap
@@ -193,9 +193,9 @@ exports[`FzCheckbox > Snapshots > should match snapshot - error state 1`] = `
   -->
   <div data-v-9bf2fc2e="" data-v-79ecb611="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="fz-checkbox-100000000001-2a84k-error" role="alert" aria-live="assertive" aria-atomic="true">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
-      <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
+      <div data-v-9bf2fc2e="" class="flex flex-1 flex-col">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">Error message</p>
+        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px] mb-0">Error message</p>
         <!--v-if-->
       </div>
     </div>

--- a/packages/checkbox/src/__tests__/__snapshots__/FzCheckboxGroup.spec.ts.snap
+++ b/packages/checkbox/src/__tests__/__snapshots__/FzCheckboxGroup.spec.ts.snap
@@ -671,11 +671,11 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - with error 1`] = 
       FzAlert with type="error" and announce prop
       would automatically get role="alert" and aria-live="assertive"
   -->
-  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between bg-transparent" id="fz-checkbox-group-100000000001-2a84k-error" role="alert" aria-live="assertive" aria-atomic="true">
+  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="fz-checkbox-group-100000000001-2a84k-error" role="alert" aria-live="assertive" aria-atomic="true">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
       <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px]">Test error message</p>
+        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">Test error message</p>
         <!--v-if-->
       </div>
     </div>

--- a/packages/checkbox/src/__tests__/__snapshots__/FzCheckboxGroup.spec.ts.snap
+++ b/packages/checkbox/src/__tests__/__snapshots__/FzCheckboxGroup.spec.ts.snap
@@ -673,9 +673,9 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - with error 1`] = 
   -->
   <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="fz-checkbox-group-100000000001-2a84k-error" role="alert" aria-live="assertive" aria-atomic="true">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
-      <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
+      <div data-v-9bf2fc2e="" class="flex flex-1 flex-col">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">Test error message</p>
+        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px] mb-0">Test error message</p>
         <!--v-if-->
       </div>
     </div>

--- a/packages/datepicker/src/__tests__/__snapshots__/FzDatepicker.spec.ts.snap
+++ b/packages/datepicker/src/__tests__/__snapshots__/FzDatepicker.spec.ts.snap
@@ -225,11 +225,11 @@ exports[`FzDatepicker > Snapshots > matches snapshot - with label and error 1`] 
             <!--v-if-->
           </div>
         </div>
-        <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between bg-transparent" id="fz-input-[id]-error" role="alert">
+        <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="fz-input-[id]-error" role="alert">
           <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
             <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
               <!--v-if-->
-              <p data-v-9bf2fc2e="" class="font-normal !leading-[20px]">This field is required</p>
+              <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">This field is required</p>
               <!--v-if-->
             </div>
           </div>

--- a/packages/datepicker/src/__tests__/__snapshots__/FzDatepicker.spec.ts.snap
+++ b/packages/datepicker/src/__tests__/__snapshots__/FzDatepicker.spec.ts.snap
@@ -227,9 +227,9 @@ exports[`FzDatepicker > Snapshots > matches snapshot - with label and error 1`] 
         </div>
         <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="fz-input-[id]-error" role="alert">
           <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
-            <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
+            <div data-v-9bf2fc2e="" class="flex flex-1 flex-col">
               <!--v-if-->
-              <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">This field is required</p>
+              <p data-v-9bf2fc2e="" class="font-normal !leading-[20px] mb-0">This field is required</p>
               <!--v-if-->
             </div>
           </div>

--- a/packages/radio/src/__tests__/__snapshots__/FzRadioGroup.spec.ts.snap
+++ b/packages/radio/src/__tests__/__snapshots__/FzRadioGroup.spec.ts.snap
@@ -111,11 +111,11 @@ exports[`FzRadioGroup > Snapshots > should match snapshot - error state 1`] = `
       FzAlert with type="error" and announce prop
       would automatically get role="alert" and aria-live="assertive"
   -->
-  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between bg-transparent" id="fz-radio-group-100000000001-2a84k-error" role="alert" aria-live="assertive" aria-atomic="true">
+  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="fz-radio-group-100000000001-2a84k-error" role="alert" aria-live="assertive" aria-atomic="true">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
       <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px]">Error text</p>
+        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">Error text</p>
         <!--v-if-->
       </div>
     </div>

--- a/packages/radio/src/__tests__/__snapshots__/FzRadioGroup.spec.ts.snap
+++ b/packages/radio/src/__tests__/__snapshots__/FzRadioGroup.spec.ts.snap
@@ -113,9 +113,9 @@ exports[`FzRadioGroup > Snapshots > should match snapshot - error state 1`] = `
   -->
   <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="fz-radio-group-100000000001-2a84k-error" role="alert" aria-live="assertive" aria-atomic="true">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
-      <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
+      <div data-v-9bf2fc2e="" class="flex flex-1 flex-col">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">Error text</p>
+        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px] mb-0">Error text</p>
         <!--v-if-->
       </div>
     </div>

--- a/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
+++ b/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
@@ -32,11 +32,11 @@ exports[`FzTextarea > Snapshots > should match snapshot - error state 1`] = `
   <div class="relative w-full"><textarea id="snapshot-error" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-semantic-error-200 focus:border-semantic-error-300 bg-core-white text-core-black cursor-text resize" rows="2" aria-required="false" aria-invalid="true" aria-disabled="false" aria-labelledby="snapshot-error-label" aria-describedby="snapshot-error-error"></textarea>
     <!--v-if-->
   </div>
-  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between bg-transparent" id="snapshot-error-error" role="alert">
+  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="snapshot-error-error" role="alert">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
       <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px]">This field is required</p>
+        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">This field is required</p>
         <!--v-if-->
       </div>
     </div>
@@ -50,11 +50,11 @@ exports[`FzTextarea > Snapshots > should match snapshot - error with disabled 1`
   <div class="relative w-full"><textarea id="snapshot-error-disabled" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-semantic-error-200 focus:border-semantic-error-300 bg-core-white text-core-black cursor-text resize" disabled="" rows="2" aria-required="false" aria-invalid="true" aria-disabled="true" aria-labelledby="snapshot-error-disabled-label" aria-describedby="snapshot-error-disabled-error"></textarea>
     <!--v-if-->
   </div>
-  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between bg-transparent" id="snapshot-error-disabled-error" role="alert">
+  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="snapshot-error-disabled-error" role="alert">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
       <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px]">Error on disabled</p>
+        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">Error on disabled</p>
         <!--v-if-->
       </div>
     </div>

--- a/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
+++ b/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
@@ -34,9 +34,9 @@ exports[`FzTextarea > Snapshots > should match snapshot - error state 1`] = `
   </div>
   <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="snapshot-error-error" role="alert">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
-      <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
+      <div data-v-9bf2fc2e="" class="flex flex-1 flex-col">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">This field is required</p>
+        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px] mb-0">This field is required</p>
         <!--v-if-->
       </div>
     </div>
@@ -52,9 +52,9 @@ exports[`FzTextarea > Snapshots > should match snapshot - error with disabled 1`
   </div>
   <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent" id="snapshot-error-disabled-error" role="alert">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
-      <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
+      <div data-v-9bf2fc2e="" class="flex flex-1 flex-col">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">Error on disabled</p>
+        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px] mb-0">Error on disabled</p>
         <!--v-if-->
       </div>
     </div>

--- a/packages/typeahead/src/__tests__/__snapshots__/FzTypeahead.spec.ts.snap
+++ b/packages/typeahead/src/__tests__/__snapshots__/FzTypeahead.spec.ts.snap
@@ -322,11 +322,11 @@ exports[`FzTypeahead > Snapshots > should match snapshot - error state 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between bg-transparent">
+  <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
       <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px]">
+        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">
         <div>Error message</div>
         </p>
         <!--v-if-->

--- a/packages/typeahead/src/__tests__/__snapshots__/FzTypeahead.spec.ts.snap
+++ b/packages/typeahead/src/__tests__/__snapshots__/FzTypeahead.spec.ts.snap
@@ -324,9 +324,9 @@ exports[`FzTypeahead > Snapshots > should match snapshot - error state 1`] = `
   </div>
   <div data-v-9bf2fc2e="" class="flex select-none gap-12 rounded justify-between text-core-black bg-transparent">
     <div data-v-da7f5873="" data-v-9bf2fc2e="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-start layout-default flex-1"><span data-v-9bf2fc2e="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-error" aria-hidden="true"><svg class="svg-inline--fa fa-circle-xmark h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-xmark" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM175 175c-9.4 9.4-9.4 24.6 0 33.9l47 47-47 47c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l47-47 47 47c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-47-47 47-47c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-47 47-47-47c-9.4-9.4-24.6-9.4-33.9 0z"></path></svg></span>
-      <div data-v-9bf2fc2e="" class="flex flex-col flex-1">
+      <div data-v-9bf2fc2e="" class="flex flex-1 flex-col">
         <!--v-if-->
-        <p data-v-9bf2fc2e="" class="font-normal mb-0 !leading-[20px]">
+        <p data-v-9bf2fc2e="" class="font-normal !leading-[20px] mb-0">
         <div>Error message</div>
         </p>
         <!--v-if-->


### PR DESCRIPTION
[Chromatic](https://fix-alert-self-contained-typography--65e5d7f524a5908cb4d75bd7.chromatic.com/?path=/story/messages-fzalert--info)

## Cosa

`FzAlert` ora applica due baseline tipografici sul template:

- `text-core-black` sul container, così il testo interno (titolo, descrizione, eventuale `errorMessage` slot) eredita il colore neutro del DS indipendentemente dal text-color default del consumer host.
- `mb-0` sul `<p>` titolo (sempre) e sul `<p>` descrizione in mutua esclusione con il pre-esistente `mb-16` (applicato solo quando è presente un'azione). Questo neutralizza il reboot `<p> { margin-bottom: 1rem }` che alcuni host applicano (es. Bootstrap 4 reboot, alcuni reset CSS) garantendo che venga emessa **una sola** utility `mb-*` per ciascun paragrafo, senza dipendere dall'ordine con cui Tailwind emette le utility nel CSS generato. Lo spacing "description → action" è preservato.

Nessuna prop pubblica cambia.

## Cosa fare in app dopo il rilascio di `@fiscozen/alert@3.0.3`

1. Bump `@fiscozen/alert` `^3.0.2` → `^3.0.3` in `backoffice/package.json` e `frontoffice/package.json` (caret pin).
2. Droppare interamente `vue_common/src/scss/fz-ds/_fz-alert.scss`. Rimuovere `@use 'fz-alert'` da `_main.scss`. Il file shim era anche già dead code lato consumer (targetava `.fz-alert`, una classe che il componente non emette).
3. Smoke browser su 2-3 pagine con `<FzAlert>` (qualsiasi modal di conferma / errore form). Verifica: testo nero, nessun margin residuo sotto al paragrafo titolo, spacing description-action invariato quando c'è un button/link nel default slot.
