### PR TITLE
fix(checkbox): self-contained text color and label spacing

### DIFF
--- a/.changeset/checkbox-self-contained-typography.md
+++ b/.changeset/checkbox-self-contained-typography.md
@@ -1,0 +1,7 @@
+---
+'@fiscozen/checkbox': patch
+---
+
+`FzCheckbox` and `FzCheckboxGroup` now set `text-core-black` on their root container and `mb-0` on their inner `<label>` as a baseline.
+This makes the components environment-agnostic: hosts with Bootstrap reboot but without global Tailwind preflight no longer leak `body { color }` into descendant text, nor `label { margin-bottom: 0.5rem }` into the label spacing.
+No changes to the public props.

--- a/packages/checkbox/src/FzCheckbox.vue
+++ b/packages/checkbox/src/FzCheckbox.vue
@@ -135,7 +135,7 @@ const staticInputClass: string = "w-0 h-0 peer fz-hidden-input";
  * Items aligned to start (top) for proper alignment with long multi-line labels.
  */
 const staticLabelClass: string = `
-  flex gap-6 items-start hover:cursor-pointer text-core-black
+  flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&_div]:after:border-1
   peer-focus:[&_div]:after:border-solid
   peer-focus:[&_div]:after:rounded-[2px]
@@ -297,7 +297,7 @@ onMounted(() => {
 
 <template>
   <!-- Root container: vertical layout with consistent spacing -->
-  <div class="flex justify-center flex-col w-fit gap-4">
+  <div class="flex justify-center flex-col w-fit gap-4 text-core-black">
     <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
     <!-- Hover effects are handled in CSS using data attributes -->
     <div

--- a/packages/checkbox/src/FzCheckboxGroup.vue
+++ b/packages/checkbox/src/FzCheckboxGroup.vue
@@ -85,10 +85,10 @@ const checkedSet = computed(() => new Set(model.value));
 provide(CHECKED_SET_KEY, { source: model, set: checkedSet });
 
 /** Base layout for the label element */
-const staticLabeldClass: string = "flex flex-col";
+const staticLabeldClass: string = "flex flex-col mb-0";
 
 /** Base layout for the root container */
-const staticContainerClass: string = "flex flex-col gap-10";
+const staticContainerClass: string = "flex flex-col gap-10 text-core-black";
 
 /** Base layout for the checkboxes container */
 const staticSlotContainerClass: string = "flex self-stretch";

--- a/packages/checkbox/src/__tests__/FzCheckbox.spec.ts
+++ b/packages/checkbox/src/__tests__/FzCheckbox.spec.ts
@@ -520,6 +520,23 @@ describe("FzCheckbox", () => {
       expect(label.classes()).toContain("items-start");
     });
 
+    it("should be environment-agnostic: text-core-black on root and mb-0 on label", async () => {
+      const wrapper = mount(FzCheckbox, {
+        props: {
+          label: "Test Checkbox",
+          value: "test",
+          modelValue: false,
+        },
+      });
+      await wrapper.vm.$nextTick();
+      // text-core-black on the root container so descendant text does not
+      // inherit a host body color (e.g. Bootstrap `body { color: #212529 }`).
+      expect(wrapper.find("div").classes()).toContain("text-core-black");
+      // mb-0 on the label so it does not pick up Bootstrap reboot's
+      // `label { margin-bottom: 0.5rem }` in hosts without Tailwind preflight.
+      expect(wrapper.find("label").classes()).toContain("mb-0");
+    });
+
     it("should apply emphasis classes when emphasis prop is true", async () => {
       const wrapper = mount(FzCheckbox, {
         props: {

--- a/packages/checkbox/src/__tests__/FzCheckboxGroup.spec.ts
+++ b/packages/checkbox/src/__tests__/FzCheckboxGroup.spec.ts
@@ -527,6 +527,23 @@ describe("FzCheckboxGroup", () => {
       expect(container.classes()).toContain("self-stretch");
     });
 
+    it("should be environment-agnostic: text-core-black on root and mb-0 on group label", async () => {
+      const wrapper = mount(FzCheckboxGroup, {
+        props: {
+          label: "Test Checkbox Group",
+          modelValue: [],
+          options: [{ label: "Option 1", value: "option1" }],
+        },
+      });
+      await wrapper.vm.$nextTick();
+      // text-core-black on the root container so descendant text does not
+      // inherit a host body color (e.g. Bootstrap `body { color: #212529 }`).
+      expect(wrapper.find("div").classes()).toContain("text-core-black");
+      // mb-0 on the group label so it does not pick up Bootstrap reboot's
+      // `label { margin-bottom: 0.5rem }` in hosts without Tailwind preflight.
+      expect(wrapper.find("label").classes()).toContain("mb-0");
+    });
+
     it("should apply horizontal layout classes when horizontal is true", async () => {
       const wrapper = mount(FzCheckboxGroup, {
         props: {

--- a/packages/checkbox/src/__tests__/__snapshots__/FzCheckbox.spec.ts.snap
+++ b/packages/checkbox/src/__tests__/__snapshots__/FzCheckbox.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`FzCheckbox > Snapshots > should match snapshot - checked state 1`] = `
 "<!-- Root container: vertical layout with consistent spacing -->
-<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
   <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
   <!-- Hover effects are handled in CSS using data attributes -->
   <div data-v-79ecb611="" class="flex items-start group">
@@ -15,7 +15,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - checked state 1`] = `
     <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -48,7 +48,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - checked state 1`] = `
 
 exports[`FzCheckbox > Snapshots > should match snapshot - default state 1`] = `
 "<!-- Root container: vertical layout with consistent spacing -->
-<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
   <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
   <!-- Hover effects are handled in CSS using data attributes -->
   <div data-v-79ecb611="" class="flex items-start group">
@@ -61,7 +61,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - default state 1`] = `
     <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -94,7 +94,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - default state 1`] = `
 
 exports[`FzCheckbox > Snapshots > should match snapshot - disabled state 1`] = `
 "<!-- Root container: vertical layout with consistent spacing -->
-<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
   <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
   <!-- Hover effects are handled in CSS using data attributes -->
   <div data-v-79ecb611="" class="flex items-start group" data-disabled="true">
@@ -107,7 +107,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - disabled state 1`] = `
     <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -140,7 +140,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - disabled state 1`] = `
 
 exports[`FzCheckbox > Snapshots > should match snapshot - error state 1`] = `
 "<!-- Root container: vertical layout with consistent spacing -->
-<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
   <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
   <!-- Hover effects are handled in CSS using data attributes -->
   <div data-v-79ecb611="" class="flex items-start group" data-error="true">
@@ -153,7 +153,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - error state 1`] = `
     <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -210,7 +210,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - error state 1`] = `
 
 exports[`FzCheckbox > Snapshots > should match snapshot - indeterminate state 1`] = `
 "<!-- Root container: vertical layout with consistent spacing -->
-<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
   <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
   <!-- Hover effects are handled in CSS using data attributes -->
   <div data-v-79ecb611="" class="flex items-start group">
@@ -223,7 +223,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - indeterminate state 1`
     <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -256,7 +256,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - indeterminate state 1`
 
 exports[`FzCheckbox > Snapshots > should match snapshot - required 1`] = `
 "<!-- Root container: vertical layout with consistent spacing -->
-<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
   <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
   <!-- Hover effects are handled in CSS using data attributes -->
   <div data-v-79ecb611="" class="flex items-start group">
@@ -269,7 +269,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - required 1`] = `
     <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -302,7 +302,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - required 1`] = `
 
 exports[`FzCheckbox > Snapshots > should match snapshot - standalone mode 1`] = `
 "<!-- Root container: vertical layout with consistent spacing -->
-<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
   <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
   <!-- Hover effects are handled in CSS using data attributes -->
   <div data-v-79ecb611="" class="flex items-start group">
@@ -315,7 +315,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - standalone mode 1`] = 
     <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -349,7 +349,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - standalone mode 1`] = 
 
 exports[`FzCheckbox > Snapshots > should match snapshot - with emphasis 1`] = `
 "<!-- Root container: vertical layout with consistent spacing -->
-<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+<div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
   <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
   <!-- Hover effects are handled in CSS using data attributes -->
   <div data-v-79ecb611="" class="flex items-start group" data-emphasis="true">
@@ -362,7 +362,7 @@ exports[`FzCheckbox > Snapshots > should match snapshot - with emphasis 1`] = `
     <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]

--- a/packages/checkbox/src/__tests__/__snapshots__/FzCheckboxGroup.spec.ts.snap
+++ b/packages/checkbox/src/__tests__/__snapshots__/FzCheckboxGroup.spec.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`FzCheckboxGroup > Snapshots > should match snapshot - default state 1`] = `
 "<!-- Root container for the entire checkbox group -->
-<div class="flex flex-col gap-10 text-base">
+<div class="flex flex-col gap-10 text-core-black text-base">
   <!-- 
       Group label with optional required indicator and help text
       Connected to checkbox group via aria-labelledby
-    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col text-base gap-6 text-core-black">
+    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col mb-0 text-base gap-6 text-core-black">
     <!-- Main label text with required asterisk if applicable --><span>Test Checkbox Group<!--v-if--></span><!-- Optional help text slot for additional context -->
     <!--v-if-->
   </label>
@@ -31,7 +31,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - default state 1`]
     - Change event cascades selection to all children
   -->
     <!-- Root container: vertical layout with consistent spacing -->
-    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
       <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
       <!-- Hover effects are handled in CSS using data attributes -->
       <div data-v-79ecb611="" class="flex items-start group">
@@ -44,7 +44,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - default state 1`]
         <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -80,7 +80,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - default state 1`]
     - Change event cascades selection to all children
   -->
     <!-- Root container: vertical layout with consistent spacing -->
-    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
       <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
       <!-- Hover effects are handled in CSS using data attributes -->
       <div data-v-79ecb611="" class="flex items-start group">
@@ -93,7 +93,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - default state 1`]
         <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000006-8d7ea-label" for="fz-checkbox-100000000006-8d7ea" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000006-8d7ea-label" for="fz-checkbox-100000000006-8d7ea" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -129,11 +129,11 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - default state 1`]
 
 exports[`FzCheckboxGroup > Snapshots > should match snapshot - disabled 1`] = `
 "<!-- Root container for the entire checkbox group -->
-<div class="flex flex-col gap-10 text-base">
+<div class="flex flex-col gap-10 text-core-black text-base">
   <!-- 
       Group label with optional required indicator and help text
       Connected to checkbox group via aria-labelledby
-    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col text-base gap-6 text-grey-400">
+    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col mb-0 text-base gap-6 text-grey-400">
     <!-- Main label text with required asterisk if applicable --><span>Test Checkbox Group<!--v-if--></span><!-- Optional help text slot for additional context -->
     <!--v-if-->
   </label>
@@ -158,7 +158,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - disabled 1`] = `
     - Change event cascades selection to all children
   -->
     <!-- Root container: vertical layout with consistent spacing -->
-    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
       <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
       <!-- Hover effects are handled in CSS using data attributes -->
       <div data-v-79ecb611="" class="flex items-start group" data-disabled="true">
@@ -171,7 +171,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - disabled 1`] = `
         <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -207,11 +207,11 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - disabled 1`] = `
 
 exports[`FzCheckboxGroup > Snapshots > should match snapshot - hierarchical structure 1`] = `
 "<!-- Root container for the entire checkbox group -->
-<div class="flex flex-col gap-10 text-base">
+<div class="flex flex-col gap-10 text-core-black text-base">
   <!-- 
       Group label with optional required indicator and help text
       Connected to checkbox group via aria-labelledby
-    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col text-base gap-6 text-core-black">
+    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col mb-0 text-base gap-6 text-core-black">
     <!-- Main label text with required asterisk if applicable --><span>Test Checkbox Group<!--v-if--></span><!-- Optional help text slot for additional context -->
     <!--v-if-->
   </label>
@@ -236,7 +236,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - hierarchical stru
     - Change event cascades selection to all children
   -->
     <!-- Root container: vertical layout with consistent spacing -->
-    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
       <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
       <!-- Hover effects are handled in CSS using data attributes -->
       <div data-v-79ecb611="" class="flex items-start group">
@@ -249,7 +249,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - hierarchical stru
         <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -286,7 +286,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - hierarchical stru
           - Share same v-model array with parent and siblings
         -->
         <!-- Root container: vertical layout with consistent spacing -->
-        <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+        <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
           <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
           <!-- Hover effects are handled in CSS using data attributes -->
           <div data-v-79ecb611="" class="flex items-start group">
@@ -299,7 +299,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - hierarchical stru
             <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000002-22ql0-child-0-label" for="fz-checkbox-100000000002-22ql0-child-0" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000002-22ql0-child-0-label" for="fz-checkbox-100000000002-22ql0-child-0" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -328,7 +328,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - hierarchical stru
       Used by FzCheckboxGroupOption to render child checkboxes
     -->
         </div><!-- Root container: vertical layout with consistent spacing -->
-        <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+        <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
           <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
           <!-- Hover effects are handled in CSS using data attributes -->
           <div data-v-79ecb611="" class="flex items-start group">
@@ -341,7 +341,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - hierarchical stru
             <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000002-22ql0-child-1-label" for="fz-checkbox-100000000002-22ql0-child-1" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000002-22ql0-child-1-label" for="fz-checkbox-100000000002-22ql0-child-1" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -379,11 +379,11 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - hierarchical stru
 
 exports[`FzCheckboxGroup > Snapshots > should match snapshot - horizontal layout 1`] = `
 "<!-- Root container for the entire checkbox group -->
-<div class="flex flex-col gap-10 text-base">
+<div class="flex flex-col gap-10 text-core-black text-base">
   <!-- 
       Group label with optional required indicator and help text
       Connected to checkbox group via aria-labelledby
-    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col text-base gap-6 text-core-black">
+    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col mb-0 text-base gap-6 text-core-black">
     <!-- Main label text with required asterisk if applicable --><span>Test Checkbox Group<!--v-if--></span><!-- Optional help text slot for additional context -->
     <!--v-if-->
   </label>
@@ -408,7 +408,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - horizontal layout
     - Change event cascades selection to all children
   -->
     <!-- Root container: vertical layout with consistent spacing -->
-    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
       <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
       <!-- Hover effects are handled in CSS using data attributes -->
       <div data-v-79ecb611="" class="flex items-start group">
@@ -421,7 +421,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - horizontal layout
         <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -457,7 +457,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - horizontal layout
     - Change event cascades selection to all children
   -->
     <!-- Root container: vertical layout with consistent spacing -->
-    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
       <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
       <!-- Hover effects are handled in CSS using data attributes -->
       <div data-v-79ecb611="" class="flex items-start group">
@@ -470,7 +470,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - horizontal layout
         <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000006-8d7ea-label" for="fz-checkbox-100000000006-8d7ea" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000006-8d7ea-label" for="fz-checkbox-100000000006-8d7ea" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -506,11 +506,11 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - horizontal layout
 
 exports[`FzCheckboxGroup > Snapshots > should match snapshot - required 1`] = `
 "<!-- Root container for the entire checkbox group -->
-<div class="flex flex-col gap-10 text-base">
+<div class="flex flex-col gap-10 text-core-black text-base">
   <!-- 
       Group label with optional required indicator and help text
       Connected to checkbox group via aria-labelledby
-    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col text-base gap-6 text-core-black">
+    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col mb-0 text-base gap-6 text-core-black">
     <!-- Main label text with required asterisk if applicable --><span>Test Checkbox Group<span> *</span></span><!-- Optional help text slot for additional context -->
     <!--v-if-->
   </label>
@@ -535,7 +535,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - required 1`] = `
     - Change event cascades selection to all children
   -->
     <!-- Root container: vertical layout with consistent spacing -->
-    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
       <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
       <!-- Hover effects are handled in CSS using data attributes -->
       <div data-v-79ecb611="" class="flex items-start group">
@@ -548,7 +548,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - required 1`] = `
         <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -584,11 +584,11 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - required 1`] = `
 
 exports[`FzCheckboxGroup > Snapshots > should match snapshot - with error 1`] = `
 "<!-- Root container for the entire checkbox group -->
-<div class="flex flex-col gap-10 text-base">
+<div class="flex flex-col gap-10 text-core-black text-base">
   <!-- 
       Group label with optional required indicator and help text
       Connected to checkbox group via aria-labelledby
-    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col text-base gap-6 text-core-black">
+    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col mb-0 text-base gap-6 text-core-black">
     <!-- Main label text with required asterisk if applicable --><span>Test Checkbox Group<!--v-if--></span><!-- Optional help text slot for additional context -->
     <!--v-if-->
   </label>
@@ -613,7 +613,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - with error 1`] = 
     - Change event cascades selection to all children
   -->
     <!-- Root container: vertical layout with consistent spacing -->
-    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
       <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
       <!-- Hover effects are handled in CSS using data attributes -->
       <div data-v-79ecb611="" class="flex items-start group" data-error="true">
@@ -626,7 +626,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - with error 1`] = 
         <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -686,11 +686,11 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - with error 1`] = 
 
 exports[`FzCheckboxGroup > Snapshots > should match snapshot - with help text 1`] = `
 "<!-- Root container for the entire checkbox group -->
-<div class="flex flex-col gap-10 text-base">
+<div class="flex flex-col gap-10 text-core-black text-base">
   <!-- 
       Group label with optional required indicator and help text
       Connected to checkbox group via aria-labelledby
-    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col text-base gap-6 text-core-black">
+    --><label id="fz-checkbox-group-100000000001-2a84k-label" class="flex flex-col mb-0 text-base gap-6 text-core-black">
     <!-- Main label text with required asterisk if applicable --><span>Test Checkbox Group<!--v-if--></span><!-- Optional help text slot for additional context -->
     <p id="fz-checkbox-group-100000000001-2a84k-help" class="text-sm text-grey-500">This is help text</p>
   </label>
@@ -715,7 +715,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - with help text 1`
     - Change event cascades selection to all children
   -->
     <!-- Root container: vertical layout with consistent spacing -->
-    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4">
+    <div data-v-79ecb611="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
       <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
       <!-- Hover effects are handled in CSS using data attributes -->
       <div data-v-79ecb611="" class="flex items-start group">
@@ -728,7 +728,7 @@ exports[`FzCheckboxGroup > Snapshots > should match snapshot - with help text 1`
         <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-79ecb611="" id="fz-checkbox-100000000003-2kdwy-label" for="fz-checkbox-100000000003-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]

--- a/packages/table/src/__tests__/__snapshots__/FzTable.spec.ts.snap
+++ b/packages/table/src/__tests__/__snapshots__/FzTable.spec.ts.snap
@@ -169,7 +169,7 @@ exports[`FzTable > Snapshots > should match snapshot - selectable variant 1`] = 
       <!--v-if-->
       <div class="fz__header__cell sticky top-0 z-[2] bg-grey-100 p-16 min-h-[52px] text-base flex items-center cursor-pointer text-grey-500 sticky left-0 z-[3] w-[36px] justify-center items-center">
         <!-- Root container: vertical layout with consistent spacing -->
-        <div data-v-2b014a17="" class="flex justify-center flex-col w-fit gap-4 fz__table__header--checkbox">
+        <div data-v-2b014a17="" class="flex justify-center flex-col w-fit gap-4 text-core-black fz__table__header--checkbox">
           <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
           <!-- Hover effects are handled in CSS using data attributes -->
           <div data-v-2b014a17="" class="flex items-start group" data-emphasis="true">
@@ -182,7 +182,7 @@ exports[`FzTable > Snapshots > should match snapshot - selectable variant 1`] = 
             <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-2b014a17="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-2b014a17="" id="fz-checkbox-100000000001-2a84k-label" for="fz-checkbox-100000000001-2a84k" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -223,7 +223,7 @@ exports[`FzTable > Snapshots > should match snapshot - selectable variant 1`] = 
         <!--v-if-->
         <div role="cell" class="w-[36px] fz__body z-[1] p-16 min-h-[52px] text-base flex items-start min-w-min text-grey-500 sticky left-0 z-[2] justify-center !min-w-[36px] bg-core-white">
           <!-- Root container: vertical layout with consistent spacing -->
-          <div data-v-2b014a17="" class="flex justify-center flex-col w-fit gap-4">
+          <div data-v-2b014a17="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
             <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
             <!-- Hover effects are handled in CSS using data attributes -->
             <div data-v-2b014a17="" class="flex items-start group" data-emphasis="true">
@@ -236,7 +236,7 @@ exports[`FzTable > Snapshots > should match snapshot - selectable variant 1`] = 
               <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-2b014a17="" id="fz-checkbox-100000000003-22ql0-label" for="fz-checkbox-100000000003-22ql0" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-2b014a17="" id="fz-checkbox-100000000003-22ql0-label" for="fz-checkbox-100000000003-22ql0" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]
@@ -275,7 +275,7 @@ exports[`FzTable > Snapshots > should match snapshot - selectable variant 1`] = 
         <!--v-if-->
         <div role="cell" class="w-[36px] fz__body z-[1] p-16 min-h-[52px] text-base flex items-start min-w-min text-grey-500 sticky left-0 z-[2] justify-center !min-w-[36px] bg-core-white">
           <!-- Root container: vertical layout with consistent spacing -->
-          <div data-v-2b014a17="" class="flex justify-center flex-col w-fit gap-4">
+          <div data-v-2b014a17="" class="flex justify-center flex-col w-fit gap-4 text-core-black">
             <!-- Checkbox row: input + label + optional tooltip, aligned to top for long labels -->
             <!-- Hover effects are handled in CSS using data attributes -->
             <div data-v-2b014a17="" class="flex items-start group" data-emphasis="true">
@@ -288,7 +288,7 @@ exports[`FzTable > Snapshots > should match snapshot - selectable variant 1`] = 
               <!-- 
         Label element: provides click target and visual representation
         Connected to hidden input via "for" attribute
-      --><label data-v-2b014a17="" id="fz-checkbox-100000000004-2kdwy-label" for="fz-checkbox-100000000004-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black
+      --><label data-v-2b014a17="" id="fz-checkbox-100000000004-2kdwy-label" for="fz-checkbox-100000000004-2kdwy" class="flex gap-6 items-start hover:cursor-pointer text-core-black mb-0
   peer-focus:[&amp;_div]:after:border-1
   peer-focus:[&amp;_div]:after:border-solid
   peer-focus:[&amp;_div]:after:rounded-[2px]


### PR DESCRIPTION
## Cosa abbiamo fatto

`FzCheckbox` e `FzCheckboxGroup` si affidavano all'ereditarietà del colore testo dal body dell'host e al preflight di Tailwind per azzerare il margine del `<label>`. In host con Bootstrap reboot ma senza preflight globale (es. `it-fiscozen-app`), il testo dei discendenti slittava a `body { color: #212529 }` e i label ereditavano `label { margin-bottom: 0.5rem }`.

Resi entrambi i componenti environment-agnostic:
- `text-core-black` sul container root di ciascun componente.
- `mb-0` sul `<label>` interno di ciascun componente.

Il label aveva già `text-core-black`; la nuova classe sul container copre i discendenti "edge" così nessun colore del body dell'host filtra dentro.

- Test di lock-in aggiunti su entrambi i componenti; snapshot aggiornati (checkbox + downstream `@fiscozen/table`, che renderizza `FzCheckbox` per le righe selezionabili — solo snapshot, nessun cambio sorgente/versione).
- Changeset: `@fiscozen/checkbox` patch.

## Cosa resta da fare in app per chiudere il task

Dopo la publish di `@fiscozen/checkbox`:

1. Bump del caret di `@fiscozen/checkbox` in `frontoffice/package.json` e `backoffice/package.json` (oggi entrambi `^3.0.7`, già allineati).
2. Droppare gli shim `vue_common/src/scss/fz-ds/_fz-checkbox.scss` e `_fz-checkbox-group.scss` (entrambi diventano vuoti) e rimuovere i due `@import` corrispondenti da `_main.scss`.
3. Smoke su 2 pagine con `<FzCheckbox>` / `<FzCheckboxGroup>` (BO + FO): testo black + nessun gap sotto al label.
4. `npm run lint-fix`.