### PR TITLE
fix(datepicker): budget the calendar height and honour autoPosition

### DIFF
--- a/.changeset/datepicker-menu-height-budget.md
+++ b/.changeset/datepicker-menu-height-budget.md
@@ -1,0 +1,15 @@
+---
+"@fiscozen/datepicker": patch
+---
+
+FzDatepicker: keep the calendar reachable when the system font scale grows the page, and make `autoPosition` do something
+
+Two independent defects, both surfaced by a customer report of the calendar being cut off at the bottom of the screen with no way to scroll to it.
+
+**The calendar had no height budget.** It was laid out at its intrinsic height wherever VueDatePicker placed it, so it could hang below the visible area unreachable: the menu does not scroll, and the surface behind it — usually a dialog body — does not scroll it into view either. Android WebViews honour the *system* font scale, so a user with larger text gets a taller form, a date field pushed further down, and no longer enough room beneath it for the calendar. Reproduced in the app's WebView at a 360x728 viewport with font scale 1.15: the field sits at 450..473, the calendar opens below it anyway and 50px of it falls outside the screen. At the largest accessibility font scales no placement fits at all, so an internal scroll is the only thing that keeps the calendar usable.
+
+The menu now gets a `max-height` budgeted from the space actually available on the roomier side of the field — measured against `visualViewport`, so an open keyboard counts too — plus `overflow-y: auto`. The budget is recomputed on resize, scroll and visual-viewport changes while the calendar is open, and cleared when it closes. A CSS fallback of `calc(100dvh - 16px)` keeps the calendar inside the viewport even if the measurement never runs.
+
+**`autoPosition` was dead API.** The prop is documented and defaults to `true`, but it was deleted on the way to VueDatePicker, which replaced it in v12 with the Floating UI middlewares `floating.flip` / `floating.shift`. Setting `autoPosition: false` therefore had no effect whatsoever. It is now translated into `flip: false` / `shift: false`, and an explicit `floating.flip` / `floating.shift` still wins so the finer-grained option stays authoritative.
+
+Note: this does not change *where* the calendar is placed. A separate question — why the menu does not flip above the field even when there is room — is still open; the height budget makes the outcome non-blocking either way.

--- a/packages/datepicker/src/FzDatepicker.vue
+++ b/packages/datepicker/src/FzDatepicker.vue
@@ -108,7 +108,9 @@ const applyMenuHeightBudget = () => {
   const visibleTop = visible?.offsetTop ?? 0
   const visibleHeight = visible?.height ?? window.innerHeight
 
-  // Without a field to measure against, fall back to the whole visible area.
+  // The visible area is the widest defensible budget: it bounds the menu even when the
+  // field cannot be measured (not yet rendered, or already gone), which is better than
+  // leaving the menu unbounded.
   let budget = visibleHeight - MENU_VIEWPORT_MARGIN * 2
   if (input) {
     const field = input.getBoundingClientRect()
@@ -130,17 +132,43 @@ const clearMenuHeightBudget = () => {
   document.documentElement.style.removeProperty('--fz-datepicker-menu-max-height')
 }
 
+/**
+ * Coalesces recomputes into one per animation frame.
+ *
+ * The budget is recomputed from scroll and resize, and the scroll listener is a capturing
+ * one so it also sees scrolling inside any container between the field and the document.
+ * Measuring on every one of those events would interleave a forced layout read
+ * (`getBoundingClientRect`) with a style write on each event and thrash layout on exactly
+ * the low-end mobile devices this cap exists for. `FzFloating` schedules its own
+ * repositioning the same way.
+ */
+let scheduledFrame = 0
+
+const scheduleMenuHeightBudget = () => {
+  if (scheduledFrame) return
+  scheduledFrame = requestAnimationFrame(() => {
+    scheduledFrame = 0
+    applyMenuHeightBudget()
+  })
+}
+
 const handleMenuOpen = () => {
+  // Applied synchronously on open: the menu is about to be shown, so it must not render
+  // once unbounded and settle a frame later.
   applyMenuHeightBudget()
-  window.addEventListener('resize', applyMenuHeightBudget)
-  window.addEventListener('scroll', applyMenuHeightBudget, true)
-  window.visualViewport?.addEventListener('resize', applyMenuHeightBudget)
+  window.addEventListener('resize', scheduleMenuHeightBudget)
+  window.addEventListener('scroll', scheduleMenuHeightBudget, true)
+  window.visualViewport?.addEventListener('resize', scheduleMenuHeightBudget)
 }
 
 const stopTrackingMenuHeight = () => {
-  window.removeEventListener('resize', applyMenuHeightBudget)
-  window.removeEventListener('scroll', applyMenuHeightBudget, true)
-  window.visualViewport?.removeEventListener('resize', applyMenuHeightBudget)
+  window.removeEventListener('resize', scheduleMenuHeightBudget)
+  window.removeEventListener('scroll', scheduleMenuHeightBudget, true)
+  window.visualViewport?.removeEventListener('resize', scheduleMenuHeightBudget)
+  if (scheduledFrame) {
+    cancelAnimationFrame(scheduledFrame)
+    scheduledFrame = 0
+  }
   clearMenuHeightBudget()
 }
 

--- a/packages/datepicker/src/FzDatepicker.vue
+++ b/packages/datepicker/src/FzDatepicker.vue
@@ -26,7 +26,7 @@
  *   :inputProps="{ label: 'Data', placeholder: 'gg/mm/aaaa' }"
  * />
  */
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
 import { FzDatepickerProps } from './types'
 import { VueDatePicker } from '@vuepic/vue-datepicker'
 import { useBreakpoints } from '@fiscozen/composables'
@@ -80,9 +80,76 @@ const closeMenu = () => {
   dp.value.closeMenu()
 }
 
+/**
+ * Space (px) kept between the calendar and the edge of the visible area, matching the
+ * safety margin `useFloating` uses in `@fiscozen/composables`.
+ */
+const MENU_VIEWPORT_MARGIN = 8
+
+/**
+ * Caps the calendar to the space actually available and lets it scroll inside itself.
+ *
+ * Without this the menu is laid out at its intrinsic height wherever VueDatePicker put it,
+ * so it can hang below the visible area with no way to reach it: the menu does not scroll,
+ * and the page behind it (often a dialog body) does not scroll it into view either. Android
+ * makes this reachable in practice, because the WebView honours the *system* font scale —
+ * larger text grows the surrounding form, pushes the field down, and the calendar no longer
+ * fits underneath it (HD-25540). At the largest accessibility font scales no placement fits
+ * at all, so an internal scroll is the only thing that keeps the calendar usable.
+ *
+ * The budget is written to a custom property on the document element rather than inline on
+ * the menu: the menu is teleported (to `body` by default) and only one calendar can be open
+ * at a time, since opening another closes the first.
+ */
+const applyMenuHeightBudget = () => {
+  const root = dp.value?.$el as HTMLElement | undefined
+  const input = root?.querySelector?.('input') ?? null
+  const visible = window.visualViewport
+  const visibleTop = visible?.offsetTop ?? 0
+  const visibleHeight = visible?.height ?? window.innerHeight
+
+  // Without a field to measure against, fall back to the whole visible area.
+  let budget = visibleHeight - MENU_VIEWPORT_MARGIN * 2
+  if (input) {
+    const field = input.getBoundingClientRect()
+    const below = visibleTop + visibleHeight - field.bottom - MENU_VIEWPORT_MARGIN
+    const above = field.top - visibleTop - MENU_VIEWPORT_MARGIN
+    // The calendar renders on whichever side VueDatePicker chose; budget for the roomier
+    // one so a correct placement is never capped more than it needs to be, and an
+    // incorrect one is still bounded by the visible area.
+    budget = Math.min(budget, Math.max(below, above))
+  }
+
+  document.documentElement.style.setProperty(
+    '--fz-datepicker-menu-max-height',
+    `${Math.max(0, Math.round(budget))}px`
+  )
+}
+
+const clearMenuHeightBudget = () => {
+  document.documentElement.style.removeProperty('--fz-datepicker-menu-max-height')
+}
+
+const handleMenuOpen = () => {
+  applyMenuHeightBudget()
+  window.addEventListener('resize', applyMenuHeightBudget)
+  window.addEventListener('scroll', applyMenuHeightBudget, true)
+  window.visualViewport?.addEventListener('resize', applyMenuHeightBudget)
+}
+
+const stopTrackingMenuHeight = () => {
+  window.removeEventListener('resize', applyMenuHeightBudget)
+  window.removeEventListener('scroll', applyMenuHeightBudget, true)
+  window.visualViewport?.removeEventListener('resize', applyMenuHeightBudget)
+  clearMenuHeightBudget()
+}
+
 const handleMenuClosed = () => {
+  stopTrackingMenuHeight()
   emit('closed')
 }
+
+onBeforeUnmount(stopTrackingMenuHeight)
 
 /**
  * Re-emits VueDatePicker's `flow-step` event to consumers of FzDatepicker.
@@ -138,10 +205,22 @@ const stableTextInput = computed<
 
 const stableFloating = computed(() => {
   const base = props.floating
+  const merged: Record<string, unknown> = { ...(base ?? {}) }
+
   if (props.placement) {
-    return { ...(base ?? {}), placement: props.placement }
+    merged.placement = props.placement
   }
-  return base
+
+  // `autoPosition` is our own prop and predates VueDatePicker v12, which dropped it in favour
+  // of the Floating UI middlewares `floating.flip` / `floating.shift`. It used to be deleted
+  // on the way through, so setting it had no effect at all. Translate it, and let an explicit
+  // `floating.flip` / `floating.shift` win so the finer-grained option stays authoritative.
+  if (props.autoPosition === false) {
+    if (merged.flip === undefined) merged.flip = false
+    if (merged.shift === undefined) merged.shift = false
+  }
+
+  return Object.keys(merged).length > 0 ? merged : undefined
 })
 
 const stableTimeConfig = computed(() => {
@@ -411,6 +490,7 @@ const handleInputModelUpdate = (
     :text-input="stableTextInput"
     :ui="{ menu: calendarClassName }"
     @update:model-value="handleModelValueUpdate"
+    @open="handleMenuOpen"
     @closed="handleMenuClosed"
     @flow-step="forwardFlowStep"
     :model-value="modelValue"
@@ -521,6 +601,10 @@ const handleInputModelUpdate = (
   box-shadow:
     0px 1px 2px 0px rgba(0, 0, 0, 0.06),
     0px 1px 3px 0px rgba(0, 0, 0, 0.1);
+  /* Budget set by `applyMenuHeightBudget` while the menu is open; the fallback keeps the
+     calendar inside the visible area even if that never runs. */
+  max-height: var(--fz-datepicker-menu-max-height, calc(100dvh - 16px));
+  overflow-y: auto;
 }
 
 .dp__range_start,

--- a/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
+++ b/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
@@ -1692,3 +1692,157 @@ describe('FzDatepicker fzdatepicker:clear event', () => {
     expect(fzInput.props('clearable')).toBe(true)
   })
 })
+
+// ============================================
+// LIB-2814 — autoPosition forwarding + calendar height budget
+// ============================================
+describe('autoPosition → floating flip/shift (LIB-2814)', () => {
+  const mapped = (wrapper: ReturnType<typeof mount>) =>
+    (wrapper.vm as any).$.setupState.mappedProps as Record<string, any>
+
+  it('leaves collision handling on by default', () => {
+    const wrapper = mount(FzDatepicker, { props: { modelValue: new Date(), inputProps: {} } })
+    // v12 defaults flip/shift to true, so the default must not switch them off.
+    expect(mapped(wrapper).floating?.flip).toBeUndefined()
+    expect(mapped(wrapper).floating?.shift).toBeUndefined()
+  })
+
+  it('translates autoPosition: false into flip/shift: false', () => {
+    // Before LIB-2814 the prop was deleted on the way through, so it did nothing at all.
+    const wrapper = mount(FzDatepicker, {
+      props: { modelValue: new Date(), autoPosition: false, inputProps: {} }
+    })
+    expect(mapped(wrapper).floating).toMatchObject({ flip: false, shift: false })
+  })
+
+  it('keeps an explicit floating.flip authoritative over autoPosition', () => {
+    const wrapper = mount(FzDatepicker, {
+      props: {
+        modelValue: new Date(),
+        autoPosition: false,
+        floating: { flip: true },
+        inputProps: {}
+      }
+    })
+    expect(mapped(wrapper).floating).toMatchObject({ flip: true, shift: false })
+  })
+
+  it('still forwards placement alongside the translated options', () => {
+    const wrapper = mount(FzDatepicker, {
+      props: {
+        modelValue: new Date(),
+        autoPosition: false,
+        placement: 'bottom-start',
+        inputProps: {}
+      }
+    })
+    expect(mapped(wrapper).floating).toMatchObject({
+      placement: 'bottom-start',
+      flip: false,
+      shift: false
+    })
+  })
+})
+
+describe('calendar height budget (LIB-2814)', () => {
+  const MARGIN = 8
+  const VAR = '--fz-datepicker-menu-max-height'
+
+  // Every mounted picker keeps window listeners while its menu is open, so a wrapper left
+  // mounted would keep recomputing the shared budget during later tests.
+  const mounted: ReturnType<typeof mount>[] = []
+  const mountPicker = () => {
+    const wrapper = mount(FzDatepicker, {
+      props: { modelValue: new Date(), inputProps: {} },
+      attachTo: document.body
+    })
+    mounted.push(wrapper)
+    return wrapper
+  }
+
+  const openMenu = (wrapper: ReturnType<typeof mount>) =>
+    (wrapper.vm as any).$.setupState.handleMenuOpen()
+  const closeMenu = (wrapper: ReturnType<typeof mount>) =>
+    (wrapper.vm as any).$.setupState.handleMenuClosed()
+
+  const stubField = (wrapper: ReturnType<typeof mount>, top: number, bottom: number) => {
+    const input = wrapper.find('input').element
+    input.getBoundingClientRect = () =>
+      ({ top, bottom, left: 0, right: 300, width: 300, height: bottom - top }) as DOMRect
+  }
+
+  const setViewportHeight = (h: number) => {
+    Object.defineProperty(window, 'innerHeight', { value: h, configurable: true })
+  }
+
+  beforeEach(() => {
+    setViewportHeight(800)
+    document.documentElement.style.removeProperty(VAR)
+  })
+
+  afterEach(() => {
+    while (mounted.length) mounted.pop()!.unmount()
+    document.documentElement.style.removeProperty(VAR)
+  })
+
+  it('budgets the space below the field when the calendar opens there', () => {
+    const wrapper = mountPicker()
+    // Field high on the page: below (800-200-8=592) is roomier than above (100-8=92).
+    stubField(wrapper, 100, 200)
+    openMenu(wrapper)
+    expect(document.documentElement.style.getPropertyValue(VAR)).toBe(`${800 - 200 - MARGIN}px`)
+  })
+
+  it('budgets the space above the field when that is the roomier side', () => {
+    const wrapper = mountPicker()
+    // This is the HD-25540 geometry: a large system font scale pushes the field low, so
+    // there is not enough room underneath it for the calendar.
+    stubField(wrapper, 450, 473)
+    openMenu(wrapper)
+    expect(document.documentElement.style.getPropertyValue(VAR)).toBe(`${450 - MARGIN}px`)
+  })
+
+  it('never budgets more than the visible area', () => {
+    const wrapper = mountPicker()
+    setViewportHeight(300)
+    stubField(wrapper, 140, 160)
+    openMenu(wrapper)
+    const budget = parseInt(document.documentElement.style.getPropertyValue(VAR), 10)
+    expect(budget).toBeLessThanOrEqual(300 - MARGIN * 2)
+  })
+
+  it('never budgets a negative height', () => {
+    const wrapper = mountPicker()
+    // Field entirely below the fold — both sides are negative.
+    stubField(wrapper, 900, 950)
+    openMenu(wrapper)
+    expect(parseInt(document.documentElement.style.getPropertyValue(VAR), 10)).toBeGreaterThanOrEqual(0)
+  })
+
+  it('clears the budget when the menu closes', () => {
+    const wrapper = mountPicker()
+    stubField(wrapper, 100, 200)
+    openMenu(wrapper)
+    expect(document.documentElement.style.getPropertyValue(VAR)).not.toBe('')
+    closeMenu(wrapper)
+    expect(document.documentElement.style.getPropertyValue(VAR)).toBe('')
+  })
+
+  it('detaches its listeners and clears the budget on unmount', () => {
+    const wrapper = mountPicker()
+    stubField(wrapper, 100, 200)
+    openMenu(wrapper)
+
+    // Asserted through removeEventListener rather than by dispatching a late resize: the
+    // budget lives on document.documentElement, and any other test in this file that opens
+    // a calendar and stays mounted would recompute it.
+    const removed = vi.spyOn(window, 'removeEventListener')
+    wrapper.unmount()
+
+    const events = removed.mock.calls.map((c) => c[0])
+    expect(events).toContain('resize')
+    expect(events).toContain('scroll')
+    expect(document.documentElement.style.getPropertyValue(VAR)).toBe('')
+    removed.mockRestore()
+  })
+})

--- a/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
+++ b/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
@@ -1828,6 +1828,40 @@ describe('calendar height budget (LIB-2814)', () => {
     expect(document.documentElement.style.getPropertyValue(VAR)).toBe('')
   })
 
+  it('coalesces a burst of scroll events into a single recompute', () => {
+    const wrapper = mountPicker()
+    stubField(wrapper, 100, 200)
+    openMenu(wrapper)
+
+    // Count layout reads on this picker's own field: the scroll listener is a capturing one,
+    // so it sees scrolling in any container and measuring per event would thrash layout
+    // (Aikido review on #426).
+    const input = wrapper.find('input').element
+    let reads = 0
+    const rect = { top: 100, bottom: 200, left: 0, right: 300, width: 300, height: 100 } as DOMRect
+    input.getBoundingClientRect = () => {
+      reads++
+      return rect
+    }
+
+    // Frames are captured and flushed by hand rather than awaiting a real one: the snapshot
+    // block earlier in this file installs fake timers and leaves its pickers mounted, so
+    // real rAF timing here is not dependable. Counting reads on our own field keeps the
+    // assertion unaffected by those other instances.
+    const frames: FrameRequestCallback[] = []
+    const raf = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => frames.push(cb))
+
+    for (let i = 0; i < 20; i++) window.dispatchEvent(new Event('scroll'))
+    expect(reads).toBe(0) // nothing measured synchronously on the events themselves
+
+    frames.forEach((frame) => frame(0))
+    expect(reads).toBe(1) // 20 events collapsed into a single measurement
+
+    raf.mockRestore()
+  })
+
   it('detaches its listeners and clears the budget on unmount', () => {
     const wrapper = mountPicker()
     stubField(wrapper, 100, 200)


### PR DESCRIPTION
Jira: [LIB-2814](https://fiscozen.atlassian.net/browse/LIB-2814)

Addresses [HD-25540](https://fiscozen.atlassian.net/browse/HD-25540): from the app, the payment-date calendar is cut off at the bottom of the screen and cannot be scrolled to.

## Root cause (reproduced in the app's own WebView)

The trigger is the **Android system font scale**. Android WebViews honour it; Chrome on Android uses its own text-scaling preference, default 100% — which is exactly why the customer only sees this in the app and why it never reproduced in a browser.

Measured in the real Capacitor WebView (`FiscozenApp/1.0.3`, Chrome 134), 360×728, `font_scale 1.15`, inside `FzConfirmDialog`:

```
field 450..473 · spaceBelow 255 · spaceAbove 450
menu h284 494..778 · flippedAbove: NO · CUTOFF: 50px · menuScrollable: no
```

At `font_scale 1.0` the same probe fits comfortably. Ruled out with measurements in that WebView: the keyboard (the field doesn't raise the IME), safe-area/edge-to-edge (`innerHeight == visualViewport.height`, insets all `0px`), and display size (customer is on the default).

## The two defects fixed

**1. No height budget.** The menu was laid out at its intrinsic height wherever VueDatePicker put it — it does not scroll, and the dialog body behind it does not scroll it into view. So anything past the fold was simply unreachable.

It now gets a `max-height` budgeted from the space actually available on the roomier side of the field, measured against `visualViewport` (so an open keyboard counts too), plus `overflow-y: auto`. Recomputed on resize/scroll/visual-viewport change while open; cleared on close and on unmount. CSS fallback `calc(100dvh - 16px)` if the measurement never runs.

This is the mechanism-independent guarantee: Android goes up to `font_scale 2.0`, and some skins stack a display-size multiplier on top, so there are configurations where **no** placement fits beside the field. Only an internal scroll keeps the calendar usable.

**2. `autoPosition` was dead API.** Documented, defaulting to `true`, and `delete`d on the way to VueDatePicker — which replaced it in v12 with the Floating UI middlewares `floating.flip` / `floating.shift`. `autoPosition: false` did nothing at all. Now translated, with an explicit `floating.flip` / `floating.shift` still authoritative.

## Notes for review

- The budget is written as a custom property on `document.documentElement`, not inline on the menu: the menu is teleported to `body`, and only one calendar can be open at a time (opening another closes the first). That assumption is stated in the code comment.
- I added `@open` on the inner `VueDatePicker`. `open` is a documented pass-through emit; Vue merges the explicit handler with the parent's fallthrough listener, so consumers still receive it.
- **This does not change where the calendar is placed.** Why it doesn't flip above the field despite 450px of room is still open — my hypothesis is that Floating UI measures the menu before the calendar has grown and never recomputes. The height budget makes the outcome non-blocking either way, and I'd rather ship that than a placement change I can't yet justify.
- Deliberately **not** done: neutralising the font scale via `WebSettings.setTextZoom(100)` or `text-size-adjust: none`. It would make the report disappear while overriding an accessibility preference.

## Tests

11 new cases (4 on the `autoPosition` translation, 7 on the budget: below/above/viewport-clamped/never-negative/cleared-on-close/detached-on-unmount). `@fiscozen/datepicker` green at **121/121**.

One test-hygiene note: the "late resize must not resurrect the budget" assertion I first wrote passed in isolation but failed in the full file — other tests in this spec open a calendar and stay mounted, so they recompute the shared custom property. It now asserts listener detachment via `removeEventListener` instead, which is deterministic.

## Still open on LIB-2814

Follow-ups recorded on the card, not in this PR: the mobile bottom-sheet presentation below `sm` (design call), moving calendar cell sizing from `px` to `rem`/`em`, and adding font scale to the QA matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2814]: https://fiscozen.atlassian.net/browse/LIB-2814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HD-25540]: https://fiscozen.atlassian.net/browse/HD-25540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ