### PR TITLE
fix(radio): self-contained label spacing (mb-0 baseline)

### DIFF
--- a/.changeset/radio-self-contained-label.md
+++ b/.changeset/radio-self-contained-label.md
@@ -1,0 +1,8 @@
+---
+'@fiscozen/radio': patch
+---
+
+`FzRadio` and `FzRadioGroup` now set `mb-0` on their `<label>` (and on `FzRadioGroup`'s help `<p>`) as a baseline.
+This makes the label spacing environment-agnostic: hosts with Bootstrap reboot but without global Tailwind preflight no longer leak `label { margin-bottom: 0.5rem }` / `p { margin-bottom: 1rem }` into the layout.
+The other baselines the shim covered (`display: flex`, `text-core-black`, disabled `grey-300`, and the `text-semantic-error` palette default) were already present in the components.
+No changes to the public props.

--- a/packages/radio/src/FzRadioGroup.vue
+++ b/packages/radio/src/FzRadioGroup.vue
@@ -88,7 +88,7 @@ const controlledProps = computed<Omit<FzRadioGroupProps, "label" | "variant">>(
   }),
 );
 
-const staticLabelClass = "flex flex-col";
+const staticLabelClass = "flex flex-col mb-0";
 const staticContainerClass = "flex flex-col";
 const staticSlotContainerClass = computed(() => [
   "flex self-stretch",
@@ -98,6 +98,7 @@ const staticSlotContainerClass = computed(() => [
 const computedHelpTextClass = computed(() => [
   "text-base",
   props.disabled ? "text-grey-400" : "text-grey-500",
+  "mb-0",
 ]);
 
 const computedLabelClass = computed(() => [

--- a/packages/radio/src/__tests__/FzRadio.spec.ts
+++ b/packages/radio/src/__tests__/FzRadio.spec.ts
@@ -51,6 +51,16 @@ describe("FzRadio", () => {
       expect(wrapper.find("label").exists()).toBe(true);
     });
 
+    it("should apply self-contained label baseline (flex, text-core-black, mb-0)", async () => {
+      const wrapper = await createWrapper({ label: "Radio", size: "md" });
+      const label = wrapper.find("label");
+      // baseline so the component renders correctly in hosts without
+      // Tailwind preflight (e.g. Bootstrap reboot sets label margin-bottom).
+      expect(label.classes()).toContain("flex");
+      expect(label.classes()).toContain("text-core-black");
+      expect(label.classes()).toContain("mb-0");
+    });
+
     it("should render label text", async () => {
       const wrapper = await createWrapper({
         label: "Radio Option",

--- a/packages/radio/src/__tests__/FzRadioGroup.spec.ts
+++ b/packages/radio/src/__tests__/FzRadioGroup.spec.ts
@@ -59,6 +59,18 @@ describe("FzRadioGroup", () => {
       const inputs = wrapper.findAll("input[type='radio']");
       expect(inputs.length).toBeGreaterThan(0);
     });
+
+    it("should apply mb-0 baseline to the group label and the help text", async () => {
+      const wrapper = mount(FzRadioGroup, {
+        props: { label: "Radio Group", size: "md", name: "radio" },
+        slots: { help: () => "Some help text" },
+      });
+      await wrapper.vm.$nextTick();
+      // group <label> and help <p> must not pick up Bootstrap reboot's
+      // `label`/`p` bottom margin in hosts without Tailwind preflight.
+      expect(wrapper.find("label").classes()).toContain("mb-0");
+      expect(wrapper.find("p").classes()).toContain("mb-0");
+    });
   });
 
   // ============================================

--- a/packages/radio/src/__tests__/__snapshots__/FzRadio.spec.ts.snap
+++ b/packages/radio/src/__tests__/__snapshots__/FzRadio.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`FzRadio > Snapshots > should match snapshot - checked state 1`] = `
 "<div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="Radio" checked="" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000001-2a84k-label" value="Radio"><label data-v-029ccdb9="" id="fz-radio-100000000001-2a84k-label" for="Radio" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio</span>
     <!--v-if-->
   </label></div>"
@@ -10,7 +10,7 @@ exports[`FzRadio > Snapshots > should match snapshot - checked state 1`] = `
 
 exports[`FzRadio > Snapshots > should match snapshot - default state 1`] = `
 "<div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="Radio" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000001-2a84k-label" value="Radio"><label data-v-029ccdb9="" id="fz-radio-100000000001-2a84k-label" for="Radio" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio</span>
     <!--v-if-->
   </label></div>"
@@ -18,7 +18,7 @@ exports[`FzRadio > Snapshots > should match snapshot - default state 1`] = `
 
 exports[`FzRadio > Snapshots > should match snapshot - disabled state 1`] = `
 "<div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="Radio" disabled="" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" aria-checked="false" aria-disabled="true" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000001-2a84k-label" value="Radio"><label data-v-029ccdb9="" id="fz-radio-100000000001-2a84k-label" for="Radio" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] text-grey-300 before:border-grey-200 before:bg-grey-200 peer-checked:before:bg-transparent"><span data-v-029ccdb9="" class="w-fit">Radio</span>
     <!--v-if-->
   </label></div>"
@@ -26,7 +26,7 @@ exports[`FzRadio > Snapshots > should match snapshot - disabled state 1`] = `
 
 exports[`FzRadio > Snapshots > should match snapshot - emphasis state 1`] = `
 "<div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="Radio" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000001-2a84k-label" value="Radio"><label data-v-029ccdb9="" id="fz-radio-100000000001-2a84k-label" for="Radio" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500 peer-checked:before:border-blue-500"><span data-v-029ccdb9="" class="w-fit">Radio</span>
     <!--v-if-->
   </label></div>"
@@ -34,7 +34,7 @@ exports[`FzRadio > Snapshots > should match snapshot - emphasis state 1`] = `
 
 exports[`FzRadio > Snapshots > should match snapshot - error state 1`] = `
 "<div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="Radio" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="true" aria-labelledby="fz-radio-100000000001-2a84k-label" value="Radio"><label data-v-029ccdb9="" id="fz-radio-100000000001-2a84k-label" for="Radio" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-semantic-error text-semantic-error"><span data-v-029ccdb9="" class="w-fit">Radio</span>
     <!--v-if-->
   </label></div>"
@@ -42,7 +42,7 @@ exports[`FzRadio > Snapshots > should match snapshot - error state 1`] = `
 
 exports[`FzRadio > Snapshots > should match snapshot - standalone state 1`] = `
 "<div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="Radio" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-label="Radio" value="Radio"><label data-v-029ccdb9="" for="Radio" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500">
     <!--v-if-->
     <!--v-if-->
@@ -51,7 +51,7 @@ exports[`FzRadio > Snapshots > should match snapshot - standalone state 1`] = `
 
 exports[`FzRadio > Snapshots > should match snapshot - with tooltip 1`] = `
 "<div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="Radio" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000001-2a84k-label" value="Radio"><label data-v-029ccdb9="" id="fz-radio-100000000001-2a84k-label" for="Radio" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio</span>
     <div data-v-49515ccb="" data-v-029ccdb9="" class="fz__tooltip flex h-max">
       <div class="inline-flex w-full sm:w-auto"><span data-v-49515ccb="" tabindex="0"><span data-v-029ccdb9="" role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px] text-semantic-info"><svg class="svg-inline--fa fa-circle-info h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="circle-info" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path class="" fill="currentColor" d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"></path></svg></span></span></div>

--- a/packages/radio/src/__tests__/__snapshots__/FzRadioGroup.spec.ts.snap
+++ b/packages/radio/src/__tests__/__snapshots__/FzRadioGroup.spec.ts.snap
@@ -1,17 +1,17 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzRadioGroup > Rendering > should render correctly 1`] = `
-"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio" class="flex flex-col text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
+"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio" class="flex flex-col mb-0 text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
     <!--v-if-->
   </label>
   <div id="fz-radio-group-100000000001-2a84k" class="flex self-stretch flex-col text-base gap-8" test-id="slot-container" role="radiogroup" aria-labelledby="fz-radio-group-100000000001-2a84k-label" aria-required="false" aria-invalid="false">
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-Radio 1" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000002-22ql0-label" value="Radio 1"><label data-v-029ccdb9="" id="fz-radio-100000000002-22ql0-label" for="radio-Radio 1" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio 1</span>
         <!--v-if-->
       </label></div>
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-Radio 2" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000004-2kdwy-label" value="Radio 2"><label data-v-029ccdb9="" id="fz-radio-100000000004-2kdwy-label" for="radio-Radio 2" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio 2</span>
         <!--v-if-->
       </label></div>
@@ -21,17 +21,17 @@ exports[`FzRadioGroup > Rendering > should render correctly 1`] = `
 `;
 
 exports[`FzRadioGroup > Snapshots > should match snapshot - default state 1`] = `
-"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio" class="flex flex-col text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
+"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio" class="flex flex-col mb-0 text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
     <!--v-if-->
   </label>
   <div id="fz-radio-group-100000000001-2a84k" class="flex self-stretch flex-col text-base gap-8" test-id="slot-container" role="radiogroup" aria-labelledby="fz-radio-group-100000000001-2a84k-label" aria-required="false" aria-invalid="false">
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-Radio 1" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000002-22ql0-label" value="Radio 1"><label data-v-029ccdb9="" id="fz-radio-100000000002-22ql0-label" for="radio-Radio 1" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio 1</span>
         <!--v-if-->
       </label></div>
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-Radio 2" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000004-2kdwy-label" value="Radio 2"><label data-v-029ccdb9="" id="fz-radio-100000000004-2kdwy-label" for="radio-Radio 2" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio 2</span>
         <!--v-if-->
       </label></div>
@@ -41,17 +41,17 @@ exports[`FzRadioGroup > Snapshots > should match snapshot - default state 1`] = 
 `;
 
 exports[`FzRadioGroup > Snapshots > should match snapshot - disabled state 1`] = `
-"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col text-base gap-6 text-grey-400"><span>Radio Group<!--v-if--></span>
+"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col mb-0 text-base gap-6 text-grey-400"><span>Radio Group<!--v-if--></span>
     <!--v-if-->
   </label>
   <div id="fz-radio-group-100000000001-2a84k" class="flex self-stretch flex-col text-base gap-8" test-id="slot-container" role="radiogroup" aria-labelledby="fz-radio-group-100000000001-2a84k-label" aria-required="false" aria-invalid="false">
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 1" disabled="" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" aria-checked="false" aria-disabled="true" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000002-2kdwy-label" value="Radio 1"><label data-v-029ccdb9="" id="fz-radio-100000000002-2kdwy-label" for="radio-group-22ql0sw-Radio 1" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] text-grey-300 before:border-grey-200 before:bg-grey-200 peer-checked:before:bg-transparent"><span data-v-029ccdb9="" class="w-fit">Radio 1</span>
         <!--v-if-->
       </label></div>
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 2" disabled="" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" aria-checked="false" aria-disabled="true" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000004-nphsn-label" value="Radio 2"><label data-v-029ccdb9="" id="fz-radio-100000000004-nphsn-label" for="radio-group-22ql0sw-Radio 2" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] text-grey-300 before:border-grey-200 before:bg-grey-200 peer-checked:before:bg-transparent"><span data-v-029ccdb9="" class="w-fit">Radio 2</span>
         <!--v-if-->
       </label></div>
@@ -61,17 +61,17 @@ exports[`FzRadioGroup > Snapshots > should match snapshot - disabled state 1`] =
 `;
 
 exports[`FzRadioGroup > Snapshots > should match snapshot - emphasis state 1`] = `
-"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
+"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col mb-0 text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
     <!--v-if-->
   </label>
   <div id="fz-radio-group-100000000001-2a84k" class="flex self-stretch flex-col text-base gap-8" test-id="slot-container" role="radiogroup" aria-labelledby="fz-radio-group-100000000001-2a84k-label" aria-required="false" aria-invalid="false">
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 1" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000002-2kdwy-label" value="Radio 1"><label data-v-029ccdb9="" id="fz-radio-100000000002-2kdwy-label" for="radio-group-22ql0sw-Radio 1" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500 peer-checked:before:border-blue-500"><span data-v-029ccdb9="" class="w-fit">Radio 1</span>
         <!--v-if-->
       </label></div>
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 2" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000004-nphsn-label" value="Radio 2"><label data-v-029ccdb9="" id="fz-radio-100000000004-nphsn-label" for="radio-group-22ql0sw-Radio 2" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500 peer-checked:before:border-blue-500"><span data-v-029ccdb9="" class="w-fit">Radio 2</span>
         <!--v-if-->
       </label></div>
@@ -81,17 +81,17 @@ exports[`FzRadioGroup > Snapshots > should match snapshot - emphasis state 1`] =
 `;
 
 exports[`FzRadioGroup > Snapshots > should match snapshot - error state 1`] = `
-"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
+"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col mb-0 text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
     <!--v-if-->
   </label>
   <div id="fz-radio-group-100000000001-2a84k" class="flex self-stretch flex-col text-base gap-8" test-id="slot-container" role="radiogroup" aria-labelledby="fz-radio-group-100000000001-2a84k-label" aria-describedby="fz-radio-group-100000000001-2a84k-error" aria-required="false" aria-invalid="true">
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 1" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="true" aria-labelledby="fz-radio-100000000002-2kdwy-label" value="Radio 1"><label data-v-029ccdb9="" id="fz-radio-100000000002-2kdwy-label" for="radio-group-22ql0sw-Radio 1" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-semantic-error text-semantic-error"><span data-v-029ccdb9="" class="w-fit">Radio 1</span>
         <!--v-if-->
       </label></div>
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 2" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="true" aria-labelledby="fz-radio-100000000004-nphsn-label" value="Radio 2"><label data-v-029ccdb9="" id="fz-radio-100000000004-nphsn-label" for="radio-group-22ql0sw-Radio 2" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-semantic-error text-semantic-error"><span data-v-029ccdb9="" class="w-fit">Radio 2</span>
         <!--v-if-->
       </label></div>
@@ -125,17 +125,17 @@ exports[`FzRadioGroup > Snapshots > should match snapshot - error state 1`] = `
 `;
 
 exports[`FzRadioGroup > Snapshots > should match snapshot - horizontal variant 1`] = `
-"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
+"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col mb-0 text-base gap-6 text-core-black"><span>Radio Group<!--v-if--></span>
     <!--v-if-->
   </label>
   <div id="fz-radio-group-100000000001-2a84k" class="flex self-stretch flex-row text-base gap-8" test-id="slot-container" role="radiogroup" aria-labelledby="fz-radio-group-100000000001-2a84k-label" aria-required="false" aria-invalid="false">
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 1" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000002-2kdwy-label" value="Radio 1"><label data-v-029ccdb9="" id="fz-radio-100000000002-2kdwy-label" for="radio-group-22ql0sw-Radio 1" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio 1</span>
         <!--v-if-->
       </label></div>
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 2" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" aria-checked="false" aria-disabled="false" aria-required="false" aria-invalid="false" aria-labelledby="fz-radio-100000000004-nphsn-label" value="Radio 2"><label data-v-029ccdb9="" id="fz-radio-100000000004-nphsn-label" for="radio-group-22ql0sw-Radio 2" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio 2</span>
         <!--v-if-->
       </label></div>
@@ -145,17 +145,17 @@ exports[`FzRadioGroup > Snapshots > should match snapshot - horizontal variant 1
 `;
 
 exports[`FzRadioGroup > Snapshots > should match snapshot - required state 1`] = `
-"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col text-base gap-6 text-core-black"><span>Radio Group<span> *</span></span>
+"<div class="flex flex-col text-base gap-10"><label id="fz-radio-group-100000000001-2a84k-label" for="radio-group-22ql0sw" class="flex flex-col mb-0 text-base gap-6 text-core-black"><span>Radio Group<span> *</span></span>
     <!--v-if-->
   </label>
   <div id="fz-radio-group-100000000001-2a84k" class="flex self-stretch flex-col text-base gap-8" test-id="slot-container" role="radiogroup" aria-labelledby="fz-radio-group-100000000001-2a84k-label" aria-required="true" aria-invalid="false">
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 1" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" required="" aria-checked="false" aria-disabled="false" aria-required="true" aria-invalid="false" aria-labelledby="fz-radio-100000000002-2kdwy-label" value="Radio 1"><label data-v-029ccdb9="" id="fz-radio-100000000002-2kdwy-label" for="radio-group-22ql0sw-Radio 1" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio 1</span>
         <!--v-if-->
       </label></div>
     <div data-v-029ccdb9="" class="flex justify-center flex-col w-fit"><input data-v-029ccdb9="" type="radio" id="radio-group-22ql0sw-Radio 2" class="peer h-0 w-0 absolute fz-hidden-input radio--medium" name="radio-group-22ql0sw" required="" aria-checked="false" aria-disabled="false" aria-required="true" aria-invalid="false" aria-labelledby="fz-radio-100000000004-nphsn-label" value="Radio 2"><label data-v-029ccdb9="" id="fz-radio-100000000004-nphsn-label" for="radio-group-22ql0sw-Radio 2" class="flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label text-base before:h-16 before:w-16 peer-checked:before:border-[5px] before:border-grey-500"><span data-v-029ccdb9="" class="w-fit">Radio 2</span>
         <!--v-if-->
       </label></div>

--- a/packages/radio/src/common.ts
+++ b/packages/radio/src/common.ts
@@ -3,6 +3,6 @@ export const beforeLabelClass =  "before:h-16 before:w-16 peer-checked:before:bo
 export const staticInputClass = "peer h-0 w-0 absolute fz-hidden-input";
 export const staticLabelClass = `
   flex items-start gap-4 
-  text-core-black
+  text-core-black mb-0
   fz-radio__label
 `;


### PR DESCRIPTION
## Cosa abbiamo fatto

`FzRadio` e `FzRadioGroup` si affidavano al preflight di Tailwind per azzerare il margine del `<label>` (e del `<p>` di help nel group). In host con Bootstrap reboot ma senza preflight globale (es. `it-fiscozen-app`) i label ereditavano `label { margin-bottom: 0.5rem }` e il `<p>` di help `p { margin-bottom: 1rem }`.

Aggiunto `mb-0` come baseline:
- `<label>` di `FzRadio` (via `common.ts` `staticLabelClass`).
- `<label>` di `FzRadioGroup` e `<p>` di help.

Gli altri item che lo shim compensava erano **già presenti** nei componenti e non sono stati toccati: `display: flex`, `text-core-black`, disabled `grey-300`, e il default di palette di `text-semantic-error` (in `@fiscozen/style` `semantic-error.DEFAULT = semantic-error.200`, quindi `text-semantic-error` risolve correttamente — il 🚨 "palette gap" della roadmap è già risolto a monte).

- Test di lock-in aggiunti su entrambi i componenti; snapshot aggiornati. Nessun downstream impattato (`@fiscozen/appointments` verde).
- Changeset: `@fiscozen/radio` patch.

## Cosa resta da fare in app per chiudere il task

Dopo la publish di `@fiscozen/radio`:

1. Bump del caret di `@fiscozen/radio` in `frontoffice/package.json` e `backoffice/package.json` (oggi entrambi `^3.0.8`, già allineati — il drift FO-alpha della roadmap è superato).
2. Droppare gli shim `vue_common/src/scss/fz-ds/_fz-radio.scss` e `_fz-radio-group.scss` (entrambi diventano vuoti) e rimuovere i due `@import` corrispondenti da `_main.scss`.
3. Smoke su pagine BO/FO con `<FzRadio>` / `<FzRadioGroup>`: label allineata a sinistra, nessun gap sotto al label, colori coerenti default/disabled/error.
4. `npm run lint-fix`.