### PR TITLE
chore(icons): bump @awesome.me/kit-8137893ad3 to ^1.0.419

### DIFF
--- a/.changeset/fa-kit-update-419.md
+++ b/.changeset/fa-kit-update-419.md
@@ -1,0 +1,5 @@
+---
+"@fiscozen/icons": patch
+---
+
+Update Font Awesome kit `@awesome.me/kit-8137893ad3` from `^1.0.418` to `^1.0.419`.

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -22,7 +22,7 @@
     "postinstall": "node scripts/postinstall-playwright.cjs"
   },
   "dependencies": {
-    "@awesome.me/kit-8137893ad3": "^1.0.418",
+    "@awesome.me/kit-8137893ad3": "^1.0.419",
     "@fiscozen/action": "workspace:^",
     "@fiscozen/actionlist": "workspace:^",
     "@fiscozen/alert": "workspace:^",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -38,7 +38,7 @@
     "vue-tsc": "^2.2.12"
   },
   "dependencies": {
-    "@awesome.me/kit-8137893ad3": "^1.0.418",
+    "@awesome.me/kit-8137893ad3": "^1.0.419",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/vue-fontawesome": "^3.1.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
   apps/storybook:
     dependencies:
       '@awesome.me/kit-8137893ad3':
-        specifier: ^1.0.418
-        version: 1.0.418
+        specifier: ^1.0.419
+        version: 1.0.419
       '@fiscozen/action':
         specifier: workspace:^
         version: link:../../packages/action
@@ -1861,8 +1861,8 @@ importers:
   packages/icons:
     dependencies:
       '@awesome.me/kit-8137893ad3':
-        specifier: ^1.0.418
-        version: 1.0.418
+        specifier: ^1.0.419
+        version: 1.0.419
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.7.2
         version: 6.7.2
@@ -3630,8 +3630,8 @@ packages:
   '@asamuzakjp/dom-selector@2.0.2':
     resolution: {integrity: sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==}
 
-  '@awesome.me/kit-8137893ad3@1.0.418':
-    resolution: {integrity: sha512-AFzhEnP9LntpXCYlFzk/FrIYroqQRL1UJsXygXF9q+LiF+gJwfqoFMruQIRaolzRlHVOV6v+vYhpHvGyhpxzLA==}
+  '@awesome.me/kit-8137893ad3@1.0.419':
+    resolution: {integrity: sha512-dQybbTB/QW26NaCe3G2N8iwdtc63ZnUR3jsr7e+DzK6ebpAMqHm2WWJT+R1kp9Y94kjnlWKBWCYXkEJEZT0OsA==}
     engines: {node: '>=16'}
 
   '@babel/code-frame@7.29.0':
@@ -8992,7 +8992,7 @@ snapshots:
       css-tree: 2.3.1
       is-potential-custom-element-name: 1.0.1
 
-  '@awesome.me/kit-8137893ad3@1.0.418':
+  '@awesome.me/kit-8137893ad3@1.0.419':
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
 


### PR DESCRIPTION
## Summary
- Bump Font Awesome kit `@awesome.me/kit-8137893ad3` from `^1.0.418` to `^1.0.419` (latest available on npm) in `@fiscozen/icons` and the Storybook app
- Adds a `patch` changeset for `@fiscozen/icons`

## Test plan
- [x] `pnpm install` resolves cleanly to `1.0.419`
- [x] Pre-push hook passes (affected unit tests + storybook play tests: 741 passed)
- [ ] Spot-check icons in Storybook after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)