### PR TITLE
fix(LIB-2829): stop the datepicker arrow from disabling flip

### DIFF
--- a/.changeset/datepicker-arrow-disables-flip.md
+++ b/.changeset/datepicker-arrow-disables-flip.md
@@ -1,0 +1,22 @@
+---
+"@fiscozen/datepicker": patch
+---
+
+FzDatepicker: stop the arrow from disabling auto-positioning, so the calendar can open above the field
+
+The calendar stayed anchored below its field even with no room below it, running off the bottom of the screen with no way to reach it. Reported as a calendar bigger than the screen in the mobile app; measured in production at a 320x640 viewport with the field at 465..537 and a 324px calendar opening at 547..871 — 231px past the bottom edge, with 497px sitting free above and ignored.
+
+`flip` was being handed that overflow and doing nothing with it. The chain, confirmed by instrumenting the middleware in the live page:
+
+- VueDatePicker builds its middleware as `[offset, arrow, flip, shift]` — `arrow` _before_ `flip`, the reverse of Floating UI's documented order — with the arrow enabled by default.
+- On an aligned placement the arrow renders with neither `dp__arrow_top` nor `dp__arrow_bottom`, because the class binding compares the whole placement against `"bottom"` / `"top"` instead of just the side. An unstyled arrow is a full-width, zero-height block.
+- `arrow()` therefore measures an arrow wider than the reference (320 against 312), concludes it points at nothing, and returns an `alignmentOffset` of -3 with a reset.
+- `flip` opens with `if (middlewareData.arrow?.alignmentOffset) return {}`, so from the first render onwards it bails on every recompute. It was logged receiving `overflow.bottom: 231` and returning `{}`.
+
+Because `alignmentOffset` only exists for aligned placements, this hit every consumer passing `bottom-start` / `bottom-end` and never showed up under the default bare `bottom` — which is why it was invisible in Storybook.
+
+`floating.arrow` now defaults to `false`. The arrow slot is gated on `floating.arrow === true`, so the element is no longer created and the full chain runs again: `bottom-start` (231 overflow) → `bottom-end` (231) → `top-start` (no overflow), calendar fully visible. `shift` also starts correcting horizontal overflow again. A consumer that wants an arrow can still pass `floating.arrow` explicitly and gets the previous behaviour, suppressed flip included.
+
+Nothing changes visually: the arrow was already hidden via `.dp__arrow_top`, so it was contributing only the loss of auto-placement. That CSS rule is now dead for the default configuration and kept only for consumers that opt the arrow back in.
+
+Note for consumers: `mappedProps.floating` is now always defined (it carries at least `arrow: false`), where before it was `undefined` when neither `floating` nor `placement` was set. The height budget shipped earlier is unaffected and remains the fallback for when neither side of the field has room — at large system font scales an internal scroll is still the only thing that keeps the calendar usable.

--- a/packages/datepicker/src/FzDatepicker.vue
+++ b/packages/datepicker/src/FzDatepicker.vue
@@ -288,6 +288,27 @@ const stableFloating = computed(() => {
     if (merged.shift === undefined) merged.shift = false
   }
 
+  // The arrow is off by default because it silently disables auto-positioning.
+  //
+  // VueDatePicker builds its middleware as `[offset, arrow, flip, shift]` — arrow *before*
+  // flip, the reverse of Floating UI's documented order — and on an aligned placement it
+  // renders the arrow with neither `dp__arrow_top` nor `dp__arrow_bottom`, because the class
+  // binding compares the whole placement against `"bottom"` / `"top"` instead of just the
+  // side. An unstyled arrow is a full-width, zero-height block, so `arrow()` sees an arrow
+  // wider than the reference, decides it points at nothing, and returns an `alignmentOffset`
+  // with a reset. `flip` opens with `if (middlewareData.arrow?.alignmentOffset) return {}`,
+  // so from the first render onwards it bails on every recompute and the menu can never
+  // leave the side it started on.
+  //
+  // Measured in production at a 320x640 viewport with the field at 465..537: flip was handed
+  // `overflow.bottom: 231` and did nothing, leaving a 324px calendar hanging to 871 with
+  // 497px free above it. Disabling the arrow restores the chain — bottom-start, bottom-end,
+  // then top-start with no overflow.
+  //
+  // We hide the arrow in CSS anyway, so this costs nothing visually. A consumer that really
+  // wants one can pass `floating.arrow` explicitly and gets the old behaviour, arrow included.
+  if (merged.arrow === undefined) merged.arrow = false
+
   return Object.keys(merged).length > 0 ? merged : undefined
 })
 

--- a/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
+++ b/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
@@ -1390,11 +1390,13 @@ describe('FzDatepicker', () => {
     const readKey = (wrapper: ReturnType<typeof mount>) =>
       (wrapper.vm as any).$.setupState.floatingKey
 
-    it('returns "default" when no floating/placement is set', () => {
+    it('reflects the resolved config, which always carries the arrow default', () => {
+      // There is no longer a "no floating config" state: LIB-2829 always resolves
+      // `arrow: false`, so the key is derived rather than the `'default'` sentinel.
       const wrapper = mount(FzDatepicker, {
         props: { modelValue: new Date(), inputProps: {} }
       })
-      expect(readKey(wrapper)).toBe('default')
+      expect(readKey(wrapper)).toBe('{"arrow":false}')
     })
 
     it('changes when `placement` changes (forces remount)', async () => {
@@ -1744,6 +1746,52 @@ describe('autoPosition → floating flip/shift (LIB-2814)', () => {
   })
 })
 
+// ============================================
+// LIB-2829 — the arrow silently disables flip, so it is off by default
+// ============================================
+describe('floating.arrow default (LIB-2829)', () => {
+  const mapped = (wrapper: ReturnType<typeof mount>) =>
+    (wrapper.vm as any).$.setupState.mappedProps as Record<string, any>
+
+  it('disables the arrow by default', () => {
+    // With an arrow, VueDatePicker's `[offset, arrow, flip, shift]` order lets `arrow`'s
+    // `alignmentOffset` trip flip's early return, and the menu can never change side.
+    const wrapper = mount(FzDatepicker, { props: { modelValue: new Date(), inputProps: {} } })
+    expect(mapped(wrapper).floating).toMatchObject({ arrow: false })
+  })
+
+  it('keeps an explicit floating.arrow authoritative', () => {
+    const wrapper = mount(FzDatepicker, {
+      props: { modelValue: new Date(), floating: { arrow: true }, inputProps: {} }
+    })
+    expect(mapped(wrapper).floating).toMatchObject({ arrow: true })
+  })
+
+  it('disables the arrow alongside a forwarded placement', () => {
+    // The aligned placements are exactly the ones the arrow bug bites, so this pairing
+    // is the one the app actually uses.
+    const wrapper = mount(FzDatepicker, {
+      props: { modelValue: new Date(), placement: 'bottom-start', inputProps: {} }
+    })
+    expect(mapped(wrapper).floating).toMatchObject({ placement: 'bottom-start', arrow: false })
+  })
+
+  it('leaves flip and shift on their v12 defaults', () => {
+    const wrapper = mount(FzDatepicker, {
+      props: { modelValue: new Date(), placement: 'bottom-start', inputProps: {} }
+    })
+    expect(mapped(wrapper).floating.flip).toBeUndefined()
+    expect(mapped(wrapper).floating.shift).toBeUndefined()
+  })
+
+  it('still switches everything off when autoPosition is false', () => {
+    const wrapper = mount(FzDatepicker, {
+      props: { modelValue: new Date(), autoPosition: false, inputProps: {} }
+    })
+    expect(mapped(wrapper).floating).toMatchObject({ flip: false, shift: false, arrow: false })
+  })
+})
+
 describe('calendar height budget (LIB-2814)', () => {
   const MARGIN = 8
   const VAR = '--fz-datepicker-menu-max-height'
@@ -1816,7 +1864,9 @@ describe('calendar height budget (LIB-2814)', () => {
     // Field entirely below the fold — both sides are negative.
     stubField(wrapper, 900, 950)
     openMenu(wrapper)
-    expect(parseInt(document.documentElement.style.getPropertyValue(VAR), 10)).toBeGreaterThanOrEqual(0)
+    expect(
+      parseInt(document.documentElement.style.getPropertyValue(VAR), 10)
+    ).toBeGreaterThanOrEqual(0)
   })
 
   it('clears the budget when the menu closes', () => {


### PR DESCRIPTION
Jira: [LIB-2829](https://fiscozen.atlassian.net/browse/LIB-2829)

The calendar stayed anchored below its field even with no room below it, running off the bottom of the screen unreachable — reported as a calendar bigger than the screen in the mobile app ([HD-25540](https://fiscozen.atlassian.net/browse/HD-25540)). Measured in production at a 320x640 viewport, field at 465..537, a 324px calendar opening at 547..871: **231px past the bottom edge, with 497px sitting free above it**.

`flip` was receiving that overflow and declining to act on it. Confirmed by instrumenting the middleware chain in the live page:

```
FLIP bottom-start 320x324 y=547 ov={"t":-547,"b":231,...} arrow={"alignmentOffset":-3}
  -> {}
```

## Root cause

1. VueDatePicker builds its middleware as `[offset, arrow, flip, shift]` — `arrow` **before** `flip`, the reverse of Floating UI's documented order — with the arrow on by default.
2. On an *aligned* placement the arrow element renders with neither `dp__arrow_top` nor `dp__arrow_bottom`, because the class binding compares the whole placement against `"bottom"` / `"top"` instead of just the side. With no class it has no `position: absolute; width: 12px`, so it lays out as a full-width, zero-height block.
3. `arrow()` measures an arrow wider than the reference (320 vs 312), concludes it points at nothing, and returns `alignmentOffset: -3` with `reset: true`.
4. `flip` opens with `if (middlewareData.arrow?.alignmentOffset) return {}` and bails on every recompute from then on.

Because `alignmentOffset` only exists for aligned placements, this hit every consumer passing `bottom-start` / `bottom-end` and was invisible under the default bare `bottom` — which is why it never reproduced in Storybook.

## Fix

Default `floating.arrow` to `false`. The arrow slot is gated on `floating.arrow === true`, so the element is no longer created and the chain runs to completion: `bottom-start` (231 overflow) → `bottom-end` (231) → `top-start` (no overflow). `shift` starts correcting horizontal overflow again too. An explicit `floating.arrow` still wins, so a consumer can opt back in.

Nothing changes visually — the arrow was already hidden by `.dp__arrow_top { @apply hidden }`, so it was contributing only the loss of auto-placement.

## Verification

Validated on production with a DevTools local override disabling the arrow: the calendar flips to `top-start` at `y: 131`, all 324px inside the modal, no scrolling.

## Notes

- Two upstream defects in `@vuepic/vue-datepicker` 12.1.0 feed this (middleware order, and the arrow class binding not using `getSide(placement)`). Worth reporting, but the fix here doesn't wait on them.
- `mappedProps.floating` is now always defined (it carries at least `arrow: false`), where before it was `undefined` when neither `floating` nor `placement` was set. The `floatingKey` remount trigger reflects that; its value is arbitrary, only its stability matters.
- This supersedes the height budget as the fix for HD-25540. The budget stays as the fallback for when *neither* side has room — at large system font scales an internal scroll is still the only thing keeping the calendar usable. LIB-2828 (budget measured from the menu edge rather than the field edge) still applies and follows separately.

Tests: 130 passed in `@fiscozen/datepicker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2829]: https://fiscozen.atlassian.net/browse/LIB-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HD-25540]: https://fiscozen.atlassian.net/browse/HD-25540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ