### PR TITLE
fix(composables): stop document.body collapsing the collision bounds

### DIFF
--- a/.changeset/floating-viewport-collision-bounds.md
+++ b/.changeset/floating-viewport-collision-bounds.md
@@ -1,0 +1,13 @@
+---
+"@fiscozen/composables": patch
+---
+
+useFloating: stop `document.body`'s box from collapsing the collision bounds
+
+Collision handling intersected the container's rect with the viewport. The container defaults to `document.body` — both in `useFloating`'s own fallback and in `FzFloating`, which always passes `props.container || document.body` — and body's box describes how the page happens to lay itself out rather than anything a floating element should be clipped to.
+
+On an app shell that gives body a fixed height and scrolls an inner element, body's rect leaves the viewport as soon as the page is scrolled, and the intersection collapses. Measured on a frontoffice invoice list with a 411px-tall viewport scrolled by 260px: body's rect was `top -260 / bottom 151`, so the usable area came out as 151px instead of 411px, and available height as 135px instead of 395px. A 348px menu was then left anchored to its opener and hanging 293px below the fold. Before the opener-aware vertical correction, the same bounds pinned it to the 8px top margin instead — the "action list opens at the top of the page" symptom.
+
+When the resolved container is `document.body`, the viewport alone is now used as the collision boundary. A container the consumer actually named still constrains the correction exactly as before, so a genuinely narrower container is still honoured. Body's rect continues to be used for everything else it feeds: openerless positioning relative to the container, the intersection observer, and the `containerRect` handed to the position callback.
+
+One behavioural note for consumers: passing `document.body` explicitly as the container now yields viewport bounds rather than body's box. That is the intended reading — body means "no container" — and no known consumer relies on the old behaviour.

--- a/packages/composables/src/__tests__/useFloating.spec.ts
+++ b/packages/composables/src/__tests__/useFloating.spec.ts
@@ -429,6 +429,72 @@ describe('useFloating', () => {
       expect(floating.float.position.y + ELEMENT_HEIGHT).toBeLessThanOrEqual(600 - VIEWPORT_MARGIN)
     })
 
+    it('ignores document.body\'s box when it is the implicit container', async () => {
+      // Measured on the ephemeral env (/app/fatture-emesse): the frontoffice shell gives
+      // body a fixed height equal to the viewport and scrolls an inner element, so once the
+      // page is scrolled body's rect leaves the viewport. Intersecting with it collapsed the
+      // usable area to 151px of a 411px viewport, and a 348px menu was left anchored to its
+      // opener and cut off 293px below the fold (LIB-2825). Before LIB-2813's guard the same
+      // bounds pinned it to the top margin instead — the HD-25736 symptom.
+      setViewport(360, 411)
+
+      mockContainer.getBoundingClientRect = vi.fn(() => ({
+        width: 360,
+        height: 411,
+        top: -260,
+        left: 0,
+        right: 360,
+        bottom: 151,
+        x: 0,
+        y: -260,
+        toJSON: () => {}
+      })) as any
+
+      const MENU_HEIGHT = 348
+      mockElement.getBoundingClientRect = vi.fn(() => ({
+        width: ELEMENT_WIDTH,
+        height: MENU_HEIGHT,
+        top: 0,
+        left: 0,
+        right: ELEMENT_WIDTH,
+        bottom: MENU_HEIGHT,
+        x: 0,
+        y: 0,
+        toJSON: () => {}
+      })) as any
+
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 44,
+        height: 44,
+        top: 308,
+        left: 100,
+        right: 144,
+        bottom: 352,
+        x: 100,
+        y: 308,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('bottom-start'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      // The whole viewport is available, so the menu flips above the opener and stays on
+      // screen instead of hanging off the bottom.
+      expect(floating.float.position.y + MENU_HEIGHT).toBeLessThanOrEqual(411 - VIEWPORT_MARGIN)
+      expect(floating.float.position.y).toBeGreaterThanOrEqual(VIEWPORT_MARGIN)
+      // Flipping above would need 348 + 8 px and only 308 are free above the opener, so the
+      // menu is clamped inside the viewport instead: 411 - 8 - 348. The point is that it is
+      // fully visible — with body's collapsed box it ended up at 352, i.e. 293px off screen.
+      expect(floating.float.position.y).toBe(411 - VIEWPORT_MARGIN - MENU_HEIGHT)
+    })
+
     it('stays anchored to the opener when the element is taller than the viewport', async () => {
       // A long action list (e.g. the tax page menus) on a phone-height viewport. No
       // vertical position can show all of it, and clamping to the top margin does not

--- a/packages/composables/src/composables/useFloating.ts
+++ b/packages/composables/src/composables/useFloating.ts
@@ -380,23 +380,31 @@ const getViewportBounds = (): Bounds => ({
   bottom: window.innerHeight
 })
 
-// Effective collision boundary: the intersection of the container and the
-// viewport. Clamping to the container alone is not enough — for openerless
-// dropdowns the container resolves to document.body, whose rect can be wider
-// than the viewport (or extend under it) on narrow screens, letting the menu
-// overflow the right edge. Intersecting with the viewport guarantees the
-// element stays on screen while still honouring a real (narrower) container.
-const getCollisionBounds = (container: DOMRect, viewport: Bounds): Bounds => ({
-  left: Math.max(container.left, viewport.left),
-  right: Math.min(container.right, viewport.right),
-  top: Math.max(container.top, viewport.top),
-  bottom: Math.min(container.bottom, viewport.bottom)
-})
+// Effective collision boundary: the intersection of a real container and the viewport, so a
+// narrower container is still honoured while the element is always kept on screen.
+//
+// `null` means there is no meaningful container and the viewport alone applies. That is the
+// case when the container resolved to `document.body`: body is the "no container" default,
+// and its box describes how the page happens to lay itself out rather than anything the
+// floating element should be clipped to. On an app shell that gives body a fixed height and
+// scrolls an inner element, body's rect leaves the viewport as soon as the page is scrolled,
+// and intersecting with it collapses the usable area — measured at 151px of a 411px viewport,
+// which left menus anchored off the bottom of the screen or pinned to the top margin
+// (LIB-2825, and the first cause of HD-25736).
+const getCollisionBounds = (container: DOMRect | null, viewport: Bounds): Bounds =>
+  container
+    ? {
+        left: Math.max(container.left, viewport.left),
+        right: Math.min(container.right, viewport.right),
+        top: Math.max(container.top, viewport.top),
+        bottom: Math.min(container.bottom, viewport.bottom)
+      }
+    : { ...viewport }
 
 const applyBoundaryCorrections = (
   realPosition: FzAbsolutePosition,
   element: DOMRect,
-  container: DOMRect,
+  container: DOMRect | null,
   transform: Transform,
   opener: DOMRect | null = null,
   viewport: Bounds = getViewportBounds(),
@@ -626,7 +634,8 @@ export const useFloating = (
       const corrected = applyBoundaryCorrections(
         realPosition,
         rects.element,
-        rects.container,
+        // body is the "no container" default; its box must not constrain collision handling.
+        refs.container === document.body ? null : rects.container,
         positionResult.transform,
         rects.opener
       )


### PR DESCRIPTION
Jira: [LIB-2825](https://fiscozen.atlassian.net/browse/LIB-2825)

Found while verifying [#15577](https://github.com/fiscozen/it.fiscozen.app/pull/15577) on the `lib-2824` ephemeral environment. This is the **first cause** of [HD-25736](https://fiscozen.atlassian.net/browse/HD-25736); [#425](https://github.com/fiscozen/design_system/pull/425) removed the symptom, this removes the cause.

## What I measured on the env

`/app/fatture-emesse`, viewport 411px tall, page scrolled by 260px:

```
document.body rect: top -260, bottom 151, height 411
→ collisionBounds:  top 0, bottom 151       (not 411)
→ availableHeight:  135                      (not 395)
   menu height 348 → fitsGuard FALSE → correction skipped
   menu left anchored at 352, hanging 293px below the fold
```

The frontoffice shell gives `body` a fixed height equal to the viewport and scrolls an inner element, so body's rect leaves the viewport as soon as you scroll. Intersecting the collision bounds with it collapses the usable area.

Run the pre-#425 formula on those same bounds and you get `maxTop = Math.max(8, 151 − 8 − 348) = 8` — the menu pinned to the top margin, i.e. *"si apre in alto alla pagina e non vicino al button"* verbatim. That's why I'm confident this is HD-25736's real cause rather than "panel taller than the viewport", which is how I originally characterised it.

## The change

When the resolved container **is** `document.body`, the viewport alone becomes the collision boundary. Body is the "no container" default, and its box describes page layout rather than a clipping region.

The predicate has to be *"the resolved container is body"*, not *"the caller passed no container"* — `FzFloating` always passes one, defaulting to `document.body`, so a caller-side check would never fire for its consumers.

A container the consumer actually named still constrains the correction exactly as before, so a genuinely narrower container is honoured. Body's rect keeps feeding everything else it feeds: openerless positioning relative to the container, the intersection observer, and the `containerRect` handed to the position callback.

#425's fits-guard stays. A panel truly taller than the available space can't fit anywhere, and without the guard it would go back to being pinned to the top. With correct bounds it now rarely triggers.

## Tests

New case reproduces the measured geometry — body `[-260, 151]`, 411px viewport, 348px menu, opener at `308..352` — and asserts the menu lands fully on screen. It fails on `main` with `expected 700 to be less than or equal to 403`, matching the 704 I measured live (the 4px being `mt-4`).

Worth noting what the expected value turned out to be: the menu does **not** flip above here, because flipping needs `348 + 8` px and only 308 are free above the opener. It clamps inside the viewport at `411 − 8 − 348 = 55` instead. Fully visible, which is the point.

`@fiscozen/composables` green at 106/106, including the existing explicit-container test. Also ran the consumers: dropdown 71, select 138, tooltip 69, tab 79, datepicker 111 — all green. No design system component passes a real `container` prop, so only the body-default path changes behaviour.

## Behavioural note

Passing `document.body` explicitly as the container now yields viewport bounds rather than body's box. That's the intended reading and no known consumer relies on the old behaviour, but it's called out in the changeset.

## Also verified on that env

[#424](https://github.com/fiscozen/design_system/pull/424) (LIB-2809) works: at `xs`, inline styles are `width: auto` / `min-width: 44px`, the panel takes its natural 240px width instead of collapsing to the 44px opener, painted content matches the box exactly (`8 → 248`), and all six actions are readable from the left margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2825]: https://fiscozen.atlassian.net/browse/LIB-2825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HD-25736]: https://fiscozen.atlassian.net/browse/HD-25736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ