### PR TITLE
chore(icons): bump @awesome.me/kit-8137893ad3 to ^1.0.421

### DIFF
--- a/.changeset/fa-kit-update-421.md
+++ b/.changeset/fa-kit-update-421.md
@@ -1,0 +1,5 @@
+---
+"@fiscozen/icons": patch
+---
+
+Update Font Awesome kit `@awesome.me/kit-8137893ad3` from `^1.0.419` to `^1.0.421`.

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -22,7 +22,7 @@
     "postinstall": "node scripts/postinstall-playwright.cjs"
   },
   "dependencies": {
-    "@awesome.me/kit-8137893ad3": "^1.0.419",
+    "@awesome.me/kit-8137893ad3": "^1.0.421",
     "@fiscozen/action": "workspace:^",
     "@fiscozen/actionlist": "workspace:^",
     "@fiscozen/alert": "workspace:^",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -38,7 +38,7 @@
     "vue-tsc": "^2.2.12"
   },
   "dependencies": {
-    "@awesome.me/kit-8137893ad3": "^1.0.419",
+    "@awesome.me/kit-8137893ad3": "^1.0.421",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/vue-fontawesome": "^3.1.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
   apps/storybook:
     dependencies:
       '@awesome.me/kit-8137893ad3':
-        specifier: ^1.0.419
-        version: 1.0.419
+        specifier: ^1.0.421
+        version: 1.0.421
       '@fiscozen/action':
         specifier: workspace:^
         version: link:../../packages/action
@@ -1861,8 +1861,8 @@ importers:
   packages/icons:
     dependencies:
       '@awesome.me/kit-8137893ad3':
-        specifier: ^1.0.419
-        version: 1.0.419
+        specifier: ^1.0.421
+        version: 1.0.421
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.7.2
         version: 6.7.2
@@ -3630,8 +3630,8 @@ packages:
   '@asamuzakjp/dom-selector@2.0.2':
     resolution: {integrity: sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==}
 
-  '@awesome.me/kit-8137893ad3@1.0.419':
-    resolution: {integrity: sha512-dQybbTB/QW26NaCe3G2N8iwdtc63ZnUR3jsr7e+DzK6ebpAMqHm2WWJT+R1kp9Y94kjnlWKBWCYXkEJEZT0OsA==}
+  '@awesome.me/kit-8137893ad3@1.0.421':
+    resolution: {integrity: sha512-b0xEES+tTFzzRBXpByPVt2+eVUJ5fpGIVeSTakBkm4YixUhESzdNjFIvwcSXUr93tBg22WuVDBT9BpgHp4/ZSQ==}
     engines: {node: '>=16'}
 
   '@babel/code-frame@7.29.0':
@@ -3802,9 +3802,6 @@ packages:
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
-
-  '@emnapi/wasi-threads@1.1.0':
-    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -7370,9 +7367,6 @@ packages:
     resolution: {integrity: sha512-tn+OxutdqhvoByKJ7p84FZBSUDfUB76bcvj0ugLBvgE9V52LFcnz8cauCDKi6otnctvFCqa9XkrU35pBY5Baig==}
     engines: {node: '>=18'}
 
-  node-readable-to-web-readable-stream@0.4.2:
-    resolution: {integrity: sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==}
-
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -8767,8 +8761,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.5:
-    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
+  vue-component-type-helpers@3.2.7:
+    resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -8992,7 +8986,7 @@ snapshots:
       css-tree: 2.3.1
       is-potential-custom-element-name: 1.0.1
 
-  '@awesome.me/kit-8137893ad3@1.0.419':
+  '@awesome.me/kit-8137893ad3@1.0.421':
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
 
@@ -9253,14 +9247,9 @@ snapshots:
 
   '@emnapi/core@1.8.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.1.0
       tslib: 2.8.1
 
   '@emnapi/runtime@1.8.1':
-    dependencies:
-      tslib: 2.8.1
-
-  '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
 
@@ -10044,7 +10033,7 @@ snapshots:
       storybook: 10.3.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@5.7.3)
-      vue-component-type-helpers: 3.3.5
+      vue-component-type-helpers: 3.2.7
 
   '@tato30/vue-pdf@2.0.2(vue@3.5.26(typescript@5.7.3))':
     dependencies:
@@ -13116,9 +13105,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  node-readable-to-web-readable-stream@0.4.2:
-    optional: true
-
   node-releases@2.0.27: {}
 
   nopt@7.2.1:
@@ -13391,7 +13377,6 @@ snapshots:
   pdfjs-dist@5.4.624:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.88
-      node-readable-to-web-readable-stream: 0.4.2
 
   pend@1.2.0: {}
 
@@ -14533,7 +14518,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.5: {}
+  vue-component-type-helpers@3.2.7: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@5.7.3)):
     dependencies:


### PR DESCRIPTION
Jira: [LIB-2645](https://fiscozen.atlassian.net/browse/LIB-2645)

Bumps the Font Awesome kit `@awesome.me/kit-8137893ad3` from `^1.0.419` to `^1.0.421` in `@fiscozen/icons` and the Storybook app, and regenerates the lockfile accordingly.

## Changes
- `packages/icons/package.json`: kit `^1.0.419` → `^1.0.421`
- `apps/storybook/package.json`: kit `^1.0.419` → `^1.0.421`
- `pnpm-lock.yaml`: regenerated (resolves to `1.0.421`)
- Added changeset: patch bump for `@fiscozen/icons`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-2645]: https://fiscozen.atlassian.net/browse/LIB-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ