### PR TITLE
fix(card): apply explicit border-0 on header/footer

### DIFF
--- a/.changeset/card-explicit-border-0-header-footer.md
+++ b/.changeset/card-explicit-border-0-header-footer.md
@@ -2,6 +2,6 @@
 '@fiscozen/card': patch
 ---
 
-`FzCard` ora applica `border-0` esplicito su header e footer di default.
-Risolve i casi in cui consumer che mescolano Tailwind senza preflight + Bootstrap reboot vedevano un bordo non voluto perché il template applicava `border-solid` solitario (border-style senza width → fallback UA `border-width: medium`).
-Le variant con bordo continuano a funzionare invariate.
+`FzCard` now applies an explicit `border-0` on the header and footer by default.
+Fixes cases where consumers mixing Tailwind without preflight + Bootstrap reboot saw an unwanted border because the template applied a lone `border-solid` (border-style without width → UA fallback `border-width: medium`).
+Variants with a border keep working unchanged.

--- a/.changeset/card-explicit-border-0-header-footer.md
+++ b/.changeset/card-explicit-border-0-header-footer.md
@@ -1,0 +1,7 @@
+---
+'@fiscozen/card': patch
+---
+
+`FzCard` ora applica `border-0` esplicito su header e footer di default.
+Risolve i casi in cui consumer che mescolano Tailwind senza preflight + Bootstrap reboot vedevano un bordo non voluto perché il template applicava `border-solid` solitario (border-style senza width → fallback UA `border-width: medium`).
+Le variant con bordo continuano a funzionare invariate.

--- a/packages/card/src/FzCard.vue
+++ b/packages/card/src/FzCard.vue
@@ -78,9 +78,9 @@ const normalizedColor = computed(() => {
 
 const sectionStaticClass = "border-1 border-solid rounded flex flex-col";
 const headerStaticClass =
-  "border-solid pt-16 px-16 flex flex-row justify-between";
+  "border-0 border-solid pt-16 px-16 flex flex-row justify-between";
 const footerStaticClass =
-  "border-solid pt-0 px-16 pb-16 flex gap-12 items-center";
+  "border-0 border-solid pt-0 px-16 pb-16 flex gap-12 items-center";
 
 const showContent = computed(() => isOpen.value || !props.collapsible);
 const isAlive = computed(() => props.alwaysAlive || showContent.value);

--- a/packages/card/src/__tests__/FzCard.spec.ts
+++ b/packages/card/src/__tests__/FzCard.spec.ts
@@ -160,7 +160,9 @@ describe("FzCard", () => {
       });
 
       it("should map deprecated aliceblue to blue and show warning", async () => {
-        const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const consoleSpy = vi
+          .spyOn(console, "warn")
+          .mockImplementation(() => {});
 
         const wrapper = mount(FzCard, {
           props: {
@@ -373,7 +375,9 @@ describe("FzCard", () => {
           },
         });
         await wrapper.vm.$nextTick();
-        expect(wrapper.find("article").classes()).toContain("custom-content-class");
+        expect(wrapper.find("article").classes()).toContain(
+          "custom-content-class",
+        );
       });
     });
   });
@@ -642,7 +646,9 @@ describe("FzCard", () => {
         },
       });
       await wrapper.vm.$nextTick();
-      expect(wrapper.find("section").classes()).toContain("bg-background-alice-blue");
+      expect(wrapper.find("section").classes()).toContain(
+        "bg-background-alice-blue",
+      );
     });
 
     it.each([
@@ -696,6 +702,21 @@ describe("FzCard", () => {
       });
       await wrapper.vm.$nextTick();
       expect(wrapper.find("article").classes()).toContain("custom-class");
+    });
+
+    it("should apply explicit border-0 to header and footer so no border renders without preflight", async () => {
+      const wrapper = mount(FzCard, {
+        props: {
+          title: "Test Card",
+          primaryAction: { label: "Save" },
+        },
+      });
+      await wrapper.vm.$nextTick();
+      // header inner div and footer pair border-solid with an explicit
+      // border-0 baseline; without it, hosts lacking Tailwind preflight
+      // (e.g. Bootstrap reboot) render an unwanted ~medium border.
+      expect(wrapper.find("header > div").classes()).toContain("border-0");
+      expect(wrapper.find("footer").classes()).toContain("border-0");
     });
   });
 
@@ -896,4 +917,3 @@ describe("FzCard", () => {
     });
   });
 });
-

--- a/packages/card/src/__tests__/__snapshots__/FzCard.spec.ts.snap
+++ b/packages/card/src/__tests__/__snapshots__/FzCard.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`FzCard > Snapshots > should match snapshot - backoffice environment 1`] = `
 "<section class="border-1 border-solid rounded flex flex-col bg-core-white text-core-black border-grey-100">
   <header class="">
-    <div class="border-solid pt-16 px-16 flex flex-row justify-between">
+    <div class="border-0 border-solid pt-16 px-16 flex flex-row justify-between">
       <div class="flex flex-row gap-12 items-start py-2">
         <h2 class="text-core-black font-medium text-xl m-0 p-0 break-words overflow-wrap-anywhere min-w-0 flex-shrink" title="Test Card">Test Card</h2>
       </div>
@@ -14,7 +14,7 @@ exports[`FzCard > Snapshots > should match snapshot - backoffice environment 1`]
     </div>
   </header>
   <article class="p-16"></article>
-  <footer class="border-solid pt-0 px-16 pb-16 flex gap-12 items-center justify-end">
+  <footer class="border-0 border-solid pt-0 px-16 pb-16 flex gap-12 items-center justify-end">
     <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default">
       <!--v-if-->
       <!--v-if--><button type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-32 px-12 min-w-96 bg-blue-500 text-core-white hover:bg-blue-600 focus:bg-blue-500 focus:!border-blue-600 disabled:bg-blue-200">
@@ -30,7 +30,7 @@ exports[`FzCard > Snapshots > should match snapshot - backoffice environment 1`]
 exports[`FzCard > Snapshots > should match snapshot - collapsible 1`] = `
 "<section class="border-1 border-solid rounded flex flex-col bg-core-white text-core-black border-grey-100">
   <header class="cursor-pointer">
-    <div class="border-solid pt-16 px-16 flex flex-row justify-between">
+    <div class="border-0 border-solid pt-16 px-16 flex flex-row justify-between">
       <div class="flex flex-row gap-12 items-start py-8">
         <h2 class="text-core-black font-medium text-xl m-0 p-0 break-words overflow-wrap-anywhere min-w-0 flex-shrink" title="Test Card">Test Card</h2>
       </div>
@@ -51,7 +51,7 @@ exports[`FzCard > Snapshots > should match snapshot - collapsible 1`] = `
 exports[`FzCard > Snapshots > should match snapshot - default state 1`] = `
 "<section class="border-1 border-solid rounded flex flex-col bg-core-white text-core-black border-grey-100">
   <header class="">
-    <div class="border-solid pt-16 px-16 flex flex-row justify-between">
+    <div class="border-0 border-solid pt-16 px-16 flex flex-row justify-between">
       <div class="flex flex-row gap-12 items-start py-8">
         <h2 class="text-core-black font-medium text-xl m-0 p-0 break-words overflow-wrap-anywhere min-w-0 flex-shrink" title="Test Card">Test Card</h2>
       </div>
@@ -69,7 +69,7 @@ exports[`FzCard > Snapshots > should match snapshot - default state 1`] = `
 exports[`FzCard > Snapshots > should match snapshot - with all actions 1`] = `
 "<section class="border-1 border-solid rounded flex flex-col bg-core-white text-core-black border-grey-100">
   <header class="">
-    <div class="border-solid pt-16 px-16 flex flex-row justify-between">
+    <div class="border-0 border-solid pt-16 px-16 flex flex-row justify-between">
       <div class="flex flex-row gap-12 items-start py-8">
         <h2 class="text-core-black font-medium text-xl m-0 p-0 break-words overflow-wrap-anywhere min-w-0 flex-shrink" title="Test Card">Test Card</h2>
       </div>
@@ -80,7 +80,7 @@ exports[`FzCard > Snapshots > should match snapshot - with all actions 1`] = `
     </div>
   </header>
   <article class="p-16"></article>
-  <footer class="border-solid pt-0 px-16 pb-16 flex gap-12 items-center justify-end">
+  <footer class="border-0 border-solid pt-0 px-16 pb-16 flex gap-12 items-center justify-end">
     <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-default"><span data-v-8090b1b6="" class="fz-icon-button-wrapper relative fz-icon-button-wrapper--frontoffice"><button data-v-8090b1b6="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-transparent text-grey-500 !border-transparent hover:bg-grey-100 hover:!border-grey-100 focus:bg-transparent focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200" aria-label=""><div class="flex items-center justify-items-center"><span role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px]"><svg class="svg-inline--fa fa-bell h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="bell" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path class="" fill="currentColor" d="M224 0c-17.7 0-32 14.3-32 32l0 19.2C119 66 64 130.6 64 208l0 25.4c0 45.4-15.5 89.5-43.8 124.9L5.3 377c-5.8 7.2-6.9 17.1-2.9 25.4S14.8 416 24 416l400 0c9.2 0 17.6-5.3 21.6-13.6s2.9-18.2-2.9-25.4l-14.9-18.6C399.5 322.9 384 278.8 384 233.4l0-25.4c0-77.4-55-142-128-156.8L256 32c0-17.7-14.3-32-32-32zm0 96c61.9 0 112 50.1 112 112l0 25.4c0 47.9 13.9 94.6 39.7 134.6L72.3 368C98.1 328 112 281.3 112 233.4l0-25.4c0-61.9 50.1-112 112-112zm64 352l-64 0-64 0c0 17 6.7 33.3 18.7 45.3s28.3 18.7 45.3 18.7s33.3-6.7 45.3-18.7s18.7-28.3 18.7-45.3z"></path></svg></span></div>
     <!--v-if-->
     <!--v-if--></button>
@@ -100,7 +100,7 @@ exports[`FzCard > Snapshots > should match snapshot - with all actions 1`] = `
 exports[`FzCard > Snapshots > should match snapshot - with all color variants 1`] = `
 "<section class="border-1 border-solid rounded flex flex-col bg-background-alice-blue text-core-black border-background-alice-blue">
   <header class="">
-    <div class="border-solid pt-16 px-16 flex flex-row justify-between">
+    <div class="border-0 border-solid pt-16 px-16 flex flex-row justify-between">
       <div class="flex flex-row gap-12 items-start py-8">
         <h2 class="text-core-black font-medium text-xl m-0 p-0 break-words overflow-wrap-anywhere min-w-0 flex-shrink" title="Test Card">Test Card</h2>
       </div>
@@ -118,7 +118,7 @@ exports[`FzCard > Snapshots > should match snapshot - with all color variants 1`
 exports[`FzCard > Snapshots > should match snapshot - with info icon 1`] = `
 "<section class="border-1 border-solid rounded flex flex-col bg-core-white text-core-black border-grey-100">
   <header class="">
-    <div class="border-solid pt-16 px-16 flex flex-row justify-between">
+    <div class="border-0 border-solid pt-16 px-16 flex flex-row justify-between">
       <div class="flex flex-row gap-12 items-start py-8">
         <h2 class="text-core-black font-medium text-xl m-0 p-0 break-words overflow-wrap-anywhere min-w-0 flex-shrink" title="Test Card">Test Card</h2>
       </div>


### PR DESCRIPTION
## Cosa abbiamo fatto

`FzCard` applicava `border-solid` solitario (solo border-style, senza width) su header-inner-div e footer, affidandosi al preflight di Tailwind dell'host per azzerare `border-width`. In host che limitano/omettono il preflight (es. Bootstrap reboot in `it-fiscozen-app`) scatta il fallback UA `border-width: medium` → bordo non voluto.

Aggiunto `border-0` esplicito accanto a `border-solid` su entrambi, così il componente non dipende più dal preflight dell'host. Variant con bordo invariate.

- Test di lock-in (`border-0` su header/footer) + snapshot aggiornati → 71/71 pass nel package.
- Changeset `patch`.

## Cosa resta da fare in app per chiudere il task

Dopo il publish di `@fiscozen/card`:

1. Bump caret di `@fiscozen/card` in `frontoffice/package.json` e `backoffice/package.json`.
2. Droppare lo shim `vue_common/src/scss/fz-ds/_fz-card.scss` (intero) e rimuovere `@import './fz-card';` da `vue_common/src/scss/fz-ds/_main.scss`.
3. Smoke su 2 pagine con `<FzCard>` (BO + FO): nessun bordo grigio/nero su header/footer senza variant.
4. `npm run lint-fix`.