### PR TITLE
feat(layout): LIB-2801 declarative page-layout manifest + parity enforcement

### DIFF
--- a/.changeset/layout-manifest.md
+++ b/.changeset/layout-manifest.md
@@ -1,0 +1,13 @@
+---
+"@fiscozen/layout": minor
+---
+
+Add `layouts.json` — a machine-readable manifest of the package's page layouts
+
+The package now publishes, alongside the components, a declarative description of what each layout is *for*: its `kind` (`shell` / `page-content` / `bounded` / `region` / `grid`), its height contract, the page shape it covers, the layout it is most easily confused with, its slots and key props, which hosts it is verified to nest inside and the props required when nesting, the version it ships in, and whether every documented capability is reachable under a strict `compose-only` styling policy.
+
+This makes the layout choice answerable from the design system's own source of truth. Repos governed by the agentic-design plugin read the manifest at session start and generate a layout decision table, so a layout added here becomes selectable across the org with no per-repo configuration — replacing hand-copied layout lists that went stale on every release.
+
+Parity is enforced rather than reviewed: `layouts.manifest.spec.ts` asserts that every exported layout has an entry, that entries match their `Fz…Slots` types, that `nestWithin` names real shells, and that a declared compose-only gap is described — and it runs in the pre-commit `nx affected -t test:unit` gate. `layoutComposition.spec.ts` verifies the shell + page-content pairs the manifest advertises, including the negative case that documents why `mainAs="div"` is mandatory when nesting. A new `CLAUDE.md` states the contract for contributors, and `src/index.ts` carries a marker pointing at it.
+
+No component behaviour changes; no existing API is touched.

--- a/packages/layout/CLAUDE.md
+++ b/packages/layout/CLAUDE.md
@@ -1,0 +1,87 @@
+# `@fiscozen/layout` — working rules
+
+Read this before adding or changing anything in this package. It is additive to the
+root `CLAUDE.md`, not a replacement.
+
+## The layout manifest is part of the public surface
+
+`layouts.json` declares, for every layout this package exports, what it is *for* and how
+it may be used. Downstream repos governed by the **agentic-design** plugin read it to
+answer the first question of any design implementation — *which layout should this page
+use?* — and generate a decision table from it at session start. It is the reason a new
+layout becomes usable across the org without anyone editing a consuming repo.
+
+**Adding or removing a layout means updating `layouts.json` in the same commit.** This is
+enforced, not advisory: `src/__tests__/layouts.manifest.spec.ts` asserts parity with
+`src/index.ts` and runs in the pre-commit `nx affected -t test:unit` gate. The failure
+message prints the JSON skeleton to add.
+
+Per entry, the fields that carry real weight:
+
+| Field | Why it matters |
+| --- | --- |
+| `kind` | `shell` (top-level, owns the viewport, one per page) / `page-content` (nests inside a shell) / `bounded` (needs a bounded-height ancestor) / `region` (layout-internal, blocked in app code) / `grid` (in-page primitive). Consumers act on this. |
+| `whenToUse` | The page *shape*, in terms a designer recognises. This is the text the layout decision gets made from — not an implementation note. |
+| `notWhenToUse` | The layout this one is confused with. Fill it in for any near-miss pair (e.g. `FzThreeColumnsTemplate` vs `FzLayout layout="threeColumns"`). |
+| `nestWithin` | Hosts this layout is **verified** to work inside. Only list a host once a case in `src/__tests__/layoutComposition.spec.ts` proves it — the plugin presents an unlisted pair as "unverified, ask", which is the correct answer when we haven't checked. |
+| `whenNested` | Props a consumer must set when nesting (e.g. `mainAs="div"` so the page doesn't expose two `main` landmarks). Treated as mandatory downstream. |
+| `composeOnly` | See below. |
+| `since` | The version the layout ships in. Consumers compare it against the installable version, so an agent doesn't plan a page around something unpublished. For a layout landing with a pending changeset, write the version that changeset will produce. |
+| `slots` | Must match the layout's `Fz…Slots` type in `types.ts` — also asserted by the spec. |
+
+The contract is documented in `docs/ds-layouts.schema.json` in the agentic-design plugin.
+
+## A layout's API must be complete under `compose-only`
+
+Consuming repos run a **compose-only** styling policy: `class`, `:class`, `style`,
+`:style` and `<style>` are blocked at write time in every layer. A capability that is
+only reachable through a fall-through `class`/`style` on the layout root therefore **does
+not exist** for those consumers.
+
+So: if a layout documents a capability, expose it as a prop or a design-system token —
+not as "pass a class". CSS custom properties count as inaccessible too, since setting
+them needs `style`.
+
+Where a gap exists today, declare it honestly:
+
+```json
+"composeOnly": { "safe": false, "gaps": ["what is unreachable, and the tracking ticket"] }
+```
+
+The plugin surfaces those gaps to the consumer at *plan* time, before they build on the
+layout. Closing a gap means flipping `safe` to `true` and removing the entry.
+
+## Additive changes only
+
+This package is a cross-repo contract: the frontoffice and backoffice depend on it and
+bump it **independently** (RFC §10, a hard project constraint). New optional props with
+defaults, new slots and new components are fine. Renaming or removing props, slots or
+exports, making an optional prop required, or narrowing a prop's accepted values are
+**breaking** and need a coordinated migration. Deprecate in a minor, remove in a major.
+
+Every change ships a Changeset at the correct level; `pnpm release:check:pending` previews
+the cascade.
+
+## Layers
+
+Region wrappers (`FzLayout{Main,Header,Aside,Footer,BottomBar}`) are **internal to the
+page layouts**, which apply their sizing and padding via fall-through classes. They are
+marked `kind: region` in the manifest and blocked in consuming app code. Build a new page
+shape as a page layout that composes them — never expect an app to assemble one.
+
+`FzLayout` stays the low-level grid primitive for in-page arrangement and for the
+split-view master-detail shape no page layout covers yet. Its `leftShoulder` variant
+forces `100vh` mobile tracks and independent per-region scroll, which is why the
+list/detail layouts compose region molecules with document scroll instead.
+
+## Height contracts
+
+Three, and mixing them up is the most common way to break a page:
+
+- **`owns-viewport`** — owns a full-height root (`min-h-dvh`); does not rely on app-global
+  height CSS. The shells.
+- **`document-scroll`** — grows with content, the host owns the scroll container and the
+  device safe-area. The page-content layouts.
+- **`fills-parent`** — fills the parent's height and scrolls its regions internally.
+  **Requires a bounded-height ancestor**; in a box with an indefinite height it collapses
+  to zero. Document the host contract on the component and verify each host with a test.

--- a/packages/layout/layouts.json
+++ b/packages/layout/layouts.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fiscozen/claude-plugin-agentic-design/main/docs/ds-layouts.schema.json",
+  "package": "@fiscozen/layout",
+  "indexPath": "src/index.ts",
+  "exportPattern": "Template$",
+  "layouts": [
+    {
+      "name": "FzAppTemplate",
+      "kind": "shell",
+      "heightContract": "owns-viewport",
+      "surfaces": ["FO", "BO"],
+      "since": "1.1.0",
+      "whenToUse": "The standard application page: a persistent navigation rail (or top bar on mobile) beside the content, with optional sticky header, complementary aside panel, sticky bottom action bar and footer. The default choice for any signed-in page.",
+      "notWhenToUse": "Not for a page whose nav rail itself collapses into a drawer — that is FzSidebarTemplate. Not for auth/login (FzBlankTemplate) or guided flows (FzFocusTemplate).",
+      "slots": ["nav", "header", "default", "aside", "bottomBar", "footer"],
+      "keyProps": ["hasAside", "hasBottomBar", "chrome", "contentWidth", "navLabel", "asideLabel"],
+      "composeOnly": {
+        "safe": false,
+        "gaps": [
+          "the page background is reachable only through a fall-through `class` on the template root (the README example uses class=\"bg-[#f7f6f3]\"); RFC §4 planned a `background` prop that was not shipped — shipped props are hasAside/hasBottomBar/chrome/contentWidth/navLabel/asideLabel"
+        ]
+      },
+      "docs": "packages/layout/README.md#fzapptemplate"
+    },
+    {
+      "name": "FzSidebarTemplate",
+      "kind": "shell",
+      "heightContract": "owns-viewport",
+      "surfaces": ["BO"],
+      "since": "1.2.0",
+      "whenToUse": "Internal-tool / console app whose entire chrome is one persistent coloured side rail in three zones: brand at the top, scrollable navigation in the middle, the signed-in user pinned to the bottom. Below the desktop breakpoint the rail itself becomes an off-canvas drawer opened from a hamburger in a mobile top bar.",
+      "notWhenToUse": "Not when the navigation stays persistent and an aside panel is what collapses — that is FzAppTemplate. The two are mirrors of each other; pick by asking which region disappears on mobile.",
+      "slots": ["brand", "nav", "footer", "topbar", "default"],
+      "keyProps": ["navLabel", "sidebarLabel", "menuLabel"],
+      "composeOnly": {
+        "safe": false,
+        "gaps": [
+          "sidebar colours and width are reachable only through the `--fz-sidebar-bg` / `--fz-sidebar-text` / `--fz-sidebar-width` custom properties set on the template root, which needs `style` or `class`; the fallbacks are #fff / inherit / 280px, so under compose-only the rail renders unthemed and a design with a coloured sidebar cannot be implemented",
+          "the page background is reachable only through a fall-through `class` on the template root"
+        ]
+      }
+    },
+    {
+      "name": "FzFocusTemplate",
+      "kind": "shell",
+      "heightContract": "owns-viewport",
+      "surfaces": ["FO"],
+      "since": "1.1.0",
+      "whenToUse": "A distraction-reduced flow: onboarding steps, guided wizards and auth screens. Centred content optionally framed by a top bar, a complementary aside (stacking below the content on narrow viewports) and a footer.",
+      "notWhenToUse": "Not for an ordinary application page with navigation — that is FzAppTemplate. Use FzBlankTemplate instead when the screen needs no chrome at all.",
+      "slots": ["topbar", "default", "aside", "footer"],
+      "keyProps": ["chrome"],
+      "composeOnly": { "safe": true },
+      "docs": "packages/layout/README.md#fzfocustemplate"
+    },
+    {
+      "name": "FzBlankTemplate",
+      "kind": "shell",
+      "heightContract": "owns-viewport",
+      "surfaces": ["FO", "BO"],
+      "since": "1.1.0",
+      "whenToUse": "A full-bleed page with no chrome whatsoever — one full-height content region and nothing else. For login/auth screens and standalone tools that render their own self-contained UI.",
+      "notWhenToUse": "Not a way to opt out of navigation on a page that belongs inside the app shell.",
+      "slots": ["default"],
+      "keyProps": ["align"],
+      "composeOnly": { "safe": true },
+      "docs": "packages/layout/README.md#fzblanktemplate"
+    },
+    {
+      "name": "FzListTemplate",
+      "kind": "page-content",
+      "heightContract": "document-scroll",
+      "surfaces": ["BO"],
+      "since": "1.1.0",
+      "whenToUse": "A list page: an optional full-width banner (alerts, action cards), an optional filter rail, an optional toolbar (title/search/actions) and the list itself, typically an FzTable. Each region renders only when its slot is filled.",
+      "notWhenToUse": "Not a split-view master-detail (list beside a navigable detail pane) — that shape still uses the FzLayout leftShoulder grid variant. Not a page shell: it must render inside one.",
+      "slots": ["banner", "filters", "header", "default"],
+      "keyProps": ["filtersPosition", "filtersLabel", "mainAs"],
+      "nestWithin": ["FzAppTemplate", "FzSidebarTemplate"],
+      "whenNested": {
+        "props": { "mainAs": "div" },
+        "note": "the shell already owns the <main> landmark; also set filtersLabel when the shell renders its own aside, so the filter rail and the shell's panel are distinguishable complementary landmarks"
+      },
+      "composeOnly": { "safe": true },
+      "docs": "packages/layout/README.md#fzlisttemplate"
+    },
+    {
+      "name": "FzDetailTemplate",
+      "kind": "page-content",
+      "heightContract": "document-scroll",
+      "surfaces": ["BO"],
+      "since": "1.1.0",
+      "whenToUse": "A record-detail page: a persistent summary/context rail (the record's identity, status, meta and actions) beside the record's content (typically FzTabs or FzCards), with an optional full-width banner and an optional toolbar. The sibling of FzListTemplate — a list pairs a filter rail with a table, a detail page pairs a summary rail with the record.",
+      "notWhenToUse": "Not a page shell: it must render inside one. If the rail holds filters rather than a record summary, the page is a list — use FzListTemplate.",
+      "slots": ["banner", "sidebar", "toolbar", "default"],
+      "keyProps": ["sidebarLabel", "mainAs"],
+      "nestWithin": ["FzAppTemplate", "FzSidebarTemplate"],
+      "whenNested": {
+        "props": { "mainAs": "div" },
+        "note": "the shell already owns the <main> landmark; also set sidebarLabel when the shell renders its own aside. The toolbar region is deliberately a plain container, not a banner landmark — the shell owns the page banner"
+      },
+      "composeOnly": { "safe": true },
+      "docs": "packages/layout/README.md#fzdetailtemplate"
+    },
+    {
+      "name": "FzThreeColumnsTemplate",
+      "kind": "bounded",
+      "heightContract": "fills-parent",
+      "surfaces": ["BO"],
+      "since": "1.2.0",
+      "whenToUse": "A review workspace page (e.g. accounting document approval): a full-width header bar, a collapsible list/navigation sidebar, and two equal-width content columns — a left preview column and a right column with its own header and an independently scrollable body.",
+      "notWhenToUse": "Not the same thing as FzLayout's layout=\"threeColumns\" variant, which is a CSS-grid primitive with menu/header/chat/main/footer regions. Not for a page that should scroll as one document — that is FzListTemplate or FzDetailTemplate.",
+      "slots": [
+        "header-left",
+        "header-right",
+        "sidebar-header",
+        "sidebar-filter",
+        "sidebar-content",
+        "column-left",
+        "column-right-header",
+        "column-right-content"
+      ],
+      "keyProps": ["sidebarCollapsed", "mainAs", "sidebarLabel"],
+      "composeOnly": {
+        "safe": false,
+        "gaps": [
+          "it fills its parent's height and requires a bounded-height ancestor, which a compose-only consumer cannot create: FzContainer exposes no height/viewport prop (tag, alignItems, main, gap, horizontal, layout). Mounted in a box with an indefinite height it collapses to zero and its regions never scroll — and no host is verified yet, so nestWithin is deliberately empty"
+        ]
+      }
+    },
+    {
+      "name": "FzLayout",
+      "kind": "grid",
+      "heightContract": "fills-parent",
+      "since": "1.0.0",
+      "whenToUse": "The low-level responsive grid primitive (oneColumn, oneColumnHeader, twoColumns, leftShoulder, rightShoulder, multipleAreas, threeColumns). Retained for in-page arrangement and for the split-view master-detail shape no page layout covers yet.",
+      "notWhenToUse": "Not a page layout — do not build a page shell out of it. Its leftShoulder variant forces 100vh mobile tracks and independent per-region scroll, which is why the list/detail layouts compose region molecules with document scroll instead.",
+      "keyProps": ["layout", "isViewport", "hasBottomBar", "disablePadding"],
+      "composeOnly": { "safe": true },
+      "docs": "packages/layout/README.md#fzlayout--grid-primitive-organism"
+    },
+    {
+      "name": "FzLayoutMain",
+      "kind": "region",
+      "heightContract": "document-scroll",
+      "since": "1.1.0",
+      "whenToUse": "Internal region wrapper for a page's primary content, rendering the <main> landmark. Composed by the page layouts.",
+      "notWhenToUse": "Not for app code. The composing layout applies its sizing and padding via fall-through attributes, so using it directly means re-implementing a page layout by hand.",
+      "keyProps": ["as", "align", "safeArea"],
+      "composeOnly": {
+        "safe": false,
+        "gaps": ["sizing and padding are applied by the composing layout via a fall-through class — by design, which is why this is layout-internal"]
+      }
+    },
+    {
+      "name": "FzLayoutHeader",
+      "kind": "region",
+      "heightContract": "document-scroll",
+      "since": "1.1.0",
+      "whenToUse": "Internal region wrapper for the top-bar region, rendering the <header> banner landmark. Composed by the page layouts.",
+      "notWhenToUse": "Not for app code — see FzLayoutMain.",
+      "keyProps": ["as"],
+      "composeOnly": {
+        "safe": false,
+        "gaps": ["sizing and padding are applied by the composing layout via a fall-through class — by design"]
+      }
+    },
+    {
+      "name": "FzLayoutAside",
+      "kind": "region",
+      "heightContract": "document-scroll",
+      "since": "1.1.0",
+      "whenToUse": "Internal region wrapper for a complementary region, rendering the <aside> landmark. Composed by the page layouts.",
+      "notWhenToUse": "Not for app code — see FzLayoutMain.",
+      "keyProps": ["as"],
+      "composeOnly": {
+        "safe": false,
+        "gaps": ["sizing and padding are applied by the composing layout via a fall-through class — by design"]
+      }
+    },
+    {
+      "name": "FzLayoutFooter",
+      "kind": "region",
+      "heightContract": "document-scroll",
+      "since": "1.1.0",
+      "whenToUse": "Internal region wrapper for the footer region, rendering the <footer> contentinfo landmark. Composed by the page layouts.",
+      "notWhenToUse": "Not for app code — see FzLayoutMain.",
+      "keyProps": ["as"],
+      "composeOnly": {
+        "safe": false,
+        "gaps": ["sizing and padding are applied by the composing layout via a fall-through class — by design"]
+      }
+    },
+    {
+      "name": "FzLayoutBottomBar",
+      "kind": "region",
+      "heightContract": "document-scroll",
+      "since": "1.1.0",
+      "whenToUse": "Internal region wrapper for the sticky bottom action bar, composed by FzAppTemplate, which provides its element as a teleport target under FZ_BOTTOM_BAR_TARGET.",
+      "notWhenToUse": "Not for app code. To put content in the bar, inject FZ_BOTTOM_BAR_TARGET and teleport into it, or fill the shell's bottomBar slot.",
+      "composeOnly": {
+        "safe": false,
+        "gaps": ["placement and geometry are owned by the composing layout — by design"]
+      },
+      "docs": "packages/layout/README.md#bottom-bar-teleport-contract-fz_bottom_bar_target"
+    }
+  ]
+}

--- a/packages/layout/src/__tests__/layoutComposition.spec.ts
+++ b/packages/layout/src/__tests__/layoutComposition.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import {
+  FzAppTemplate,
+  FzSidebarTemplate,
+  FzListTemplate,
+  FzDetailTemplate
+} from '..'
+
+/**
+ * Verifies the shell + page-content pairs that `layouts.json` advertises in each
+ * entry's `nestWithin`.
+ *
+ * The manifest is what tells every consuming repo which layouts may be composed
+ * together, and the plugin presents an unlisted pair as "unverified — ask". That
+ * promise is only worth making if the listed pairs are actually exercised, so
+ * each one gets a test here. The invariant that matters is landmark ownership:
+ * the shell owns `<main>`, the nested page-content layout must not add a second
+ * one (which is what its documented `mainAs="div"` is for), and the nested
+ * layout's own complementary rail must survive the nesting.
+ *
+ * Adding a `nestWithin` entry to the manifest means adding a case here.
+ */
+
+// ---------------------------------------------------------------------------
+// window.matchMedia mock — jsdom doesn't provide it and both shells query
+// `(min-width: 1200px)`. Desktop keeps the shells in their persistent-rail
+// state, which is the layout the pairs are documented against.
+// ---------------------------------------------------------------------------
+const originalMatchMedia = window.matchMedia
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  })
+})
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: originalMatchMedia
+  })
+})
+
+const SHELLS = [
+  { name: 'FzAppTemplate', component: FzAppTemplate },
+  { name: 'FzSidebarTemplate', component: FzSidebarTemplate }
+] as const
+
+describe('layout composition (manifest `nestWithin`)', () => {
+  describe.each(SHELLS)('$name', ({ component: Shell }) => {
+    it('owns exactly one main landmark on its own', () => {
+      const wrapper = mount(Shell, { slots: { default: 'content' } })
+      expect(wrapper.findAll('main')).toHaveLength(1)
+    })
+
+    it('hosts FzListTemplate without a second main landmark', () => {
+      const wrapper = mount(Shell, {
+        slots: {
+          default: () =>
+            h(
+              FzListTemplate,
+              { mainAs: 'div', filtersLabel: 'Filtri' },
+              {
+                filters: () => 'filters',
+                header: () => 'toolbar',
+                default: () => 'rows'
+              }
+            )
+        }
+      })
+
+      // The shell owns the single `main`; the nested layout renders its content
+      // region as a plain container instead.
+      expect(wrapper.findAll('main')).toHaveLength(1)
+      expect(wrapper.find('.fz-list-template').exists()).toBe(true)
+      expect(wrapper.text()).toContain('rows')
+      // The nested layout's own complementary rail survives, and stays named so
+      // it is distinguishable from any rail the shell contributes.
+      const rails = wrapper.findAll('aside[aria-label="Filtri"]')
+      expect(rails).toHaveLength(1)
+    })
+
+    it('hosts FzDetailTemplate without a second main landmark', () => {
+      const wrapper = mount(Shell, {
+        slots: {
+          default: () =>
+            h(
+              FzDetailTemplate,
+              { mainAs: 'div', sidebarLabel: 'Riepilogo' },
+              {
+                sidebar: () => 'summary',
+                toolbar: () => 'actions',
+                default: () => 'body'
+              }
+            )
+        }
+      })
+
+      expect(wrapper.findAll('main')).toHaveLength(1)
+      expect(wrapper.find('.fz-detail-template').exists()).toBe(true)
+      expect(wrapper.text()).toContain('body')
+      expect(wrapper.findAll('aside[aria-label="Riepilogo"]')).toHaveLength(1)
+    })
+
+    it('produces two main landmarks if the nested layout keeps its default mainAs', () => {
+      // Documents *why* `whenNested.props` in the manifest is not optional: drop
+      // the prop and the page exposes two `main` landmarks, which is invalid.
+      const wrapper = mount(Shell, {
+        slots: { default: () => h(FzListTemplate, null, { default: () => 'rows' }) }
+      })
+      expect(wrapper.findAll('main')).toHaveLength(2)
+    })
+  })
+})

--- a/packages/layout/src/__tests__/layouts.manifest.spec.ts
+++ b/packages/layout/src/__tests__/layouts.manifest.spec.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Guards `packages/layout/layouts.json` — the page-layout manifest consumed by
+ * the agentic-design plugin to answer "which layout should this page use?" in
+ * every repo built on this design system.
+ *
+ * The manifest is only useful if it stays in step with what the package actually
+ * exports. A layout added without a manifest entry is invisible to the tooling
+ * (or, worse, reported as unclassified), so parity is enforced here rather than
+ * left to review. This spec runs in the pre-commit `nx affected -t test:unit`
+ * gate, which means the manifest cannot drift into a commit.
+ *
+ * Failure messages are written to be actionable on first read — including the
+ * exact JSON skeleton to add — because the thing that most often adds a layout
+ * here is an agent, and a red test that says only "expected 13 to be 14" costs a
+ * round trip.
+ */
+
+// `fileURLToPath` on the string, not on a `new URL(...)`: under the jsdom test
+// environment the global `URL` is jsdom's, which Node's converter rejects.
+const HERE = dirname(fileURLToPath(import.meta.url))
+const manifest = JSON.parse(readFileSync(join(HERE, '../../layouts.json'), 'utf8'))
+const indexSource = readFileSync(join(HERE, '../index.ts'), 'utf8')
+const typesSource = readFileSync(join(HERE, '../types.ts'), 'utf8')
+
+const KINDS = ['shell', 'page-content', 'bounded', 'region', 'grid']
+const HEIGHT_CONTRACTS = ['owns-viewport', 'document-scroll', 'fills-parent']
+
+/** Names re-exported from the barrel that look like page layouts. */
+function exportedLayoutNames(): string[] {
+  const pattern = new RegExp(manifest.exportPattern ?? 'Template$')
+  const names = new Set<string>()
+  for (const line of indexSource.split('\n')) {
+    const match = line.match(/export\s*\{\s*default\s+as\s+([A-Za-z0-9_]+)\s*\}/)
+    if (match && pattern.test(match[1])) names.add(match[1])
+  }
+  return [...names].sort()
+}
+
+/** Slot keys declared on a layout's `Fz<Name>Slots` type in types.ts. */
+function declaredSlots(name: string): string[] | null {
+  const typeName = `${name}Slots`
+  const start = typesSource.indexOf(`type ${typeName} = {`)
+  if (start === -1) return null
+  const open = typesSource.indexOf('{', start)
+  let depth = 0
+  let end = -1
+  for (let i = open; i < typesSource.length; i++) {
+    if (typesSource[i] === '{') depth++
+    else if (typesSource[i] === '}') {
+      depth--
+      if (depth === 0) {
+        end = i
+        break
+      }
+    }
+  }
+  if (end === -1) return null
+  const body = typesSource.slice(open + 1, end)
+  const slots: string[] = []
+  // Top-level members only: `name?(props): any` / `'name'?(props): any`
+  let nesting = 0
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim()
+    if (nesting === 0) {
+      const member = trimmed.match(/^'?([A-Za-z][A-Za-z0-9-]*)'?\??\(/)
+      if (member) slots.push(member[1])
+    }
+    nesting += (line.match(/\{/g) ?? []).length - (line.match(/\}/g) ?? []).length
+  }
+  return slots
+}
+
+function skeleton(name: string): string {
+  return JSON.stringify(
+    {
+      name,
+      kind: `one of ${KINDS.join(' | ')}`,
+      heightContract: `one of ${HEIGHT_CONTRACTS.join(' | ')}`,
+      surfaces: ['FO or BO'],
+      since: 'the version this ships in',
+      whenToUse: 'the page shape this is for, in one or two sentences',
+      notWhenToUse: 'the layout it is most easily confused with, and why this is not it',
+      slots: declaredSlots(name) ?? ['see Fz…Slots in types.ts'],
+      keyProps: ['props worth surfacing at plan time'],
+      nestWithin: ['only hosts proven by a composition test — omit if none'],
+      composeOnly: { safe: true, gaps: [] }
+    },
+    null,
+    2
+  )
+}
+
+describe('layouts.json manifest', () => {
+  // ============================================
+  // PARITY WITH THE BARREL
+  // ============================================
+  describe('Parity with src/index.ts', () => {
+    it('has an entry for every exported page layout', () => {
+      const declared = new Set(manifest.layouts.map((l: { name: string }) => l.name))
+      const missing = exportedLayoutNames().filter((n) => !declared.has(n))
+
+      expect(
+        missing,
+        missing.length === 0
+          ? ''
+          : [
+              '',
+              `packages/layout/layouts.json is missing ${missing.length} exported layout(s): ${missing.join(', ')}.`,
+              '',
+              'This manifest is how every repo built on this design system decides which layout a',
+              'page should use. A layout that is exported but unlisted is invisible to that tooling.',
+              '',
+              'Add an entry per missing layout to the `layouts` array, e.g.:',
+              '',
+              missing.map(skeleton).join(',\n'),
+              '',
+              'Field meanings — see docs/ds-layouts.schema.json in the agentic-design plugin:',
+              '  kind=shell         a top-level page frame that owns the viewport height (one per page)',
+              '  kind=page-content  renders INSIDE a shell; set `nestWithin` + `whenNested`',
+              '  kind=bounded       fills its parent and needs a bounded-height ancestor',
+              '  kind=region        an internal region wrapper — not for app code',
+              '  kind=grid          an in-page grid primitive, not a page frame',
+              '',
+              'Only list a host in `nestWithin` if a composition test proves the pair works.',
+              ''
+            ].join('\n')
+      ).toEqual([])
+    })
+
+    it('has no entry for a layout the package no longer exports', () => {
+      // Region molecules and the grid primitive are exported without the layout
+      // suffix, so check every manifest entry against the barrel text directly.
+      const stale = manifest.layouts
+        .map((l: { name: string }) => l.name)
+        .filter((name: string) => !new RegExp(`\\b${name}\\b`).test(indexSource))
+
+      expect(
+        stale,
+        stale.length === 0
+          ? ''
+          : `layouts.json lists ${stale.join(', ')}, which src/index.ts no longer exports. ` +
+              'Remove the stale entry (or restore the export).'
+      ).toEqual([])
+    })
+  })
+
+  // ============================================
+  // SHAPE
+  // ============================================
+  describe('Shape', () => {
+    it('declares the package and a non-empty layouts array', () => {
+      expect(manifest.package).toBe('@fiscozen/layout')
+      expect(Array.isArray(manifest.layouts)).toBe(true)
+      expect(manifest.layouts.length).toBeGreaterThan(0)
+    })
+
+    it.each(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      manifest.layouts.map((l: any) => [l.name, l] as const)
+    )('%s has the required fields with valid values', (name, layout) => {
+      expect(typeof name, 'every entry needs a `name`').toBe('string')
+      expect(KINDS, `${name}.kind must be one of ${KINDS.join(' | ')}`).toContain(layout.kind)
+      expect(
+        typeof layout.whenToUse === 'string' && layout.whenToUse.length > 20,
+        `${name}.whenToUse must describe the page shape this layout is for — it is the text the ` +
+          'layout decision is actually made from'
+      ).toBe(true)
+      if (layout.heightContract !== undefined) {
+        expect(HEIGHT_CONTRACTS, `${name}.heightContract is invalid`).toContain(layout.heightContract)
+      }
+      if (layout.since !== undefined) {
+        expect(layout.since, `${name}.since must be a semver version`).toMatch(/^\d+\.\d+\.\d+/)
+      }
+      if (layout.composeOnly !== undefined) {
+        expect(typeof layout.composeOnly.safe, `${name}.composeOnly.safe must be a boolean`).toBe(
+          'boolean'
+        )
+        if (layout.composeOnly.safe === false) {
+          expect(
+            layout.composeOnly.gaps?.length,
+            `${name}.composeOnly.safe is false, so list the gap(s) — consumers under a ` +
+              'compose-only policy are shown this text before they commit to the layout'
+          ).toBeGreaterThan(0)
+        }
+      }
+    })
+
+    it('gives every nesting layout a host list or none at all, never a host that is not a shell', () => {
+      const shells = new Set(
+        manifest.layouts
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .filter((l: any) => l.kind === 'shell')
+          .map((l: { name: string }) => l.name)
+      )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for (const layout of manifest.layouts as any[]) {
+        for (const host of layout.nestWithin ?? []) {
+          expect(
+            shells.has(host),
+            `${layout.name}.nestWithin lists "${host}", which is not a shell in this manifest`
+          ).toBe(true)
+        }
+      }
+    })
+  })
+
+  // ============================================
+  // SLOT PARITY
+  // ============================================
+  describe('Slot parity with types.ts', () => {
+    it.each(
+      manifest.layouts
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .filter((l: any) => Array.isArray(l.slots) && declaredSlots(l.name) !== null)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .map((l: any) => [l.name, l.slots] as const)
+    )('%s slots match its Fz…Slots type', (name, slots) => {
+      const declared = declaredSlots(name as string)!
+      expect(
+        [...slots].sort(),
+        `layouts.json lists slots [${[...slots].sort().join(', ')}] for ${name}, but ` +
+          `${name}Slots in types.ts declares [${[...declared].sort().join(', ')}]. ` +
+          'Update the manifest (or the type) so the two agree — consumers read the manifest ' +
+          'to know which slots exist.'
+      ).toEqual([...declared].sort())
+    })
+  })
+})

--- a/packages/layout/src/index.ts
+++ b/packages/layout/src/index.ts
@@ -1,3 +1,14 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// ⚠ MANIFEST CONTRACT — every layout exported from this barrel MUST have an
+// entry in ./layouts.json (see ../CLAUDE.md). That manifest is how every repo
+// built on this design system decides which layout a page should use; a layout
+// that is exported but unlisted is invisible to that tooling.
+//
+// Enforced by ./__tests__/layouts.manifest.spec.ts, which runs in the
+// pre-commit `nx affected -t test:unit` gate. Add the entry in the same commit
+// as the export. Add a `nestWithin` host only when a composition test in
+// ./__tests__/layoutComposition.spec.ts proves the pair works.
+// ─────────────────────────────────────────────────────────────────────────────
 export { default as FzLayout } from './FzLayout.vue'
 export { default as FzLayoutMain } from './FzLayoutMain.vue'
 export { default as FzLayoutHeader } from './FzLayoutHeader.vue'


### PR DESCRIPTION
Jira: [LIB-2801](https://fiscozen.atlassian.net/browse/LIB-2801)

Publishes `packages/layout/layouts.json` alongside the components: a machine-readable description of what each page layout is *for*, so the layout choice is answerable from the design system's own source of truth.

## Why

The page layouts are currently discoverable only by reading source. `src/index.ts` exports thirteen components, which downstream tooling reduces to a comma-separated list of names against the package description ("Design System Layout component"). Nothing says which page shape each one covers, which is a shell and which is page content, which nests inside which, or which props are mandatory when nesting — and those distinctions are not cosmetic: a `page-content` layout used at top level has no scroll container, and a `bounded` layout without a bounded-height ancestor collapses to zero height.

So repos governed by the agentic-design plugin hand-copy the layout list into their own config, and that copy goes stale every release — `FzThreeColumnsTemplate` and `FzSidebarTemplate` aren't even in the package README yet.

## What's in the manifest

Per entry: `kind` (`shell` / `page-content` / `bounded` / `region` / `grid`), `heightContract`, `whenToUse` / `notWhenToUse`, `slots`, `keyProps`, `nestWithin` + `whenNested`, `since`, and `composeOnly`.

Consuming repos read it at session start and generate a layout decision table, so a layout added here becomes selectable across the org with no per-repo configuration and no change to the plugin. Contract: `docs/ds-layouts.schema.json` in the agentic-design plugin (this manifest validates against it).

## How drift is prevented

`layouts.manifest.spec.ts` asserts that every exported layout has an entry (and no entry names a removed export), that `slots` match the corresponding `Fz…Slots` type in `types.ts`, that `nestWithin` names real shells, and that a declared compose-only gap is described. It runs in the existing pre-commit `nx affected -t test:unit` gate, so the manifest can't drift into a commit.

Its failure message prints the JSON skeleton to add, with the `kind` values explained — the thing that most often adds a layout is an agent, and a bare assertion diff costs a round trip. `src/index.ts` carries a marker pointing at the contract, and `packages/layout/CLAUDE.md` states it for contributors.

## Verified, not asserted

`layoutComposition.spec.ts` covers the shell + page-content pairs the manifest advertises (`FzListTemplate` and `FzDetailTemplate` inside `FzAppTemplate` and `FzSidebarTemplate`), asserting a single `<main>` landmark and that the nested layout's own complementary rail survives — plus the negative case showing that dropping `mainAs="div"` yields two `main` landmarks, which is why `whenNested.props` is treated as mandatory downstream.

`FzThreeColumnsTemplate` deliberately has **no** `nestWithin` host: its bounded-height contract isn't verified against any shell, so consumers are shown "unverified — ask" rather than a guess.

## Known compose-only gaps, declared honestly

Consuming repos run a compose-only styling policy (no `class` / `style` anywhere), so a capability reachable only via a fall-through `class`/`style` doesn't exist for them. Three are recorded in the manifest so the plugin warns at plan time instead of the developer hitting a blocked write:

- `FzSidebarTemplate` — sidebar colours only settable via `--fz-sidebar-*` custom properties, i.e. `style`. Fallbacks are `#fff` / `inherit`, so a design with a coloured sidebar can't be implemented.
- `FzAppTemplate` — page background only via a fall-through `class` (the README example does exactly this); RFC §4 planned a `background` prop that wasn't shipped.
- `FzThreeColumnsTemplate` — needs a bounded-height ancestor a compose-only consumer can't create, since `FzContainer` has no height/viewport prop.

Each gets its own card; this PR only records them.

## Checks

- 240/240 layout package tests pass; `vue-tsc` and ESLint clean.
- `layouts.json` validated against the schema independently via `ajv-cli`.
- Drift test confirmed to fire on a simulated new export.
- Additive only (RFC §10): no component behaviour changes, no existing API touched. Changeset at `minor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-2801]: https://fiscozen.atlassian.net/browse/LIB-2801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ