### PR TITLE
fix(composables): make FzFloating vertical correction opener-aware

### DIFF
--- a/.changeset/fzfloating-vertical-clamp-opener-aware.md
+++ b/.changeset/fzfloating-vertical-clamp-opener-aware.md
@@ -1,0 +1,22 @@
+---
+"@fiscozen/composables": patch
+---
+
+FzFloating: stop the vertical viewport correction from detaching the panel from its opener
+
+The boundary correction added in 1.1.1 shifted a floating panel up whenever it would overflow the bottom of the viewport. That is the wrong move for a panel anchored to an opener, and it produced two visible defects — reported as action lists opening at the top of the page instead of next to their button:
+
+* a panel slightly too tall was slid up **across its own opener**, covering the control that opened it;
+* a panel taller than the viewport was pinned to the 8px top margin, i.e. arbitrarily far from its opener — 760px away at a 412x792 viewport with the opener near the bottom.
+
+It bites hardest on placements that never flip: `FzDropdown` resolves its `align` prop to an explicit `bottom` / `bottom-start` / `bottom-end` position, and auto-position resolution only runs for `auto*` placements, so this correction is the only vertical adjustment a dropdown ever receives.
+
+The vertical correction is now opener-aware:
+
+* if the panel would overflow the bottom and fits on the other side of the opener, it **flips above** it (and the mirror case for `top*` placements overflowing the top);
+* if it fits nowhere else but fits in the viewport, it is clamped as before;
+* if it is taller than the available space, the anchored position is kept — clamping cannot reveal more of it and only breaks the association with the opener.
+
+The horizontal correction is deliberately unchanged: a panel shifted sideways stays on the opener's row and still reads as belonging to it, and clamping a too-wide panel to the left margin does bring its content on screen. Neither of those holds vertically.
+
+Note for consumers: a panel taller than the visible space is now cropped at the bottom instead of being moved to the top of the screen. Capping the panel height with internal scrolling is tracked separately.

--- a/packages/composables/src/__tests__/useFloating.spec.ts
+++ b/packages/composables/src/__tests__/useFloating.spec.ts
@@ -360,7 +360,7 @@ describe('useFloating', () => {
       expect(Number.isNaN(floating.float.position.y)).toBe(false)
     })
 
-    it('shifts a menu up so its bottom edge stays on screen (vertical clamp)', async () => {
+    it('flips a menu above its opener when it would overflow the bottom', async () => {
       setViewport(390, 600)
 
       // Opener near the bottom of the viewport; a bottom-anchored menu would
@@ -387,9 +387,138 @@ describe('useFloating', () => {
       await floating.setPosition()
       await nextTick()
 
+      // The invariant is unchanged: the whole menu stays on screen.
+      expect(floating.float.position.y).toBeGreaterThanOrEqual(VIEWPORT_MARGIN)
       expect(floating.float.position.y + ELEMENT_HEIGHT).toBeLessThanOrEqual(600 - VIEWPORT_MARGIN)
-      // Clamped to viewportHeight - margin - elementHeight = 600 - 8 - 100.
-      expect(floating.float.position.y).toBe(600 - VIEWPORT_MARGIN - ELEMENT_HEIGHT)
+      // It gets there by flipping to the other side of the opener (bottom edge one margin
+      // above opener.top = 540 - 8 - 100) rather than sliding up across it, which would
+      // have left the menu covering the control that opened it.
+      expect(floating.float.position.y).toBe(540 - VIEWPORT_MARGIN - ELEMENT_HEIGHT)
+      expect(floating.float.position.y + ELEMENT_HEIGHT).toBeLessThanOrEqual(540)
+    })
+
+    it('flips a menu below its opener when it would overflow the top', async () => {
+      setViewport(390, 600)
+
+      // Opener near the top; a top-anchored menu would overflow above the fold.
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 100,
+        height: 40,
+        top: 20,
+        left: 100,
+        right: 200,
+        bottom: 60,
+        x: 100,
+        y: 20,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('top-start'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      // One margin below opener.bottom, so the menu clears its opener instead of
+      // covering it.
+      expect(floating.float.position.y).toBe(60 + VIEWPORT_MARGIN)
+      expect(floating.float.position.y + ELEMENT_HEIGHT).toBeLessThanOrEqual(600 - VIEWPORT_MARGIN)
+    })
+
+    it('stays anchored to the opener when the element is taller than the viewport', async () => {
+      // A long action list (e.g. the tax page menus) on a phone-height viewport. No
+      // vertical position can show all of it, and clamping to the top margin does not
+      // reveal more of it — it just detaches the panel from the button that opened it,
+      // which is what users reported as "the menu opens at the top of the page" (HD-25736).
+      setViewport(412, 792)
+
+      const TALL_HEIGHT = 900
+      mockElement.getBoundingClientRect = vi.fn(() => ({
+        width: ELEMENT_WIDTH,
+        height: TALL_HEIGHT,
+        top: 0,
+        left: 0,
+        right: ELEMENT_WIDTH,
+        bottom: TALL_HEIGHT,
+        x: 0,
+        y: 0,
+        toJSON: () => {}
+      })) as any
+
+      // Opener low on the screen, as a per-row menu far down a list would be.
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 44,
+        height: 44,
+        top: 728,
+        left: 100,
+        right: 144,
+        bottom: 772,
+        x: 100,
+        y: 728,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('bottom-start'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      // bottom-start anchors the top edge at opener.bottom. The panel must keep that
+      // anchor rather than being pinned to the margin at the top of the screen.
+      expect(floating.float.position.y).toBe(772)
+      expect(floating.float.position.y).not.toBe(VIEWPORT_MARGIN)
+    })
+
+    it('still clamps vertically when the element fits exactly in the available space', async () => {
+      // Boundary case for the fits-check: height equals the space between the margins,
+      // so the correction must still apply (and land the element flush at the margin).
+      setViewport(390, 600)
+
+      const EXACT_HEIGHT = 600 - VIEWPORT_MARGIN * 2
+      mockElement.getBoundingClientRect = vi.fn(() => ({
+        width: ELEMENT_WIDTH,
+        height: EXACT_HEIGHT,
+        top: 0,
+        left: 0,
+        right: ELEMENT_WIDTH,
+        bottom: EXACT_HEIGHT,
+        x: 0,
+        y: 0,
+        toJSON: () => {}
+      })) as any
+
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 100,
+        height: 40,
+        top: 540,
+        left: 100,
+        right: 200,
+        bottom: 580,
+        x: 100,
+        y: 540,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('bottom-start'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      expect(floating.float.position.y).toBe(VIEWPORT_MARGIN)
     })
   })
 

--- a/packages/composables/src/composables/useFloating.ts
+++ b/packages/composables/src/composables/useFloating.ts
@@ -398,6 +398,7 @@ const applyBoundaryCorrections = (
   element: DOMRect,
   container: DOMRect,
   transform: Transform,
+  opener: DOMRect | null = null,
   viewport: Bounds = getViewportBounds(),
   margin: number = VIEWPORT_MARGIN
 ): { position: FzAbsolutePosition; transform: Transform } => {
@@ -425,16 +426,36 @@ const applyBoundaryCorrections = (
   }
 
   // --- Vertical ---
-  const minTop = bounds.top + margin
-  const maxTop = Math.max(minTop, bounds.bottom - margin - element.height)
+  // Only correct when the element can actually fit between the margins. A taller element
+  // is cropped by the same amount wherever it sits, so shifting it reveals nothing — it
+  // only detaches the panel from its opener, landing it at the top margin however far
+  // that is from the control that opened it. That is what surfaced as "the menu opens at
+  // the top of the page instead of next to the button" (HD-25736), and it bites hardest
+  // on placements that never flip: FzDropdown resolves `align` to an explicit `bottom*`
+  // position, so this correction is the only vertical adjustment it ever gets.
+  //
+  // Deliberately asymmetric with the horizontal case above: a panel shifted sideways stays
+  // on the opener's row and reads as belonging to it, and clamping a too-wide panel to the
+  // left margin at least brings its content on screen. Neither holds vertically.
+  const availableHeight = bounds.bottom - bounds.top - margin * 2
 
-  if (correctedPosition.y > maxTop) {
-    correctedPosition.y = maxTop
-    correctedTransform.y = 0
-  }
-  if (correctedPosition.y < minTop) {
-    correctedPosition.y = minTop
-    correctedTransform.y = 0
+  if (element.height <= availableHeight) {
+    const minTop = bounds.top + margin
+    const maxTop = bounds.bottom - margin - element.height
+    // Where the element would sit on the opposite side of the opener.
+    const aboveOpener = opener ? opener.top - margin - element.height : null
+    const belowOpener = opener ? opener.bottom + margin : null
+
+    if (correctedPosition.y > maxTop) {
+      // Overflows the bottom. Prefer the other side of the opener: sliding the panel up
+      // within the viewport would drag it across the control that opened it.
+      correctedPosition.y = aboveOpener !== null && aboveOpener >= minTop ? aboveOpener : maxTop
+      correctedTransform.y = 0
+    } else if (correctedPosition.y < minTop) {
+      // Mirror case for `top*` placements near the top edge.
+      correctedPosition.y = belowOpener !== null && belowOpener <= maxTop ? belowOpener : minTop
+      correctedTransform.y = 0
+    }
   }
 
   return { position: correctedPosition, transform: correctedTransform }
@@ -606,7 +627,8 @@ export const useFloating = (
         realPosition,
         rects.element,
         rects.container,
-        positionResult.transform
+        positionResult.transform,
+        rects.opener
       )
 
       // Step 10: Update float state


### PR DESCRIPTION
Jira: [LIB-2813](https://fiscozen.atlassian.net/browse/LIB-2813)

Fixes [HD-25736](https://fiscozen.atlassian.net/browse/HD-25736) — on production, pressing a button that opens an action list makes the menu appear at the top of the page instead of next to the button (reported on `/app/tasse`).

## This is a regression from #418, now live in production

1. `1ba3c85540 chore(LIB-2807)` (app PR #15458) is on master, pinning `@fiscozen/composables ^1.1.1`.
2. The bundle production serves — `frontoffice.fiscozen-ds.Dc0Usel8.js` — contains this package's clamp code (`VIEWPORT_MARGIN`, `getViewportBounds`, `getCollisionBounds`).
3. `FzDropdown` resolves `align` to an explicit `bottom` / `bottom-start` / `bottom-end`, and `resolveAutoPosition` only runs for `auto*` placements — so a dropdown **never flips**, and #418's clamp is the only vertical adjustment it receives.
4. `maxTop = Math.max(minTop, bounds.bottom − margin − element.height)` collapses to `minTop` once the panel is as tall as the viewport, regardless of where the opener is.

Measured at 412×792 with the opener near the bottom (`top 728 / bottom 772`):

| menu height | before | after |
|---|---|---|
| 240px (fits) | `top 548` — slid up **across its own opener**, 224px overlap | `top 484 / bottom 724` — flipped above, 4px clear of the button |
| 900px (taller than viewport) | `top 12` — **760px from the button** | `top 776` — anchored at the opener's bottom |

## The change

`applyBoundaryCorrections` now receives the opener rect and prefers the opposite side of the opener over sliding across it:

- overflows the bottom and fits above → **flip above the opener** (mirror case for `top*` placements overflowing the top);
- fits neither side but fits the viewport → clamp, as before;
- taller than the available space → **keep the anchored position**. Clamping cannot reveal more of it; it only detaches the panel from its opener.

The horizontal half of #418 is deliberately untouched — it's what fixes the off-screen kebab menu (HD-25388), and a panel shifted sideways stays on the opener's row so it still reads as belonging to it. Neither of those holds vertically; the comment in the code states this asymmetry.

## Reviewer note: one existing test changed

`shifts a menu up so its bottom edge stays on screen (vertical clamp)` (added by #418) asserted the exact slid-up coordinate, `600 − 8 − 100 = 492`. With this change the menu reaches safety by flipping above the opener instead, so the value is now `540 − 8 − 100 = 432`. The invariant the test was protecting — the whole menu stays on screen — still holds and is still asserted; I also added the stronger assertion that the menu clears its opener. Renamed to `flips a menu above its opener when it would overflow the bottom`.

## Tests

3 new cases: taller-than-viewport stays anchored (fails on `main` with `expected 8 to be 772`), fits-exactly still clamps (boundary case for the fits check), and `top*` overflowing the top flips below. `@fiscozen/composables` green at 102/102.

## Behaviour change to be aware of

A panel taller than the visible space is now cropped at the bottom rather than moved to the top of the screen. That's the pre-#418 behaviour and the honest outcome; capping panel height with internal scrolling is tracked separately (it's also what the Datepicker needs — LIB-2814).

Note: PR #424 (LIB-2809) also touches this package but a different file and hunk (`FzFloating.vue`'s width assignment vs `useFloating.ts`'s vertical correction), so the two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2813]: https://fiscozen.atlassian.net/browse/LIB-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HD-25736]: https://fiscozen.atlassian.net/browse/HD-25736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ