### PR TITLE
fix(composables): don't pin FzFloating to a narrow opener below xs

### DIFF
--- a/.changeset/fzfloating-xs-opener-width.md
+++ b/.changeset/fzfloating-xs-opener-width.md
@@ -1,0 +1,11 @@
+---
+"@fiscozen/composables": patch
+---
+
+FzFloating: stop pinning the panel to a narrow opener below the `xs` breakpoint
+
+On viewports at or below the `xs` breakpoint (376px) `FzFloating` forced the floating panel's width to the opener's width, so the panel would cover its opener — the intent behind the `FzTab` mobile picker and select-like inputs, whose openers span the available width.
+
+For a narrow opener the same rule broke the panel: a 44px icon button (`FzIconDropdown`, e.g. a per-row kebab menu) collapsed the panel box to 44px while its action list kept painting at its intrinsic width, outside the box. The viewport clamp added in 1.1.1 could not correct this — it measures the panel box, which at 44px was already comfortably on screen — so on a 360px-wide device the menu rendered roughly 190px off the right edge, half visible.
+
+The rule is now expressed as a minimum instead of a fixed width: `width` stays `auto` and `min-width` is set to the opener's width on `xs`. Full-width openers still get a panel that covers them, while a narrow opener's panel takes its content width, at which point the existing boundary correction keeps it inside the viewport. Above `xs` nothing changes.

--- a/packages/composables/src/FzFloating.vue
+++ b/packages/composables/src/FzFloating.vue
@@ -170,7 +170,15 @@ watch(
     content.value.style.top = '0px'
     content.value.style.left = '0px'
     content.value.style.transform = 'none'
-    content.value.style.width = xs.value ? openerRect?.width + 'px' : 'auto'
+    // On the smallest screens the panel should cover its opener (e.g. the FzTab picker or
+    // a select input). Pinning the width to the opener does that, but it breaks narrow
+    // openers: a 44px icon button collapses the panel box while its content keeps painting
+    // at its intrinsic width — outside the box, and therefore invisible to the viewport
+    // clamp in useFloating, which only ever sees a small box that is already on screen.
+    // A minimum keeps the cover-the-opener behaviour and lets a narrow opener's panel grow
+    // to its content, which the clamp can then keep inside the viewport.
+    content.value.style.width = 'auto'
+    content.value.style.minWidth = xs.value && openerRect ? `${openerRect.width}px` : ''
     floating.setPosition()
   }
 )

--- a/packages/composables/src/__tests__/FzFloating.spec.ts
+++ b/packages/composables/src/__tests__/FzFloating.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import FzFloating from '../FzFloating.vue'
 import { FzFloatingPosition } from '../types'
 
@@ -57,6 +58,74 @@ describe('FzFloating', () => {
 
       wrapper.find('button').trigger('click')
       expect(wrapper.html()).toMatchSnapshot()
+    })
+  })
+
+  describe('content width on the smallest screens', () => {
+    const setViewportMatchesXs = (matches: boolean) => {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query) => ({
+          matches,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+
+    // Mounts closed, stubs the opener width, then opens so the width assignment runs.
+    const openWithOpenerWidth = async (openerWidth: number) => {
+      const wrapper = mount(FzFloating, {
+        props: { position: 'bottom', isOpen: false },
+        slots: {
+          opener: '<button>opener</button>',
+          default: '<div>content</div>'
+        },
+        attachTo: document.body
+      })
+
+      const openerEl = wrapper.find('button').element.parentElement!
+      openerEl.getBoundingClientRect = () =>
+        ({ width: openerWidth, height: 44, top: 0, left: 0, right: openerWidth, bottom: 44 }) as DOMRect
+
+      await wrapper.setProps({ isOpen: true })
+      await nextTick()
+
+      return wrapper.find('.fz__floating__content').element as HTMLElement
+    }
+
+    it('does not pin the panel to a narrow (icon-button) opener', async () => {
+      setViewportMatchesXs(true)
+
+      const content = await openWithOpenerWidth(44)
+
+      // Pinning the width to a 44px icon button collapses the panel: its content keeps
+      // painting at its intrinsic width, outside the box and off screen, where the
+      // viewport clamp in useFloating cannot see it (HD-25388 / LIB-2809).
+      expect(content.style.width).toBe('auto')
+      expect(content.style.minWidth).toBe('44px')
+    })
+
+    it('still covers a full-width opener', async () => {
+      setViewportMatchesXs(true)
+
+      const content = await openWithOpenerWidth(360)
+
+      expect(content.style.minWidth).toBe('360px')
+    })
+
+    it('does not constrain the panel above the xs breakpoint', async () => {
+      setViewportMatchesXs(false)
+
+      const content = await openWithOpenerWidth(44)
+
+      expect(content.style.width).toBe('auto')
+      expect(content.style.minWidth).toBe('')
     })
   })
 })


### PR DESCRIPTION
Jira: [LIB-2809](https://fiscozen.atlassian.net/browse/LIB-2809)

Fixes the customer report in [HD-25388](https://fiscozen.atlassian.net/browse/HD-25388): on an Android phone, the per-row kebab menu in the invoice list opens half off the right edge of the screen.

## Root cause

`FzFloating` pins the floating panel's width to the opener's width at or below the `xs` breakpoint (376px), so the panel covers its opener. That is right for a full-width opener — it is what `fix(tab): full width picker on mobile` (d6b3669e) was written for — but wrong for a narrow one: a 44px `FzIconButton` opener collapses the panel box to 44px while the action list keeps painting at its intrinsic ~240px, outside the box.

The viewport clamp added in #418 (`@fiscozen/composables` 1.1.1) cannot correct that. `applyBoundaryCorrections` measures the panel box, and a 44px box near the right edge is already comfortably on screen, so nothing is shifted. Measured at a 360px viewport before this change: box `left 308 / right 352`, content painted out to `x = 548` — about 190px off screen.

This is why bumping the app's `@fiscozen/*` dependencies (LIB-2807) did not fix the report: the deployed bundle does contain the 1.1.1 clamp, it just never applies to this case.

## The change

Express the rule as a minimum rather than a fixed width — `width: auto` plus `min-width: <opener width>` on `xs`. Full-width openers still get a panel that covers them; a narrow opener's panel takes its content width, at which point the existing boundary correction keeps it inside the viewport. Above `xs` nothing changes.

## Verification

Storybook at a 360px viewport, `FzIconDropdown` pinned to the right edge:

| | box | painted right edge | on screen |
|---|---|---|---|
| before | `left 308 / right 352`, width 44px | 548 | ❌ ~190px off |
| after | `left 79.6 / right 352`, width 272px | 352 | ✅ right edge at viewport − 8 |

No regression for full-width openers at 360px:

- `FzTabs` picker — panel 296px, opener 296px, fully on screen
- `FzSelect` — panel 284px, opener 284px, fully on screen
- `FzDatepicker` — unaffected; it renders `@vuepic/vue-datepicker`'s own menu, not `FzFloating`

Tests: 3 new cases in `FzFloating.spec.ts` (narrow opener, full-width opener, above `xs`); they fail on `main` and pass here. `@fiscozen/composables` is green at 102/102. The `tab`, `datepicker`, `dropdown` and `typeahead` suites show the same 5 pre-existing `data-v-*` snapshot mismatches before and after the change — unrelated to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2809]: https://fiscozen.atlassian.net/browse/LIB-2809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HD-25388]: https://fiscozen.atlassian.net/browse/HD-25388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ