### PR TITLE
fix(LIB-2831): make a flipped panel's gap follow the side it landed on

### DIFF
--- a/.changeset/floating-margin-follows-flip.md
+++ b/.changeset/floating-margin-follows-flip.md
@@ -1,0 +1,18 @@
+---
+"@fiscozen/composables": patch
+---
+
+FzFloating: make a flipped panel's gap and gap class follow the side it actually landed on
+
+The opener-aware vertical correction shipped in 1.1.2 moves a panel to the other side of its opener when it does not fit. What it did not move was the spacing: the gap class is derived from the resolved position, so a `top` panel flipped below its opener kept `mb-4`, leaving the margin on the edge facing away from the opener.
+
+That class is load-bearing, not decorative. The position calculators take the gap from the element's own margin — `bottom*` leaves `y` on the opener's edge and lets `margin-top` shift the fixed element down, `top*` subtracts `margin-bottom` outright — while the correction spaced a flipped panel by `VIEWPORT_MARGIN` instead. So a flipped panel sat 8px from its opener where a natively-placed one on that side sits 16px, and carried a margin that did nothing on a fixed element positioned by `top`.
+
+Both halves now come from the same place:
+
+- the flip is spaced by the gap the requested side declares in its margin class, so a flipped panel is spaced exactly like a native one on that side — above the opener the gap is in the arithmetic, below it `y` sits on the opener's edge and the flipped side's `margin-top` supplies it;
+- the correction reports the side it landed on, and the resolved position is mirrored onto it (keeping the alignment: `top-start` becomes `bottom-start`), so the gap class follows.
+
+Only `top*` / `bottom*` placements are affected. `left*` / `right*` sit beside their opener and keep their horizontal gap, so a vertical correction no longer restyles them onto a vertical side.
+
+Two notes for consumers. The resolved position now reports the flipped side, which is the intended reading — a flipped panel _is_ a panel on that side — but code that compared it against the requested `position` prop to detect "no flip happened" will see them differ. And a panel whose gap class has been overridden away now touches its opener when it flips, exactly as it already did when placed natively on that side; the flip no longer supplies a gap of its own.

--- a/packages/composables/src/__tests__/useFloating.spec.ts
+++ b/packages/composables/src/__tests__/useFloating.spec.ts
@@ -390,11 +390,14 @@ describe('useFloating', () => {
       // The invariant is unchanged: the whole menu stays on screen.
       expect(floating.float.position.y).toBeGreaterThanOrEqual(VIEWPORT_MARGIN)
       expect(floating.float.position.y + ELEMENT_HEIGHT).toBeLessThanOrEqual(600 - VIEWPORT_MARGIN)
-      // It gets there by flipping to the other side of the opener (bottom edge one margin
-      // above opener.top = 540 - 8 - 100) rather than sliding up across it, which would
-      // have left the menu covering the control that opened it.
-      expect(floating.float.position.y).toBe(540 - VIEWPORT_MARGIN - ELEMENT_HEIGHT)
+      // It gets there by flipping to the other side of the opener rather than sliding up
+      // across it, which would have left the menu covering the control that opened it.
+      // The gap comes from the element's own margin (zero here, since the harness mounts a
+      // bare element with no gap class), so the menu's bottom lands on opener.top = 540.
+      expect(floating.float.position.y).toBe(540 - ELEMENT_HEIGHT)
       expect(floating.float.position.y + ELEMENT_HEIGHT).toBeLessThanOrEqual(540)
+      // The resolved position follows the flip, so the consumer's gap class does too.
+      expect(floating.actualPosition?.value).toBe('top-start')
     })
 
     it('flips a menu below its opener when it would overflow the top', async () => {
@@ -423,13 +426,84 @@ describe('useFloating', () => {
       await floating.setPosition()
       await nextTick()
 
-      // One margin below opener.bottom, so the menu clears its opener instead of
-      // covering it.
-      expect(floating.float.position.y).toBe(60 + VIEWPORT_MARGIN)
+      // Sits on opener.bottom, exactly where the `bottom*` calculator would put it: the
+      // flipped side's `margin-top` is what produces the gap, and it is zero in this
+      // harness. The menu clears its opener instead of covering it.
+      expect(floating.float.position.y).toBe(60)
+      expect(floating.float.position.y + ELEMENT_HEIGHT).toBeLessThanOrEqual(600 - VIEWPORT_MARGIN)
+      expect(floating.actualPosition?.value).toBe('bottom-start')
+    })
+
+    it('spaces a flipped menu by the gap class, not by the viewport margin', async () => {
+      // Regression for LIB-2831: the flip used to fall back to VIEWPORT_MARGIN, so a panel
+      // that flipped ended up 8px from its opener while an unflipped one on that side got
+      // the 16px the gap class provides — and it kept the class of the requested side, so
+      // the margin sat on the wrong edge.
+      setViewport(390, 600)
+      mockElement.style.marginTop = '16px'
+
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 100,
+        height: 40,
+        top: 540,
+        left: 100,
+        right: 200,
+        bottom: 580,
+        x: 100,
+        y: 540,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('bottom-start'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      // Flipped above: the 16px gap is in the arithmetic, because a `margin-bottom` cannot
+      // move a fixed element positioned by `top`.
+      expect(floating.float.position.y).toBe(540 - 16 - ELEMENT_HEIGHT)
+      expect(floating.actualPosition?.value).toBe('top-start')
+
+      mockElement.style.marginTop = ''
+    })
+
+    it('leaves a left placement styled as horizontal when it is corrected vertically', async () => {
+      // `left*` / `right*` sit beside the opener and keep their horizontal gap, so a
+      // vertical correction must not restyle them onto a vertical side.
+      setViewport(390, 600)
+
+      mockOpener.getBoundingClientRect = vi.fn(() => ({
+        width: 100,
+        height: 40,
+        top: 560,
+        left: 250,
+        right: 350,
+        bottom: 600,
+        x: 250,
+        y: 560,
+        toJSON: () => {}
+      })) as any
+
+      const args = toRefs({
+        position: ref<FzFloatingPosition>('left-start'),
+        element: { domRef: ref(mockElement) },
+        opener: { domRef: ref(mockOpener) }
+      })
+
+      const floating = useFloating(args)
+      await floating.setPosition()
+      await nextTick()
+
+      expect(floating.actualPosition?.value).toBe('left-start')
       expect(floating.float.position.y + ELEMENT_HEIGHT).toBeLessThanOrEqual(600 - VIEWPORT_MARGIN)
     })
 
-    it('ignores document.body\'s box when it is the implicit container', async () => {
+    it("ignores document.body's box when it is the implicit container", async () => {
       // Measured on the ephemeral env (/app/fatture-emesse): the frontoffice shell gives
       // body a fixed height equal to the viewport and scrolls an inner element, so once the
       // page is scrolled body's rect leaves the viewport. Intersecting with it collapsed the
@@ -685,7 +759,7 @@ describe('useFloating', () => {
       // Should not throw, just return early when element is missing
       await floating.setPosition()
       await nextTick()
-      
+
       // Position should remain at initial values (0, 0)
       expect(floating.float.position.x).toBe(0)
       expect(floating.float.position.y).toBe(0)

--- a/packages/composables/src/composables/useFloating.ts
+++ b/packages/composables/src/composables/useFloating.ts
@@ -1,41 +1,41 @@
 /**
  * @module useFloating
  * @description Composable for managing floating/popover element positioning
- * 
+ *
  * ## Why This Refactoring?
- * 
+ *
  * The previous implementation had several issues:
- * 
+ *
  * 1. **Monolithic function**: All positioning logic was in a single function
  *    making it hard to test individual positioning strategies
- * 
+ *
  * 2. **Inconsistent margin handling**: Margins were calculated differently for
  *    different positions, leading to visual inconsistencies
- * 
+ *
  * 3. **No reactive repositioning**: The floating element didn't respond to
  *    opener/content size changes or scroll events
- * 
+ *
  * 4. **Layout shift on open**: The floating element was added to document flow
  *    before positioning, causing visual jumps
- * 
+ *
  * ## Architecture
- * 
+ *
  * The new implementation uses:
- * 
+ *
  * - **Pure position calculators**: Each position (top, bottom, left, right and
  *   their variants) has a dedicated calculator function stored in lookup tables
- * 
- * - **Lookup tables**: `positionCalculators` (with opener) and 
+ *
+ * - **Lookup tables**: `positionCalculators` (with opener) and
  *   `containerPositionCalculators` (without opener) provide O(1) access
- * 
+ *
  * - **Immediate fixed positioning**: Elements are set to `position: fixed`
  *   immediately to prevent layout shift
- * 
+ *
  * - **Reactive repositioning**: ResizeObserver and scroll/resize event listeners
  *   ensure the floating stays positioned correctly during dynamic changes
- * 
+ *
  * ## Usage
- * 
+ *
  * ```typescript
  * const { float, setPosition, actualPosition } = useFloating({
  *   element: toRef(props, 'element'),
@@ -43,22 +43,22 @@
  *   position: toRef(props, 'position'),
  *   container: toRef(props, 'container')
  * })
- * 
+ *
  * // Position is set automatically, or call manually:
  * await setPosition()
- * 
+ *
  * // Access computed position values:
  * console.log(float.position.x, float.position.y)
  * console.log(actualPosition.value) // Resolved position for 'auto' modes
  * ```
- * 
+ *
  * ## Position Types
- * 
+ *
  * - Explicit: top, bottom, left, right and variants (-start, -end)
  * - Auto: auto, auto-vertical, auto-start, auto-end, etc.
- * 
+ *
  * Auto positions are resolved based on available space around the opener
- * 
+ *
  * @see FzFloating.vue - The component that uses this composable
  */
 
@@ -128,7 +128,7 @@ const isRectPositionable = (rect: DOMRect | null): boolean =>
 
 const positionCalculators: Record<string, PositionCalculator> = {
   // Bottom positions - content below opener
-  'bottom': (opener, margins) => ({
+  bottom: (opener, margins) => ({
     position: {
       x: opener.left - margins.left + opener.width / 2,
       y: opener.bottom
@@ -153,7 +153,7 @@ const positionCalculators: Record<string, PositionCalculator> = {
   }),
 
   // Top positions - content above opener
-  'top': (opener, margins) => ({
+  top: (opener, margins) => ({
     position: {
       x: opener.left - margins.left + opener.width / 2,
       y: opener.top - margins.bottom
@@ -178,7 +178,7 @@ const positionCalculators: Record<string, PositionCalculator> = {
   }),
 
   // Left positions - content to left of opener
-  'left': (opener, margins) => ({
+  left: (opener, margins) => ({
     position: {
       x: opener.left - margins.right,
       y: opener.top - margins.top + opener.height / 2
@@ -203,7 +203,7 @@ const positionCalculators: Record<string, PositionCalculator> = {
   }),
 
   // Right positions - content to right of opener
-  'right': (opener, margins) => ({
+  right: (opener, margins) => ({
     position: {
       x: opener.right + margins.left,
       y: opener.top - margins.top + opener.height / 2
@@ -246,98 +246,98 @@ const calculatePositionWithOpener = (
 type ContainerPositionCalculator = (container: DOMRect, element: DOMRect) => PositionResult
 
 const containerPositionCalculators: Record<string, ContainerPositionCalculator> = {
-  'bottom': (container, element) => ({
-    position: { 
-      x: container.left + container.width / 2, 
-      y: container.bottom - element.height 
+  bottom: (container, element) => ({
+    position: {
+      x: container.left + container.width / 2,
+      y: container.bottom - element.height
     },
     transform: { x: -50, y: 0 }
   }),
 
   'bottom-start': (container, element) => ({
-    position: { 
-      x: container.left, 
-      y: container.bottom - element.height 
+    position: {
+      x: container.left,
+      y: container.bottom - element.height
     },
     transform: { x: 0, y: 0 }
   }),
 
   'bottom-end': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.bottom - element.height 
+    position: {
+      x: container.right - element.width,
+      y: container.bottom - element.height
     },
     transform: { x: 0, y: 0 }
   }),
 
-  'top': (container) => ({
-    position: { 
-      x: container.left + container.width / 2, 
-      y: container.top 
+  top: (container) => ({
+    position: {
+      x: container.left + container.width / 2,
+      y: container.top
     },
     transform: { x: -50, y: 0 }
   }),
 
   'top-start': (container) => ({
-    position: { 
-      x: container.left, 
-      y: container.top 
+    position: {
+      x: container.left,
+      y: container.top
     },
     transform: { x: 0, y: 0 }
   }),
 
   'top-end': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.top 
+    position: {
+      x: container.right - element.width,
+      y: container.top
     },
     transform: { x: 0, y: 0 }
   }),
 
-  'left': (container, element) => ({
-    position: { 
-      x: container.left, 
-      y: container.top + (container.height - element.height) / 2 
+  left: (container, element) => ({
+    position: {
+      x: container.left,
+      y: container.top + (container.height - element.height) / 2
     },
     transform: { x: 0, y: 0 }
   }),
 
   'left-start': (container) => ({
-    position: { 
-      x: container.left, 
-      y: container.top 
+    position: {
+      x: container.left,
+      y: container.top
     },
     transform: { x: 0, y: 0 }
   }),
 
   'left-end': (container, element) => ({
-    position: { 
-      x: container.left, 
-      y: container.bottom - element.height 
+    position: {
+      x: container.left,
+      y: container.bottom - element.height
     },
     transform: { x: 0, y: 0 }
   }),
 
-  'right': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.top + (container.height - element.height) / 2 
+  right: (container, element) => ({
+    position: {
+      x: container.right - element.width,
+      y: container.top + (container.height - element.height) / 2
     },
     transform: { x: 0, y: 0 }
   }),
 
   'right-start': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.top 
+    position: {
+      x: container.right - element.width,
+      y: container.top
     },
     transform: { x: 0, y: 0 }
   }),
 
   'right-end': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.bottom - element.height 
+    position: {
+      x: container.right - element.width,
+      y: container.bottom - element.height
     },
     transform: { x: 0, y: 0 }
   })
@@ -349,7 +349,7 @@ const calculatePositionWithoutOpener = (
   element: DOMRect
 ): PositionResult => {
   const calculator = containerPositionCalculators[position]
-  return calculator 
+  return calculator
     ? calculator(container, element)
     : { position: { x: 0, y: 0 }, transform: { x: 0, y: 0 } }
 }
@@ -362,6 +362,11 @@ const calculatePositionWithoutOpener = (
 // to be shifted to stay on screen, so the menu never sits flush against (or
 // bleeds past) the viewport edge on narrow/mobile screens.
 const VIEWPORT_MARGIN = 8
+
+type VerticalSide = 'top' | 'bottom'
+
+const isVerticalPosition = (position: FzFloatingPosition): boolean =>
+  position.startsWith('top') || position.startsWith('bottom')
 
 interface Bounds {
   left: number
@@ -408,8 +413,13 @@ const applyBoundaryCorrections = (
   transform: Transform,
   opener: DOMRect | null = null,
   viewport: Bounds = getViewportBounds(),
-  margin: number = VIEWPORT_MARGIN
-): { position: FzAbsolutePosition; transform: Transform } => {
+  margin: number = VIEWPORT_MARGIN,
+  // The gap the panel keeps from its opener. The position calculators take it from the
+  // element's own margin — `bottom*` leaves `y` on the opener's edge and lets `margin-top`
+  // shift the fixed element down, `top*` subtracts `margin-bottom` outright — so a flip has
+  // to reproduce the same spacing, not fall back to the viewport margin.
+  gap: number = margin
+): { position: FzAbsolutePosition; transform: Transform; flippedTo?: VerticalSide } => {
   const correctedPosition = { ...realPosition }
   const correctedTransform = { ...transform }
 
@@ -447,33 +457,67 @@ const applyBoundaryCorrections = (
   // left margin at least brings its content on screen. Neither holds vertically.
   const availableHeight = bounds.bottom - bounds.top - margin * 2
 
+  let flippedTo: VerticalSide | undefined
+
   if (element.height <= availableHeight) {
     const minTop = bounds.top + margin
     const maxTop = bounds.bottom - margin - element.height
-    // Where the element would sit on the opposite side of the opener.
-    const aboveOpener = opener ? opener.top - margin - element.height : null
-    const belowOpener = opener ? opener.bottom + margin : null
+    // Where the element would sit on the opposite side of the opener, spaced by the same
+    // gap a natively-placed panel gets. Above the opener the gap has to be in the
+    // arithmetic (a `margin-bottom` cannot move a fixed element positioned by `top`);
+    // below it, `y` sits on the opener's edge because the flipped side's `margin-top`
+    // supplies the gap itself — exactly what the `bottom*` calculator does.
+    const aboveOpener = opener ? opener.top - gap - element.height : null
+    const belowOpener = opener ? opener.bottom : null
 
     if (correctedPosition.y > maxTop) {
       // Overflows the bottom. Prefer the other side of the opener: sliding the panel up
       // within the viewport would drag it across the control that opened it.
-      correctedPosition.y = aboveOpener !== null && aboveOpener >= minTop ? aboveOpener : maxTop
+      if (aboveOpener !== null && aboveOpener >= minTop) {
+        correctedPosition.y = aboveOpener
+        flippedTo = 'top'
+      } else {
+        correctedPosition.y = maxTop
+      }
       correctedTransform.y = 0
     } else if (correctedPosition.y < minTop) {
       // Mirror case for `top*` placements near the top edge.
-      correctedPosition.y = belowOpener !== null && belowOpener <= maxTop ? belowOpener : minTop
+      if (belowOpener !== null && belowOpener <= maxTop) {
+        correctedPosition.y = belowOpener
+        flippedTo = 'bottom'
+      } else {
+        correctedPosition.y = minTop
+      }
       correctedTransform.y = 0
     }
   }
 
-  return { position: correctedPosition, transform: correctedTransform }
+  return { position: correctedPosition, transform: correctedTransform, flippedTo }
+}
+
+/**
+ * Mirrors a placement onto the other side of the opener, keeping its alignment.
+ *
+ * A flipped panel is, for every purpose the consumer can observe, a panel on the other
+ * side: `FzFloating` derives its gap class from the resolved position, so reporting the
+ * requested side would leave the spacing on the wrong edge.
+ */
+const mirrorVertically = (position: FzFloatingPosition, side: VerticalSide): FzFloatingPosition => {
+  const alignment = position.includes('-') ? position.slice(position.indexOf('-')) : ''
+  return `${side}${alignment}` as FzFloatingPosition
 }
 
 // ============================================================================
 // Auto Position Resolution - Pure Function
 // ============================================================================
 
-type AutoPositionType = 'auto' | 'auto-vertical' | 'auto-start' | 'auto-vertical-start' | 'auto-end' | 'auto-vertical-end'
+type AutoPositionType =
+  | 'auto'
+  | 'auto-vertical'
+  | 'auto-start'
+  | 'auto-vertical-start'
+  | 'auto-end'
+  | 'auto-vertical-end'
 
 const resolveAutoPosition = (
   autoType: AutoPositionType,
@@ -553,12 +597,10 @@ export const useFloating = (
     }
 
     const container = args.container?.value
-      ? resolveElement(args.container.value.domRef.value) ?? document.body
+      ? (resolveElement(args.container.value.domRef.value) ?? document.body)
       : document.body
 
-    const opener = args.opener?.value
-      ? resolveElement(args.opener.value.domRef.value)
-      : null
+    const opener = args.opener?.value ? resolveElement(args.opener.value.domRef.value) : null
 
     return { element, container, opener }
   }
@@ -617,10 +659,11 @@ export const useFloating = (
 
       // Step 7: Calculate position
       const margins = getMargins(window.getComputedStyle(refs.element))
-      
-      const positionResult = refs.opener && rects.opener
-        ? calculatePositionWithOpener(actualPosition.value!, rects.opener, margins)
-        : calculatePositionWithoutOpener(actualPosition.value!, rects.container, rects.element)
+
+      const positionResult =
+        refs.opener && rects.opener
+          ? calculatePositionWithOpener(actualPosition.value!, rects.opener, margins)
+          : calculatePositionWithoutOpener(actualPosition.value!, rects.container, rects.element)
 
       // Step 8: Apply transform to get real position
       const realPosition = calcRealPos(
@@ -631,14 +674,33 @@ export const useFloating = (
       )
 
       // Step 9: Apply boundary corrections
+      //
+      // Only vertical placements get the flip treatment: `left*` / `right*` sit beside the
+      // opener and keep their horizontal gap, so moving one vertically must not restyle it.
+      const vertical = isVerticalPosition(actualPosition.value!)
+      // The design gap lives in the margin class of the requested side, so read it from
+      // there rather than hard-coding 16px: `top*` carries it as `margin-bottom`,
+      // `bottom*` as `margin-top`.
+      const openerGap = actualPosition.value!.startsWith('top') ? margins.bottom : margins.top
+
       const corrected = applyBoundaryCorrections(
         realPosition,
         rects.element,
         // body is the "no container" default; its box must not constrain collision handling.
         refs.container === document.body ? null : rects.container,
         positionResult.transform,
-        rects.opener
+        rects.opener,
+        getViewportBounds(),
+        VIEWPORT_MARGIN,
+        vertical ? openerGap : VIEWPORT_MARGIN
       )
+
+      // A flipped panel is reported as living on the side it actually landed on, so the
+      // consumer's gap class follows it. `actualPosition` is reset from the prop at the top
+      // of every run, so this never makes a flip sticky.
+      if (vertical && corrected.flippedTo) {
+        actualPosition.value = mirrorVertically(actualPosition.value!, corrected.flippedTo)
+      }
 
       // Step 10: Update float state
       float.position.x = corrected.position.x


### PR DESCRIPTION
Jira: [LIB-2831](https://fiscozen.atlassian.net/browse/LIB-2831)

The opener-aware vertical correction from [LIB-2813](https://fiscozen.atlassian.net/browse/LIB-2813) (composables 1.1.2) moves a panel to the other side of its opener when it doesn't fit — but the spacing didn't move with it. `FzFloating` derives its gap class from the resolved position, so a `top` panel flipped below its opener kept `mb-4`: margin on the edge facing *away* from the opener.

## Why this isn't cosmetic

The gap class is load-bearing. The position calculators take the gap from the element's own margin:

- `bottom*` → `y = opener.bottom`, and `margin-top` shifts the fixed element down to create the gap
- `top*` → `y = opener.top - margins.bottom`, gap subtracted outright

The correction, meanwhile, spaced a flip by `VIEWPORT_MARGIN` (8). So a flipped panel sat **8px** from its opener where a natively-placed one on that side sits **16px**, while carrying a `margin-bottom` that does nothing to a fixed element positioned by `top`.

## Change

Both halves now come from the same place:

- the flip is spaced by the gap the requested side declares in its margin class — above the opener the gap is in the arithmetic, below it `y` sits on the opener's edge and the flipped side's `margin-top` supplies it, exactly matching the `bottom*` calculator;
- `applyBoundaryCorrections` reports the side it landed on (`flippedTo`), and the resolved position is mirrored onto it keeping the alignment (`top-start` → `bottom-start`), so the gap class follows.

Scoped to `top*` / `bottom*`. `left*` / `right*` sit beside their opener and keep their horizontal gap, so a vertical correction no longer restyles them onto a vertical side — that's covered by a test.

## Tests

`composables` 108 pass (2 updated, 2 added). The two updated ones are the LIB-2813 flip tests, which encoded the old `VIEWPORT_MARGIN` spacing; they now encode the margin-driven gap (zero in the harness, which mounts a bare element with no gap class) and additionally assert the reported side. New tests cover a non-zero gap class and the `left-start` no-restyle case.

Every `FzFloating` consumer's suite passes too: tooltip 69, dropdown 71, select 138, tab 79, typeahead 122, card-list 60, datepicker 130.

## Notes for reviewers

- The resolved position now reports the flipped side. That's the intended reading — a flipped panel *is* a panel on that side — but code comparing it against the requested `position` prop to detect "no flip happened" will now see them differ.
- A panel whose gap class is overridden away will touch its opener when it flips. That already happens when it's placed natively on that side; the flip simply no longer supplies a gap of its own.
- `nx run-many --target=test:unit` can't run in a worktree here (the `build` prerequisite fails for `icons`/`style`/etc. without `FONTAWESOME_PACKAGE_TOKEN`), so the suites above were run per-package through vitest directly.
- [LIB-2832](https://fiscozen.atlassian.net/browse/LIB-2832) is the companion: the `Tooltip Top Position` story asserts both the old placement *and* `mb-4`, so it needs updating on top of this. It is currently failing on main and blocking the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2831]: https://fiscozen.atlassian.net/browse/LIB-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIB-2813]: https://fiscozen.atlassian.net/browse/LIB-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIB-2832]: https://fiscozen.atlassian.net/browse/LIB-2832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ