### PR TITLE
fix(composables): clamp FzFloating to viewport to prevent horizontal overflow

### DIFF
--- a/.changeset/fzfloating-viewport-collision.md
+++ b/.changeset/fzfloating-viewport-collision.md
@@ -1,0 +1,9 @@
+---
+"@fiscozen/composables": patch
+---
+
+FzFloating: keep floating content inside the viewport horizontally and vertically
+
+`useFloating`'s boundary correction previously clamped the floating element to the resolved container rect only. For openerless / container-less consumers (e.g. `FzDropdown`) the container resolves to `document.body`, whose rect can be wider than — or extend below — the visible viewport on narrow/mobile screens. A dropdown opened from a control near the right edge (such as a per-row kebab menu in a table) could therefore render overflowing off the right edge or overlapping adjacent menus.
+
+Boundary correction now clamps against the intersection of the container and the viewport (`window.innerWidth`/`innerHeight`, mirroring the auto-positioning util) and keeps an 8px safety margin: if the element would overflow the right edge it is shifted left so its right edge stays on screen, the left edge is clamped to the margin, and the same is applied vertically. Behaviour is unchanged when there is enough room.

--- a/packages/composables/src/__tests__/useFloating.spec.ts
+++ b/packages/composables/src/__tests__/useFloating.spec.ts
@@ -224,6 +224,175 @@ describe('useFloating', () => {
     })
   })
 
+  describe('viewport collision (mobile)', () => {
+    const VIEWPORT_MARGIN = 8
+    const ELEMENT_WIDTH = 200
+    const ELEMENT_HEIGHT = 100
+
+    let originalInnerWidth: number
+    let originalInnerHeight: number
+
+    const setViewport = (width: number, height: number) => {
+      Object.defineProperty(window, 'innerWidth', { value: width, configurable: true })
+      Object.defineProperty(window, 'innerHeight', { value: height, configurable: true })
+    }
+
+    beforeEach(() => {
+      originalInnerWidth = window.innerWidth
+      originalInnerHeight = window.innerHeight
+    })
+
+    afterEach(() => {
+      setViewport(originalInnerWidth, originalInnerHeight)
+    })
+
+    it('leaves the position untouched when there is enough room (wide viewport)', async () => {
+      setViewport(1440, 900)
+
+      // Opener comfortably inside the viewport, plenty of room to the right.
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 100,
+        height: 40,
+        top: 200,
+        left: 300,
+        right: 400,
+        bottom: 240,
+        x: 300,
+        y: 200,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('bottom-start'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      // bottom-start anchors the element's left edge at opener.left (300) and the
+      // top at opener.bottom (240). There's room, so nothing is shifted.
+      expect(floating.float.position.x).toBe(300)
+      expect(floating.float.position.y).toBe(240)
+    })
+
+    it('shifts a near-right-edge menu left so it stays on screen (narrow viewport)', async () => {
+      // Narrow mobile viewport. NOTE: the container (document.body by default here)
+      // reports a rect WIDER than the viewport, reproducing the real bug — clamping
+      // to the container alone would not keep the menu on screen.
+      setViewport(390, 844)
+      mockContainer.getBoundingClientRect = vi.fn(() => ({
+        width: 800,
+        height: 844,
+        top: 0,
+        left: 0,
+        right: 800,
+        bottom: 844,
+        x: 0,
+        y: 0,
+        toJSON: () => {}
+      })) as any
+
+      // Kebab opener pinned to the right edge of the narrow screen.
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 32,
+        height: 32,
+        top: 120,
+        left: 350,
+        right: 382,
+        bottom: 152,
+        x: 350,
+        y: 120,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('bottom-start'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) },
+        container: { domRef: ref(mockContainer) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      const left = floating.float.position.x
+      // Right edge must stay within the viewport (minus the safety margin)…
+      expect(left + ELEMENT_WIDTH).toBeLessThanOrEqual(390 - VIEWPORT_MARGIN)
+      // …and the left edge must not be pushed off the left side either.
+      expect(left).toBeGreaterThanOrEqual(VIEWPORT_MARGIN)
+      // Concretely: clamped to viewportWidth - margin - elementWidth = 390 - 8 - 200.
+      expect(left).toBe(390 - VIEWPORT_MARGIN - ELEMENT_WIDTH)
+    })
+
+    it('clamps the left edge to the margin when the element is wider than the viewport', async () => {
+      // Pathological narrow viewport where the menu cannot fully fit; it should
+      // still start on screen (left edge at the margin) rather than disappear.
+      setViewport(180, 844)
+
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 32,
+        height: 32,
+        top: 120,
+        left: 150,
+        right: 182,
+        bottom: 152,
+        x: 150,
+        y: 120,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('bottom-end'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      // element width (200) > viewport width (180): left edge clamps to the margin.
+      expect(floating.float.position.x).toBe(VIEWPORT_MARGIN)
+      expect(Number.isNaN(floating.float.position.y)).toBe(false)
+    })
+
+    it('shifts a menu up so its bottom edge stays on screen (vertical clamp)', async () => {
+      setViewport(390, 600)
+
+      // Opener near the bottom of the viewport; a bottom-anchored menu would
+      // overflow below the fold and must be lifted up.
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 100,
+        height: 40,
+        top: 540,
+        left: 100,
+        right: 200,
+        bottom: 580,
+        x: 100,
+        y: 540,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('bottom-start'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      expect(floating.float.position.y + ELEMENT_HEIGHT).toBeLessThanOrEqual(600 - VIEWPORT_MARGIN)
+      // Clamped to viewportHeight - margin - elementHeight = 600 - 8 - 100.
+      expect(floating.float.position.y).toBe(600 - VIEWPORT_MARGIN - ELEMENT_HEIGHT)
+    })
+  })
+
   describe('element styling', () => {
     it('should apply position fixed immediately', async () => {
       const args = toRefs({

--- a/packages/composables/src/composables/useFloating.ts
+++ b/packages/composables/src/composables/useFloating.ts
@@ -358,42 +358,82 @@ const calculatePositionWithoutOpener = (
 // Boundary Correction - Pure Function
 // ============================================================================
 
+// Gap (px) kept between the floating element and the boundary edge when it has
+// to be shifted to stay on screen, so the menu never sits flush against (or
+// bleeds past) the viewport edge on narrow/mobile screens.
+const VIEWPORT_MARGIN = 8
+
+interface Bounds {
+  left: number
+  right: number
+  top: number
+  bottom: number
+}
+
+// The visible viewport as a rect. Mirrors the `windowDOMrect` used by the
+// auto-positioning util so collision handling and auto-positioning agree on
+// what "on screen" means.
+const getViewportBounds = (): Bounds => ({
+  left: 0,
+  top: 0,
+  right: window.innerWidth,
+  bottom: window.innerHeight
+})
+
+// Effective collision boundary: the intersection of the container and the
+// viewport. Clamping to the container alone is not enough — for openerless
+// dropdowns the container resolves to document.body, whose rect can be wider
+// than the viewport (or extend under it) on narrow screens, letting the menu
+// overflow the right edge. Intersecting with the viewport guarantees the
+// element stays on screen while still honouring a real (narrower) container.
+const getCollisionBounds = (container: DOMRect, viewport: Bounds): Bounds => ({
+  left: Math.max(container.left, viewport.left),
+  right: Math.min(container.right, viewport.right),
+  top: Math.max(container.top, viewport.top),
+  bottom: Math.min(container.bottom, viewport.bottom)
+})
+
 const applyBoundaryCorrections = (
   realPosition: FzAbsolutePosition,
   element: DOMRect,
   container: DOMRect,
-  transform: Transform
+  transform: Transform,
+  viewport: Bounds = getViewportBounds(),
+  margin: number = VIEWPORT_MARGIN
 ): { position: FzAbsolutePosition; transform: Transform } => {
   const correctedPosition = { ...realPosition }
   const correctedTransform = { ...transform }
 
-  // Left boundary
-  if (realPosition.x < container.left) {
-    correctedPosition.x = container.left
+  const bounds = getCollisionBounds(container, viewport)
+
+  // --- Horizontal ---
+  // Inset the usable area by the margin, but never produce an inverted range
+  // when the element is wider than the available space (keep the left edge
+  // anchored so the element starts on screen rather than vanishing).
+  const minLeft = bounds.left + margin
+  const maxLeft = Math.max(minLeft, bounds.right - margin - element.width)
+
+  // Right overflow: shift the element left so its right edge stays on screen.
+  if (correctedPosition.x > maxLeft) {
+    correctedPosition.x = maxLeft
+    correctedTransform.x = 0
+  }
+  // Left overflow / clamp: never let the left edge cross the margin.
+  if (correctedPosition.x < minLeft) {
+    correctedPosition.x = minLeft
     correctedTransform.x = 0
   }
 
-  // Right boundary
-  if (realPosition.x + element.width > container.right) {
-    const fixedX = container.right - element.width
-    if (fixedX > 0) {
-      correctedPosition.x = fixedX
-    }
-    correctedTransform.x = 0
-  }
+  // --- Vertical ---
+  const minTop = bounds.top + margin
+  const maxTop = Math.max(minTop, bounds.bottom - margin - element.height)
 
-  // Top boundary
-  if (realPosition.y < container.top) {
-    correctedPosition.y = container.top
+  if (correctedPosition.y > maxTop) {
+    correctedPosition.y = maxTop
     correctedTransform.y = 0
   }
-
-  // Bottom boundary
-  if (realPosition.y + element.height > container.bottom) {
-    const fixedY = container.bottom - element.height
-    if (fixedY > 0) {
-      correctedPosition.y = fixedY
-    }
+  if (correctedPosition.y < minTop) {
+    correctedPosition.y = minTop
     correctedTransform.y = 0
   }
 


### PR DESCRIPTION
Jira: [LIB-2730](https://fiscozen.atlassian.net/browse/LIB-2730)

## Problem

`useFloating`'s boundary correction (`applyBoundaryCorrections`) clamped the floating element to the resolved **container** rect only. For openerless / container-less consumers (e.g. `FzDropdown`), the container resolves to `document.body`, whose rect can be wider than — or extend below — the visible viewport on narrow/mobile screens. A dropdown opened from a control near the right edge (e.g. a per-row kebab menu in a card/table) therefore rendered half off the right edge or overlapping adjacent menus.

Reported via customer feedback [HD-25388](https://fiscozen.atlassian.net/browse/HD-25388): on a narrow Android device, the three-dots "Duplica" menu on the *fatture emesse* page opens half off-screen.

## Fix

Boundary correction now clamps against the **intersection of the container and the viewport** (`window.innerWidth` / `innerHeight`, mirroring the auto-positioning util) with an 8px safety margin:

- right overflow → element shifted left so its right edge stays on screen;
- left edge clamped to the margin (anchored on screen even when the element is wider than the viewport);
- the same applied vertically.

Behaviour is unchanged when there's enough room.

## Notes

- Patch bump for `@fiscozen/composables` (changeset included).
- 30 `useFloating` unit tests pass, including new regression cases for viewport clamping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2730]: https://fiscozen.atlassian.net/browse/LIB-2730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HD-25388]: https://fiscozen.atlassian.net/browse/HD-25388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ