### PR TITLE
fix(datepicker): budget the calendar against the side it is placed on

### DIFF
--- a/.changeset/datepicker-budget-used-side.md
+++ b/.changeset/datepicker-budget-used-side.md
@@ -1,0 +1,13 @@
+---
+"@fiscozen/datepicker": patch
+---
+
+FzDatepicker: budget the calendar's height against the side it is actually placed on
+
+The height cap added in 3.2.10 budgeted the roomier side above or below the field, assuming VueDatePicker would place the calendar there. It does not always: when it picks the tighter side the cap is far too generous to ever bind, so the calendar is cut off exactly as it was before the cap existed.
+
+Measured on a 320x620 viewport with the field at `504..524` — 504px above it, 96px below — VueDatePicker placed the calendar below anyway. The budget came out 496px (the space above) against 88px of real space, so `max-height` never constrained anything, `overflow-y: auto` produced no scroll, and 250px of calendar hung off the bottom with not a single date cell reachable.
+
+The budget is now taken from the side the menu actually occupies, determined by comparing the menu's box with the field's. Since the menu is not in the DOM on the first pass, the budget is recomputed once VueDatePicker has rendered it, and a `ResizeObserver` on the menu keeps it correct when the calendar changes height (switching to the month or year view). Only a menu with a real box is considered, so a zero-size one — mid-transition, or belonging to another picker — cannot mislead the side detection.
+
+Still open, and deliberately not addressed here: why `flip` does not move the calendar to the side with more room. Forcing a Floating UI recompute while the menu is open leaves the position unchanged, so it is not a stale measurement. The lever for whoever takes it on is that VueDatePicker builds its middleware as `flip(typeof floating.flip === 'object' ? floating.flip : {})`, so Floating UI options can be passed through FzDatepicker's `floating.flip` prop. This change makes the outcome usable regardless of the answer.

--- a/packages/datepicker/src/FzDatepicker.vue
+++ b/packages/datepicker/src/FzDatepicker.vue
@@ -116,10 +116,27 @@ const applyMenuHeightBudget = () => {
     const field = input.getBoundingClientRect()
     const below = visibleTop + visibleHeight - field.bottom - MENU_VIEWPORT_MARGIN
     const above = field.top - visibleTop - MENU_VIEWPORT_MARGIN
-    // The calendar renders on whichever side VueDatePicker chose; budget for the roomier
-    // one so a correct placement is never capped more than it needs to be, and an
-    // incorrect one is still bounded by the visible area.
-    budget = Math.min(budget, Math.max(below, above))
+
+    // Budget the side the menu is *actually* on. An earlier version budgeted the roomier
+    // side, assuming VueDatePicker would place the calendar there — it does not always, and
+    // when it picks the tighter side the cap is far too generous to ever bind. Measured on a
+    // 320x620 viewport with the field at 504..524: 504px above, 96px below, calendar placed
+    // below, budget 496px against 88px of real space, so the calendar was cut off by 250px
+    // with no row reachable (LIB-2827).
+    // Only a menu with a real box counts: a zero-size one is either mid-transition or a
+    // leftover from another picker, and trusting its rect would pick the wrong side.
+    const menu = [...document.querySelectorAll('.dp__menu')].find(
+      (el) => el.getBoundingClientRect().height > 0
+    )
+    if (menu) {
+      const placedBelow = menu.getBoundingClientRect().top >= field.bottom - 1
+      budget = Math.min(budget, placedBelow ? below : above)
+    } else {
+      // First run happens before VueDatePicker has rendered the menu, so the side is not
+      // known yet. Stay generous rather than flash a needlessly short calendar; the
+      // post-render recompute below refines it.
+      budget = Math.min(budget, Math.max(below, above))
+    }
   }
 
   document.documentElement.style.setProperty(
@@ -152,10 +169,31 @@ const scheduleMenuHeightBudget = () => {
   })
 }
 
+/**
+ * Watches the menu so the budget follows its real height: the calendar is not in the DOM on
+ * the first pass, and it changes height when the user switches to the month or year view.
+ */
+let menuResizeObserver: ResizeObserver | null = null
+
+const observeMenu = () => {
+  const menu = [...document.querySelectorAll('.dp__menu')].find(
+    (el) => el.getBoundingClientRect().height > 0
+  )
+  if (!menu || menuResizeObserver) return
+  menuResizeObserver = new ResizeObserver(scheduleMenuHeightBudget)
+  menuResizeObserver.observe(menu)
+}
+
 const handleMenuOpen = () => {
   // Applied synchronously on open: the menu is about to be shown, so it must not render
   // once unbounded and settle a frame later.
   applyMenuHeightBudget()
+  // ...then again once VueDatePicker has rendered the menu, which is when the side it was
+  // placed on becomes knowable.
+  requestAnimationFrame(() => {
+    observeMenu()
+    applyMenuHeightBudget()
+  })
   window.addEventListener('resize', scheduleMenuHeightBudget)
   window.addEventListener('scroll', scheduleMenuHeightBudget, true)
   window.visualViewport?.addEventListener('resize', scheduleMenuHeightBudget)
@@ -169,6 +207,8 @@ const stopTrackingMenuHeight = () => {
     cancelAnimationFrame(scheduledFrame)
     scheduledFrame = 0
   }
+  menuResizeObserver?.disconnect()
+  menuResizeObserver = null
   clearMenuHeightBudget()
 }
 

--- a/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
+++ b/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
@@ -1862,6 +1862,56 @@ describe('calendar height budget (LIB-2814)', () => {
     raf.mockRestore()
   })
 
+  // The menu is teleported to body, so tests stand one in for it and stub its rect.
+  const stubMenu = (top: number, height: number) => {
+    let el = document.querySelector('.dp__menu') as HTMLElement | null
+    if (!el) {
+      el = document.createElement('div')
+      el.className = 'dp__menu'
+      document.body.appendChild(el)
+    }
+    el.getBoundingClientRect = () =>
+      ({ top, bottom: top + height, height, left: 0, right: 240, width: 240 }) as DOMRect
+    // jsdom reports 0 for real layout, so the stub is what makes this menu "rendered"
+    return el
+  }
+  const removeMenu = () => document.querySelector('.dp__menu')?.remove()
+
+  it('budgets the side the menu is actually on, not the roomier one', () => {
+    const wrapper = mountPicker()
+    // HD-25540 geometry measured on the ephemeral env: field low, 96px below it, 504 above,
+    // and VueDatePicker places the calendar BELOW anyway. Budgeting the roomier side left
+    // the cap at 496px against 88px of real space, so it never bound and the calendar was
+    // cut off by 250px with no row reachable (LIB-2827).
+    setViewportHeight(620)
+    stubField(wrapper, 504, 524)
+    stubMenu(546, 324) // below the field
+    openMenu(wrapper)
+    expect(document.documentElement.style.getPropertyValue(VAR)).toBe(`${620 - 524 - MARGIN}px`)
+    removeMenu()
+  })
+
+  it('budgets the space above when the menu is placed above the field', () => {
+    const wrapper = mountPicker()
+    setViewportHeight(620)
+    stubField(wrapper, 504, 524)
+    stubMenu(180, 324) // above the field
+    openMenu(wrapper)
+    expect(document.documentElement.style.getPropertyValue(VAR)).toBe(`${504 - MARGIN}px`)
+    removeMenu()
+  })
+
+  it('falls back to the roomier side until the menu exists in the DOM', () => {
+    const wrapper = mountPicker()
+    // First run happens before VueDatePicker has rendered the menu, so no side is known yet;
+    // a later recompute refines it once the menu is there.
+    setViewportHeight(620)
+    stubField(wrapper, 504, 524)
+    removeMenu()
+    openMenu(wrapper)
+    expect(document.documentElement.style.getPropertyValue(VAR)).toBe(`${504 - MARGIN}px`)
+  })
+
   it('detaches its listeners and clears the budget on unmount', () => {
     const wrapper = mountPicker()
     stubField(wrapper, 100, 200)


### PR DESCRIPTION
Jira: [LIB-2827](https://fiscozen.atlassian.net/browse/LIB-2827)

Fixes the gap that stopped [#426](https://github.com/fiscozen/design_system/pull/426) from actually closing [HD-25540](https://fiscozen.atlassian.net/browse/HD-25540). Found by verifying `datepicker@3.2.10` on the `lib-2826` ephemeral environment.

## My reasoning in #426 was wrong

That PR budgeted the **roomier** side above or below the field, on the assumption VueDatePicker would place the calendar there, and claimed a wrong placement "would still be bounded by the visible area". It isn't — it's bounded by the *roomier side's* budget, which can far exceed the space where the menu actually sits.

Measured on `lib-2826` with mobile emulation, in the "Incassa la fattura" modal:

```
viewport 320x620 · field 504..524 → 504px above, 96px below
VueDatePicker placed the calendar BELOW: 546..870
budget applied: 496px  ← space above
space on the side used: 88px   → too generous by 408px
max-height never binds · overflow-y: auto produces no scroll
cutOffBelow: 250px · lastVisibleRow: "none visible"
```

Not one date cell was reachable. So 3.2.10 shipped a cap that couldn't engage in exactly the scenario it was written for.

## The change

The budget now comes from the side the menu **actually occupies**, decided by comparing the menu's box against the field's.

Two supporting pieces, both needed:

- **Recompute after render.** The menu isn't in the DOM on the first pass, so the side isn't knowable yet. The first pass stays generous (rather than flashing a needlessly short calendar) and a `requestAnimationFrame` recompute refines it once VueDatePicker has rendered.
- **`ResizeObserver` on the menu**, so the budget stays correct when the calendar changes height — switching to the month or year view — and is disconnected on close and unmount.

Only a menu with a **non-zero box** is considered. A zero-size one is either mid-transition or belongs to another picker, and trusting its rect selects the wrong side. That also removed a latent fragility the tests surfaced: a leftover menu from another spec in this file was steering the side detection, which broke an existing 3.2.10 test until the visibility check went in.

Expected at the measured geometry: a ~241px calendar (249 − margin) scrolling internally, every row reachable.

## Still open, deliberately

Why `flip` doesn't move the calendar to the side with 504px free. I checked whether it was a stale pre-render measurement by forcing a Floating UI recompute with a `resize` event while the menu was open — the position was byte-identical before and after (`547..871`), so it isn't that.

The lever for whoever picks it up: VueDatePicker builds its middleware as `flip(typeof floating.flip === 'object' ? floating.flip : {})`, so Floating UI options (`boundary`, `rootBoundary`, `padding`, `fallbackStrategy`) can be passed straight through FzDatepicker's `floating.flip` prop. This PR makes the outcome usable whatever that answer turns out to be, rather than guessing at it.

## Tests

3 new cases — menu below the field, menu above the field, menu not yet in the DOM. The first fails on `main` with `expected '496px' to be '88px'`, the same 496-vs-88 mismatch measured on the environment. Suite green at **125/125**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2827]: https://fiscozen.atlassian.net/browse/LIB-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HD-25540]: https://fiscozen.atlassian.net/browse/HD-25540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ