### PR TITLE
feat(FzCardList): action sections in kebab dropdown

### DIFF
--- a/.changeset/card-list-action-sections.md
+++ b/.changeset/card-list-action-sections.md
@@ -1,0 +1,8 @@
+---
+"@fiscozen/card-list": minor
+---
+
+Allow grouping a row's kebab actions into labeled sections by passing
+`{ type: 'section', label }` markers inside the `actions` array, mirroring
+the `FzActionSection` pattern already supported by `FzDropdown`. Existing
+flat-array usages are unaffected.

--- a/packages/card-list/src/FzCardListItem.vue
+++ b/packages/card-list/src/FzCardListItem.vue
@@ -19,6 +19,7 @@
 import { computed } from "vue";
 import type {
   ActionsMode,
+  FzCardListItemAction,
   FzCardListItemProps,
   FzCardListItemEmits,
 } from "./types";
@@ -31,9 +32,15 @@ const props = defineProps<FzCardListItemProps>();
 
 const emit = defineEmits<FzCardListItemEmits>();
 
+// Section markers render as group headers in the dropdown but don't count
+// toward the action-count routing (none / link / actions).
+const interactiveActions = computed<FzActionProps[]>(
+  () => (props.actions?.filter((a) => a.type !== "section") ?? []) as FzActionProps[],
+);
+
 const actionsMode = computed<ActionsMode>(() => {
-  if (!props.actions?.length) return "none";
-  if (props.actions.length === 1 && props.actions[0].type === "link") return "link";
+  if (!interactiveActions.value.length) return "none";
+  if (interactiveActions.value.length === 1 && interactiveActions.value[0].type === "link") return "link";
   return "actions";
 });
 
@@ -55,7 +62,7 @@ const actionsMode = computed<ActionsMode>(() => {
     :show-indicator="showIndicator"
     :value="value"
     :descriptions="descriptions"
-    :action="actions?.[0] as FzActionLinkProps"
+    :action="interactiveActions[0] as FzActionLinkProps"
     @fzaction:click="(action) => emit('fzaction:click', 0, action as FzActionProps)"
   />
   <FzCardMultiActions
@@ -65,7 +72,7 @@ const actionsMode = computed<ActionsMode>(() => {
     :show-indicator="showIndicator"
     :value="value"
     :descriptions="descriptions"
-    :actions="actions as FzActionProps[]"
+    :actions="actions as FzCardListItemAction[]"
     @fzaction:click="(index, action) => emit('fzaction:click', index, action)"
   />
 </template>

--- a/packages/card-list/src/__tests__/FzCardListItem.spec.ts
+++ b/packages/card-list/src/__tests__/FzCardListItem.spec.ts
@@ -205,6 +205,39 @@ describe("FzCardListItem", () => {
       expect(dropdown.props("actions")).toEqual([actionA, actionB]);
     });
 
+    it("should ignore section markers when deciding actions mode", async () => {
+      // Only a section header + one link action → still arrow (link) mode,
+      // not dropdown — markers don't count as interactive actions.
+      const sectionOnly = mount(FzCardListItem, {
+        props: { title: "Item", actions: [{ type: "section", label: "Group" }] },
+      });
+      const sectionPlusOneLink = mount(FzCardListItem, {
+        props: {
+          title: "Item",
+          actions: [{ type: "section", label: "Group" }, linkAction],
+        },
+      });
+      await Promise.all([sectionOnly.vm.$nextTick(), sectionPlusOneLink.vm.$nextTick()]);
+      expect(sectionOnly.findComponent({ name: "FzIconButton" }).exists()).toBe(false);
+      expect(sectionOnly.findComponent({ name: "FzIconDropdown" }).exists()).toBe(false);
+      expect(
+        sectionPlusOneLink
+          .findAllComponents({ name: "FzIcon" })
+          .some((w) => w.props("name") === "chevron-right"),
+      ).toBe(true);
+    });
+
+    it("should pass section markers through to the dropdown", async () => {
+      const section = { type: "section" as const, label: "Scarica" };
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, section, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+      const dropdown = wrapper.findComponent({ name: "FzIconDropdown" });
+      expect(dropdown.exists()).toBe(true);
+      expect(dropdown.props("actions")).toEqual([actionA, section, actionB]);
+    });
+
     it("should render badge in the top row when badge is provided", async () => {
       const wrapper = mount(FzCardListItem, {
         props: { title: "Item", badge: { text: "Tag", tone: "info" } },

--- a/packages/card-list/src/components/FzCardMultiActions.vue
+++ b/packages/card-list/src/components/FzCardMultiActions.vue
@@ -15,10 +15,7 @@ const emit = defineEmits<FzCardMultiActionsEmits>();
 
 const hasTitleOnly = computed(() => !props.badge && !props.value);
 
-function emitActionClick(
-  actionIndex: number = 0,
-  action: FzActionProps = props.actions![0],
-) {
+function emitActionClick(actionIndex: number, action: FzActionProps) {
   emit("fzaction:click", actionIndex, action);
 }
 </script>

--- a/packages/card-list/src/components/types.ts
+++ b/packages/card-list/src/components/types.ts
@@ -1,5 +1,6 @@
 import { FzActionLinkProps, FzActionProps } from "@fiscozen/action";
 import { FzBadgeTone } from "@fiscozen/badge";
+import type { FzCardListItemAction } from "../types";
 
 export type FzCardBadge = {
   text: string;
@@ -37,7 +38,7 @@ export interface FzCardSingleActionEmits {
 
 export interface FzCardMultiActionsProps
   extends FzCardHeaderProps, FzCardListFooterProps, FzCardNoActionProps {
-  actions: FzActionProps[];
+  actions: FzCardListItemAction[];
 }
 
 export interface FzCardMultiActionsEmits {

--- a/packages/card-list/src/types.ts
+++ b/packages/card-list/src/types.ts
@@ -1,7 +1,17 @@
-import type { FzActionProps } from "@fiscozen/action";
+import type { FzActionProps, FzActionSectionProps } from "@fiscozen/action";
 import type { FzBadgeTone } from "@fiscozen/badge";
 
 export type ActionsMode = "none" | "link" | "actions";
+
+/**
+ * A row action, or a section separator that groups the following actions
+ * under a labeled header inside the kebab dropdown (mirrors `FzActionSection`).
+ * Section markers are not interactive — they only render as group headers
+ * and are skipped by click events.
+ */
+export type FzCardListItemAction =
+  | FzActionProps
+  | (FzActionSectionProps & { type: "section" });
 
 export interface FzCardListItemProps {
   /**
@@ -35,9 +45,13 @@ export interface FzCardListItemProps {
    */
   showIndicator?: boolean;
   /**
-   * Row actions. When omitted or `[]`, no trailing control is shown. With one item, an arrow button is shown; with more than one, an ellipsis opens a dropdown.
+   * Row actions. When omitted or `[]`, no trailing control is shown. With one
+   * non-section action, an arrow button is shown; with more, an ellipsis opens
+   * a dropdown. Pass a `{ type: 'section', label }` marker to start a labeled
+   * group inside the dropdown (subsequent actions go into that section until
+   * the next marker).
    */
-  actions?: FzActionProps[];
+  actions?: FzCardListItemAction[];
 }
 
 export interface FzCardListItemEmits {


### PR DESCRIPTION
## Summary
- Allows grouping a row's kebab actions into labeled sections by passing `{ type: 'section', label }` markers inside `FzCardListItemProps.actions`, mirroring the `FzActionSection` pattern already supported by `FzDropdown`
- New `FzCardListItemAction = FzActionProps | (FzActionSectionProps & { type: 'section' })` exported alongside the existing types
- Section markers are non-interactive — they only render as group headers and are skipped by the action-count routing (`[section, link]` still renders the single-link arrow mode, not the dropdown)
- Existing flat-array usages are unchanged (backwards-compat)

## Motivation
The `it.fiscozen.app` redesign of the passive credit note view needs a grouped kebab on autofatture cards ("Apri" / "Scarica autofattura" → PDF + XML). Today the only workaround is to either flatten everything into one list (losing the group label) or to wrap a custom dropdown around the card, sidestepping `FzCardList`.

## Test plan
- [x] `pnpm --filter @fiscozen/card-list test:unit` — 56/56 passing (added 2 new tests covering section behavior: filtered-out from mode routing, passed through to the dropdown)
- [x] `pnpm --filter @fiscozen/card-list build` — vue-tsc + vite green
- [ ] Manual: in Storybook (or a consumer app) pass an `actions` array with a `{ type: 'section', label: 'Scarica' }` marker and verify the dropdown renders the group header in the expected position

## Changeset
Included a minor bump for `@fiscozen/card-list` (additive, no breaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)