### PR TITLE
fix(LIB-2828): budget the calendar from the menu edge, not the field edge

### DIFF
--- a/.changeset/datepicker-budget-from-menu-edge.md
+++ b/.changeset/datepicker-budget-from-menu-edge.md
@@ -1,0 +1,15 @@
+---
+"@fiscozen/datepicker": patch
+---
+
+FzDatepicker: measure the calendar's height budget from the menu's edge, not the field's
+
+The budget introduced for large system font scales was measured from the bottom (or top) of the _field_, but VueDatePicker separates field and menu by its own `offset`, plus arrow and padding. That gap was handed back as if it were usable space, so whenever the budget bound, the calendar overflowed by exactly `gap - margin`.
+
+Measured on a 360x640 viewport with the field at 505..525 and the menu opening at 547: a 107px budget (`640 - 525 - 8`) against 85px of real space, cutting the calendar off by 14px — deterministically the 22px gap minus the 8px margin. Confirmed against the shipped bundle with a DevTools override before writing the fix: measuring from the menu edge gives 85px, the menu occupies 547..632, and nothing is cut.
+
+The budget now measures from the edge Floating UI holds still — the menu's top when it is placed below the field, its bottom when placed above — so shrinking the height never moves that edge and the budget cannot oscillate. The menu's rect was already being read to decide which side it is on, so this is a few lines.
+
+The fallback path is unchanged: before VueDatePicker has rendered the menu there is no menu box to measure, so the field stays the reference and the budget stays generous until the post-render recompute refines it.
+
+Context: after the arrow fix in 3.2.12 the calendar flips above the field when there is no room below, so this budget is no longer what keeps HD-25540's calendar usable — it is the fallback for the case where _neither_ side has room, which is what happens at the largest accessibility font scales. It matters there, and the arithmetic being right matters whenever it binds.

--- a/packages/datepicker/src/FzDatepicker.vue
+++ b/packages/datepicker/src/FzDatepicker.vue
@@ -114,8 +114,6 @@ const applyMenuHeightBudget = () => {
   let budget = visibleHeight - MENU_VIEWPORT_MARGIN * 2
   if (input) {
     const field = input.getBoundingClientRect()
-    const below = visibleTop + visibleHeight - field.bottom - MENU_VIEWPORT_MARGIN
-    const above = field.top - visibleTop - MENU_VIEWPORT_MARGIN
 
     // Budget the side the menu is *actually* on. An earlier version budgeted the roomier
     // side, assuming VueDatePicker would place the calendar there — it does not always, and
@@ -129,12 +127,32 @@ const applyMenuHeightBudget = () => {
       (el) => el.getBoundingClientRect().height > 0
     )
     if (menu) {
-      const placedBelow = menu.getBoundingClientRect().top >= field.bottom - 1
-      budget = Math.min(budget, placedBelow ? below : above)
+      const menuRect = menu.getBoundingClientRect()
+      const placedBelow = menuRect.top >= field.bottom - 1
+
+      // Measure from the menu's own edge rather than the field's. VueDatePicker separates
+      // the two by its `offset` (plus arrow and padding), and measuring from the field hands
+      // that gap back as if it were usable space, so the calendar overflowed by exactly
+      // `gap - margin` every time. Measured on a 360x640 viewport with the field at 505..525
+      // and the menu opening at 547: a 107px budget (640 - 525 - 8) against 85px of real
+      // space, cut off by 14px — deterministically the 22px gap minus the 8px margin.
+      //
+      // The edge we measure from is the one Floating UI holds still: it anchors the menu's
+      // top when placed below and its bottom when placed above. Shrinking the height
+      // therefore never moves that edge, so the budget cannot oscillate.
+      budget = Math.min(
+        budget,
+        placedBelow
+          ? visibleTop + visibleHeight - menuRect.top - MENU_VIEWPORT_MARGIN
+          : menuRect.bottom - visibleTop - MENU_VIEWPORT_MARGIN
+      )
     } else {
-      // First run happens before VueDatePicker has rendered the menu, so the side is not
-      // known yet. Stay generous rather than flash a needlessly short calendar; the
-      // post-render recompute below refines it.
+      // First run happens before VueDatePicker has rendered the menu, so neither the side
+      // nor the gap is known yet. The field is the only reference available: stay generous
+      // rather than flash a needlessly short calendar, and let the post-render recompute
+      // below refine it against the real menu box.
+      const below = visibleTop + visibleHeight - field.bottom - MENU_VIEWPORT_MARGIN
+      const above = field.top - visibleTop - MENU_VIEWPORT_MARGIN
       budget = Math.min(budget, Math.max(below, above))
     }
   }

--- a/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
+++ b/packages/datepicker/src/__tests__/FzDatepicker.spec.ts
@@ -1927,27 +1927,43 @@ describe('calendar height budget (LIB-2814)', () => {
   }
   const removeMenu = () => document.querySelector('.dp__menu')?.remove()
 
-  it('budgets the side the menu is actually on, not the roomier one', () => {
+  it('measures from the menu edge, not the field, when the calendar opens below', () => {
     const wrapper = mountPicker()
-    // HD-25540 geometry measured on the ephemeral env: field low, 96px below it, 504 above,
-    // and VueDatePicker places the calendar BELOW anyway. Budgeting the roomier side left
-    // the cap at 496px against 88px of real space, so it never bound and the calendar was
-    // cut off by 250px with no row reachable (LIB-2827).
+    // Production geometry (LIB-2828): field 504..524 with the menu opening at 546, so
+    // VueDatePicker's offset leaves a 22px gap between them. Measuring from the field hands
+    // that gap back as usable space, and the calendar overflows by exactly gap - margin.
     setViewportHeight(620)
     stubField(wrapper, 504, 524)
-    stubMenu(546, 324) // below the field
+    stubMenu(546, 324)
     openMenu(wrapper)
-    expect(document.documentElement.style.getPropertyValue(VAR)).toBe(`${620 - 524 - MARGIN}px`)
+    expect(document.documentElement.style.getPropertyValue(VAR)).toBe(`${620 - 546 - MARGIN}px`)
     removeMenu()
   })
 
-  it('budgets the space above when the menu is placed above the field', () => {
+  it('measures from the menu edge when the calendar opens above', () => {
     const wrapper = mountPicker()
+    // Mirror case: above the field the edge Floating UI holds still is the menu's *bottom*,
+    // and the same 22px gap sits between it and the field.
     setViewportHeight(620)
     stubField(wrapper, 504, 524)
-    stubMenu(180, 324) // above the field
+    stubMenu(158, 324) // bottom at 482, i.e. 22px above the field
     openMenu(wrapper)
-    expect(document.documentElement.style.getPropertyValue(VAR)).toBe(`${504 - MARGIN}px`)
+    expect(document.documentElement.style.getPropertyValue(VAR)).toBe(`${482 - MARGIN}px`)
+    removeMenu()
+  })
+
+  it('still budgets the side the menu is on, not the roomier one', () => {
+    const wrapper = mountPicker()
+    // LIB-2827's regression guard: 96px below the field against 504 above, and VueDatePicker
+    // places the calendar BELOW anyway. Budgeting the roomier side left the cap at 496px
+    // against real space in the eighties, so it never bound and the calendar was cut off
+    // with no row reachable.
+    setViewportHeight(620)
+    stubField(wrapper, 504, 524)
+    stubMenu(546, 324)
+    openMenu(wrapper)
+    const budget = parseInt(document.documentElement.style.getPropertyValue(VAR), 10)
+    expect(budget).toBeLessThan(504 - MARGIN)
     removeMenu()
   })
 


### PR DESCRIPTION
Jira: [LIB-2828](https://fiscozen.atlassian.net/browse/LIB-2828)

The calendar's height budget was measured from the bottom (or top) of the **field**, but VueDatePicker separates field and menu by its own `offset`, plus arrow and padding. That gap was handed back as if it were usable space, so whenever the budget bound, the calendar overflowed by exactly `gap - margin`.

Measured on a 360x640 viewport with the field at 505..525 and the menu opening at 547 — a 22px gap:

| | budget | real space | cut off |
|---|---|---|---|
| from the field edge | `640 - 525 - 8` = **107px** | 85px | **14px** |
| from the menu edge | `640 - 547 - 8` = **85px** | 85px | **0** |

The 14px is deterministic: the 22px gap minus the 8px margin. Confirmed against the shipped bundle with a DevTools override before writing the fix — menu `547..632`, `cutOffBelow: 0`.

## Why measuring from the menu is stable

The edge we measure from is the one Floating UI holds still: it anchors the menu's top when placed below the field and its bottom when placed above. Shrinking the height therefore never moves that edge, so the budget can't oscillate. The menu's rect was already being read to decide which side it's on, so this is a few lines.

The fallback path is deliberately unchanged: before VueDatePicker has rendered the menu there is no menu box to measure, so the field stays the reference and the budget stays generous until the post-render recompute refines it.

## Scope, after 3.2.12

With the arrow fix ([LIB-2829](https://fiscozen.atlassian.net/browse/LIB-2829), #429) the calendar now flips above the field when there's no room below, so this budget is **no longer** what keeps [HD-25540](https://fiscozen.atlassian.net/browse/HD-25540) usable. It's the fallback for the case where *neither* side has room — which is what happens at the largest accessibility font scales, where no popover fits beside the field at all. It matters there, and the arithmetic being right matters whenever it binds.

## Tests

131 pass. The two LIB-2827 expectations that encoded the field-edge formula are updated, and both sides now assert against an explicit non-zero gap (below: `620 - 546 - 8`; above: menu bottom at 482, so `482 - 8`). LIB-2827's regression guard — budget the side the menu is *on*, not the roomier one — is kept as its own test.

## Known gap, not addressed here

The budget refinement and the `ResizeObserver` are both attached inside a `requestAnimationFrame` callback, which doesn't run in a hidden tab. A calendar opened while the tab is in the background keeps the fallback budget and never self-corrects, because the observer is never attached either. Worth a follow-up: attach the observer without depending on rAF and recompute on `visibilitychange`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2828]: https://fiscozen.atlassian.net/browse/LIB-2828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIB-2829]: https://fiscozen.atlassian.net/browse/LIB-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ