### PR TITLE
fix(FzSelect): preserve falsy option values (0, "") in v-model

### DIFF
--- a/.changeset/fz-select-falsy-model-values.md
+++ b/.changeset/fz-select-falsy-model-values.md
@@ -1,0 +1,15 @@
+---
+"@fiscozen/select": patch
+---
+
+fix(FzSelect): preserve falsy option values (`0`, `""`) in v-model
+
+The `selectedOption` computed short-circuited on `!model.value`, which is
+truthy for any falsy value. Selecting an option whose `value` is the
+number `0` or the empty string was therefore matched and emitted
+correctly but never reflected back: the opener kept showing the
+placeholder instead of the selected option label.
+
+Switched the guard to an explicit `undefined`/`null` check so only
+"no selection" short-circuits — actual option values pass through to
+`Array.prototype.find` and are matched by strict equality as before.

--- a/packages/select/src/FzSelect.vue
+++ b/packages/select/src/FzSelect.vue
@@ -361,7 +361,8 @@ const isInteractive = computed(() => !isDisabled.value && !isReadonly.value);
 // ============================================================================
 
 const selectedOption = computed(() => {
-  if (!props.options || !model.value) return undefined;
+  if (!props.options || model.value === undefined || model.value === null)
+    return undefined;
   return props.options.find(
     (option): option is FzSelectOptionProps =>
       isSelectableOption(option) && option.value === model.value,

--- a/packages/select/src/__tests__/FzSelect.spec.ts
+++ b/packages/select/src/__tests__/FzSelect.spec.ts
@@ -120,6 +120,137 @@ describe("FzSelect", () => {
     });
   });
 
+  describe("Falsy model values", () => {
+    it("displays selected option label when modelValue is 0 (number)", async () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: undefined,
+          placeholder: "Choose a number",
+          options: [
+            { value: 0, label: "Zero" },
+            { value: 1, label: "One" },
+          ],
+        },
+      });
+
+      await wrapper.setProps({ modelValue: 0 });
+
+      const opener = wrapper.find('button[test-id="fzselect-opener"]');
+      expect(opener.text()).toContain("Zero");
+      expect(opener.text()).not.toContain("Choose a number");
+    });
+
+    it("displays selected option label when modelValue is '' (empty string)", async () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: undefined,
+          placeholder: "Pick one",
+          options: [
+            { value: "", label: "None selected explicitly" },
+            { value: "a", label: "Alpha" },
+          ],
+        },
+      });
+
+      await wrapper.setProps({ modelValue: "" });
+
+      const opener = wrapper.find('button[test-id="fzselect-opener"]');
+      expect(opener.text()).toContain("None selected explicitly");
+      expect(opener.text()).not.toContain("Pick one");
+    });
+
+    it("displays selected option label when modelValue is '0' (string) — regression guard", async () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: undefined,
+          options: [
+            { value: "0", label: "Zero string" },
+            { value: "1", label: "One string" },
+          ],
+        },
+      });
+
+      await wrapper.setProps({ modelValue: "0" });
+
+      const opener = wrapper.find('button[test-id="fzselect-opener"]');
+      expect(opener.text()).toContain("Zero string");
+    });
+
+    it("shows placeholder when modelValue is undefined", () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: undefined,
+          placeholder: "Choose a number",
+          options: [
+            { value: 0, label: "Zero" },
+            { value: 1, label: "One" },
+          ],
+        },
+      });
+
+      const opener = wrapper.find('button[test-id="fzselect-opener"]');
+      expect(opener.text()).toContain("Choose a number");
+      expect(opener.text()).not.toContain("Zero");
+    });
+
+    it("emits the falsy value when an option with value 0 is selected", async () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: undefined,
+          options: [
+            { value: 0, label: "Zero" },
+            { value: 1, label: "One" },
+          ],
+        },
+      });
+
+      await wrapper.find('button[test-id="fzselect-opener"]').trigger("click");
+      await wrapper.vm.$nextTick();
+
+      const zeroOption = Array.from(
+        document.querySelectorAll('button[role="option"]'),
+      ).find((el) => el.textContent?.includes("Zero")) as
+        | HTMLElement
+        | undefined;
+      expect(zeroOption).toBeDefined();
+      zeroOption!.click();
+      await wrapper.vm.$nextTick();
+
+      const updates = wrapper.emitted("update:modelValue");
+      expect(updates).toBeTruthy();
+      expect(updates![updates!.length - 1]).toEqual([0]);
+    });
+
+    it("clears the selection (back to undefined) when re-selecting the option with value 0", async () => {
+      const wrapper = mount(FzSelect, {
+        props: {
+          modelValue: 0,
+          clearable: true,
+          options: [
+            { value: 0, label: "Zero" },
+            { value: 1, label: "One" },
+          ],
+        },
+      });
+
+      await wrapper.find('button[test-id="fzselect-opener"]').trigger("click");
+      await wrapper.vm.$nextTick();
+
+      const zeroOption = Array.from(
+        document.querySelectorAll('button[role="option"]'),
+      ).find((el) => el.textContent?.includes("Zero")) as
+        | HTMLElement
+        | undefined;
+      expect(zeroOption).toBeDefined();
+      zeroOption!.click();
+      await wrapper.vm.$nextTick();
+
+      const updates = wrapper.emitted("update:modelValue");
+      expect(updates).toBeTruthy();
+      expect(updates![updates!.length - 1]).toEqual([undefined]);
+    });
+  });
+
   describe("Environment Styling", () => {
     it("applies backoffice styling classes", () => {
       const wrapper = mount(FzSelect, {


### PR DESCRIPTION
## Sommario

- `selectedOption` in `FzSelect` cortocircuitava su `!model.value`, che è truthy per qualsiasi valore falsy. Le opzioni con `value` uguale al numero `0` o alla stringa vuota venivano selezionate ed emesse correttamente, ma l'opener continuava a mostrare il placeholder invece della label dell'opzione selezionata.
- Sostituito il guard con un check stretto su `undefined`/`null`, così solo "nessuna selezione" cortocircuita — i valori reali passano a `find()` e vengono confrontati con uguaglianza stretta come prima.
- Aggiunti 6 nuovi unit test che coprono display, emit e round-trip clearable per valori falsy, oltre a regression guard per `"0"` (stringa) e `undefined`.