### PR TITLE
fix(dropdown): close on trigger re-tap and prevent menu jumping to top-left

### DIFF
--- a/.changeset/fix-mobile-dropdown-close-and-position.md
+++ b/.changeset/fix-mobile-dropdown-close-and-position.md
@@ -1,0 +1,6 @@
+---
+"@fiscozen/composables": patch
+"@fiscozen/dropdown": patch
+---
+
+Fix mobile dropdown menu issues: tapping the icon dropdown trigger again now closes the menu (it previously only ever re-opened it), and the floating menu no longer jumps to the top-left corner when its opener becomes hidden (e.g. an accordion collapses while the menu is still open).

--- a/apps/storybook/src/stories/navigation/IconDropdown.stories.ts
+++ b/apps/storybook/src/stories/navigation/IconDropdown.stories.ts
@@ -414,4 +414,85 @@ export const WithCustomActionListSlot: Story = {
   }
 }
 
+/**
+ * Regression: re-tapping the trigger must close the menu.
+ * The icon opener used to only ever call open(), so a second tap could not close it.
+ */
+export const ClosesOnTriggerRetap: Story = {
+  args: {
+    iconName: 'ellipsis-vertical',
+    'onUpdate:isOpen': fn()
+  },
+  render: (args) => ({
+    components: { FzIconDropdown },
+    setup: () => ({ args }),
+    template: `<FzIconDropdown v-bind="args" @update:isOpen="args['onUpdate:isOpen']" />`
+  }),
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const parentCanvas = within(canvasElement.parentElement!)
+    const trigger = canvas.getByRole('button')
+
+    await step('First tap opens the menu', async () => {
+      await userEvent.click(trigger)
+      await expect(args['onUpdate:isOpen']).toHaveBeenLastCalledWith(true)
+      await waitFor(async () => {
+        await expect(parentCanvas.getByText('This is a action')).toBeVisible()
+      })
+    })
+
+    await step('Second tap on the trigger closes the menu', async () => {
+      await userEvent.click(trigger)
+      await expect(args['onUpdate:isOpen']).toHaveBeenLastCalledWith(false)
+      await waitFor(async () => {
+        await expect(parentCanvas.queryByText('This is a action')).not.toBeVisible()
+      })
+    })
+  }
+}
+
+/**
+ * Regression: when the opener becomes hidden while the menu is open (e.g. an accordion
+ * section collapses), the floating menu must hide — not jump to the viewport's top-left
+ * corner. On a desktop browser an outside-click would normally close the menu first, so
+ * here we collapse the opener's container directly (the iOS case where that click does
+ * not fire) and trigger a reposition.
+ */
+export const HiddenWhenOpenerCollapses: Story = {
+  args: {
+    iconName: 'ellipsis-vertical'
+  },
+  render: (args) => ({
+    components: { FzIconDropdown },
+    setup: () => ({ args }),
+    template: `
+      <div data-testid="accordion-content" class="border border-grey-200 rounded p-4">
+        <FzIconDropdown v-bind="args" />
+      </div>
+    `
+  }),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const parentCanvas = within(canvasElement.parentElement!)
+    const trigger = canvas.getByRole('button')
+
+    await step('Open the menu inside the accordion section', async () => {
+      await userEvent.click(trigger)
+      await waitFor(async () => {
+        await expect(parentCanvas.getByText('This is a action')).toBeVisible()
+      })
+    })
+
+    await step('Collapsing the section hides the menu instead of parking it top-left', async () => {
+      const accordion = canvas.getByTestId('accordion-content')
+      accordion.style.display = 'none'
+      window.dispatchEvent(new Event('resize'))
+
+      await waitFor(async () => {
+        await expect(parentCanvas.queryByText('This is a action')).not.toBeVisible()
+      })
+    })
+  }
+}
+
 export default meta

--- a/packages/composables/src/__tests__/useFloating.spec.ts
+++ b/packages/composables/src/__tests__/useFloating.spec.ts
@@ -343,4 +343,36 @@ describe('useFloating', () => {
       expect(mockIntersectionObserver).toHaveBeenCalled()
     })
   })
+
+  describe('collapsed opener', () => {
+    it('should hide the element when the opener has a zero-size rect', async () => {
+      // Simulate the opener living inside a collapsed accordion: a hidden element
+      // reports an all-zero bounding rect.
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 0,
+        height: 0,
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('bottom'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) },
+        container: { domRef: ref(mockContainer) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      // Must NOT jump to the top-left corner; the floating content is hidden instead.
+      expect(mockElement.style.display).toBe('none')
+    })
+  })
 })

--- a/packages/composables/src/composables/useFloating.ts
+++ b/packages/composables/src/composables/useFloating.ts
@@ -115,6 +115,12 @@ const getMargins = (style: CSSStyleDeclaration): Margins => ({
   bottom: parseFloat(style.marginBottom)
 })
 
+// An element hidden via display:none (e.g. an opener inside a collapsed accordion)
+// reports an all-zero bounding rect. Anchoring to it would place the floating content
+// at the viewport's top-left corner, so a zero-size opener is treated as not positionable.
+const isRectPositionable = (rect: DOMRect | null): boolean =>
+  rect !== null && (rect.width > 0 || rect.height > 0)
+
 // ============================================================================
 // Position Calculators WITH Opener - Lookup Table
 // Each calculator receives opener rect and element margins for consistent spacing
@@ -516,6 +522,14 @@ export const useFloating = (
       rect.value = rects.element
       openerRect.value = rects.opener ?? undefined
       containerRect.value = rects.container
+
+      // Step 4b: If an opener is expected but currently hidden (zero-size rect, e.g. its
+      // accordion collapsed while the floating was still open), don't anchor to (0,0) and
+      // jump to the top-left corner — hide the floating content instead.
+      if (refs.opener && !isRectPositionable(rects.opener)) {
+        refs.element.style.display = 'none'
+        return
+      }
 
       // Step 5: Setup observers
       floatObserver.value.observe(refs.element)

--- a/packages/dropdown/src/FzIconDropdown.vue
+++ b/packages/dropdown/src/FzIconDropdown.vue
@@ -5,10 +5,10 @@
     @fzaction:click="(...args) => emit('fzaction:click', ...args)"
     :environment="mappedSizeToEnvironment"
   >
-    <template #opener="{ open }">
+    <template #opener="{ isOpen, open, close }">
       <FzIconButton
         :iconName="iconName"
-        @click.stop="open()"
+        @click.stop="isOpen ? close() : open()"
         :variant="buttonVariant"
         :disabled="disabled"
         :environment="mappedSizeToEnvironment"

--- a/packages/dropdown/src/__tests__/FzDropdown.spec.ts
+++ b/packages/dropdown/src/__tests__/FzDropdown.spec.ts
@@ -1282,6 +1282,25 @@ describe('FzIconDropdown', () => {
       // The dropdown should now be open (isOpen will be true after click)
       expect(updatedDropdown.exists()).toBe(true)
     })
+
+    it('should close when the icon button is clicked a second time', async () => {
+      const wrapper = mount(FzIconDropdown, {
+        props: {
+          actions: []
+        }
+      })
+
+      const floating = wrapper.findComponent({ name: 'FzFloating' })
+      const button = wrapper.find('button')
+
+      await button.trigger('click')
+      await wrapper.vm.$nextTick()
+      expect(floating.props('isOpen')).toBe(true)
+
+      await button.trigger('click')
+      await wrapper.vm.$nextTick()
+      expect(floating.props('isOpen')).toBe(false)
+    })
   })
 
   // ============================================


### PR DESCRIPTION
## Summary

Fixes two mobile (iOS) bugs seen on the Fiscozen frontoffice invoices list, both rooted in the floating dropdown menu:

- **`FzIconDropdown` could not be closed by re-tapping its trigger.** The icon opener only ever called `open()` (and `@click.stop` blocks the click-outside handler), so a second tap never closed the menu. It now toggles (`isOpen ? close() : open()`), matching the base `FzDropdown` opener.
- **The open menu jumped to the viewport's top-left corner when its opener became hidden** (e.g. an accordion collapsing while the menu was still open). `useFloating.setPosition()` anchored to the opener's `getBoundingClientRect()`, which is all-zeros for a `display:none` element → `(0,0)`. It now treats a zero-size opener as not positionable and hides the floating content instead.

## Changes

- `packages/dropdown/src/FzIconDropdown.vue` — opener toggles instead of only opening.
- `packages/composables/src/composables/useFloating.ts` — `isRectPositionable()` guard; hide content when the opener has a zero-size rect.
- Tests added for both (RED→GREEN).
- Changeset: patch for `@fiscozen/composables` + `@fiscozen/dropdown`.

## Test plan

- [x] `@fiscozen/dropdown` unit tests — 71/71 (incl. new "closes on second click").
- [x] `@fiscozen/composables` unit tests — 77/77 (incl. new "hide on zero-size opener").
- [x] Full `nx run-many -t build` green and Storybook interaction tests pass (674/674) via the pre-push hook.
- [ ] Smoke-test on the iOS app after release: ⋮ menu on the invoices list closes on re-tap, and collapsing the "Fatture da inviare" accordion no longer parks the menu top-left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)