### PR TITLE
feat(popover): LIB-2851 FzPopover — CSS-anchored floating content with a JS fallback, piloted on card-list

### DIFF
--- a/.changeset/card-list-actions-popover.md
+++ b/.changeset/card-list-actions-popover.md
@@ -1,0 +1,5 @@
+---
+'@fiscozen/card-list': minor
+---
+
+FzCardListItem: the multi-action menu is now a native popover positioned with CSS anchor positioning (top layer, so it is never clipped by the row, with light dismiss and Esc for free). Browsers without the Popover API or CSS anchor positioning keep the previous `FzIconDropdown` menu as a fallback, with the same actions, sections and `fzaction:click` payload. The ellipsis opener is now labelled "Mostra azioni" in both paths (it previously exposed the default "Open dropdown" label).

--- a/.changeset/card-list-actions-popover.md
+++ b/.changeset/card-list-actions-popover.md
@@ -2,6 +2,8 @@
 '@fiscozen/card-list': minor
 ---
 
-FzCardListItem: the multi-action menu is now a native popover positioned with CSS anchor positioning (top layer, so it is never clipped by the row, with light dismiss and Esc for free). Browsers without the Popover API or CSS anchor positioning keep the previous `FzIconDropdown` menu as a fallback, with the same actions, sections and `fzaction:click` payload. The ellipsis opener is now labelled "Mostra azioni" in both paths (it previously exposed the default "Open dropdown" label).
+FzCardListItem: the multi-action menu is an `FzPopover` now, so it renders in the top layer — never clipped by the row — and comes with light dismiss and Esc. Which engine places it (native popover in CSS, or `FzFloating`) is the popover's business; the card only says `bottom-end`. Same actions, same sections, same `fzaction:click` payload as the `FzIconDropdown` it replaces, and the ellipsis opener is now labelled "Mostra azioni" (it previously exposed the default "Open dropdown" label) and reports its state through `aria-expanded`.
+
+`@fiscozen/dropdown` is no longer a dependency of this package; `@fiscozen/popover` is.
 
 Fixes ids that other elements resolve: they were generated with `useId()`, which is scoped to the Vue app, so a document holding several apps (Storybook docs mode, or an app with several mount points) reused them. An ellipsis button could open another card's menu, and the `aria-labelledby` of a link row could make a screen reader announce another card's title. Both are now unique document-wide.

--- a/.changeset/card-list-actions-popover.md
+++ b/.changeset/card-list-actions-popover.md
@@ -3,3 +3,5 @@
 ---
 
 FzCardListItem: the multi-action menu is now a native popover positioned with CSS anchor positioning (top layer, so it is never clipped by the row, with light dismiss and Esc for free). Browsers without the Popover API or CSS anchor positioning keep the previous `FzIconDropdown` menu as a fallback, with the same actions, sections and `fzaction:click` payload. The ellipsis opener is now labelled "Mostra azioni" in both paths (it previously exposed the default "Open dropdown" label).
+
+Fixes ids that other elements resolve: they were generated with `useId()`, which is scoped to the Vue app, so a document holding several apps (Storybook docs mode, or an app with several mount points) reused them. An ellipsis button could open another card's menu, and the `aria-labelledby` of a link row could make a screen reader announce another card's title. Both are now unique document-wide.

--- a/.changeset/floating-viewport-collision-bounds.md
+++ b/.changeset/floating-viewport-collision-bounds.md
@@ -1,0 +1,9 @@
+---
+'@fiscozen/composables': patch
+---
+
+FzFloating: with `useViewport`, clamp against the viewport instead of `document.body`.
+
+The collision boundary is the container ∩ viewport, which is right for a real container but wrong for the implicit `document.body` default: body is not a clipping box for fixed content, and whenever the page is shorter than the viewport its rect shrinks the usable area. The clamp then pulled the content up over its own opener — on a 108px tall page a 48px menu resolved `maxTop = 108 - 8 - 48 = 52`, above an opener whose bottom sat at 76.
+
+Only affects callers that pass `useViewport` (`FzSelect`, `FzTypeahead`, `FzPopover`), for which the viewport is exactly what the prop name promises; everyone else keeps the previous boundary.

--- a/.changeset/popover-open-on-mount.md
+++ b/.changeset/popover-open-on-mount.md
@@ -1,0 +1,5 @@
+---
+'@fiscozen/popover': patch
+---
+
+FzPopover: show a popover whose `open` is already true at mount. The watcher only fires on change, so a popover that starts open — a docs example, a visual snapshot, a menu restored from state — rendered closed while the model said open.

--- a/.changeset/popover-primitive.md
+++ b/.changeset/popover-primitive.md
@@ -1,0 +1,11 @@
+---
+'@fiscozen/popover': minor
+---
+
+New package: `FzPopover`, floating content that prefers the platform.
+
+Two engines behind one API. Where the browser has the Popover API, CSS anchor positioning and `position-area`, the content is a native `[popover]` in the top layer — never clipped by an ancestor's overflow, no z-index to arbitrate — placed entirely in CSS, so the browser keeps it glued to its anchor on scroll and resize with no JS, and light dismiss plus Esc come for free. Everywhere else, for `auto` placements, or on `forceFallback`, it delegates to `FzFloating` with `useClickOutside` / `useKeyDown` for dismissal.
+
+The API mirrors `FzFloating`'s vocabulary (the same 12 positions) so migrating a call site is a copy of the prop, and adds `v-model:open`, `offset`, `matchOpenerWidth` (`anchor-size()` in the CSS engine) and `anchor` for hanging the content off an element other than the opener.
+
+The fallback is meant to die: when CSS anchor positioning is everywhere, the second engine goes and `FzFloating` goes with it.

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -53,6 +53,7 @@
     "@fiscozen/navlist": "workspace:^",
     "@fiscozen/pagination": "workspace:*",
     "@fiscozen/pdf-viewer": "workspace:^",
+    "@fiscozen/popover": "workspace:*",
     "@fiscozen/progress": "workspace:^",
     "@fiscozen/radio": "workspace:^",
     "@fiscozen/select": "workspace:^",

--- a/apps/storybook/src/FzPopover.mdx
+++ b/apps/storybook/src/FzPopover.mdx
@@ -1,0 +1,153 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Documentation/Overlay/FzPopover" />
+
+# @fiscozen/popover
+
+Floating content that prefers the platform. `FzPopover` positions arbitrary content against an anchor and, where the browser allows, does it with **no JavaScript at all**: a native popover in the top layer, placed with CSS anchor positioning. Where the browser can't, it falls back to `FzFloating` — the measured-rect engine the design system already ships.
+
+It is the intended replacement for reaching for `FzFloating` directly.
+
+## Features
+
+- **Top layer, no clipping.** In the CSS engine the content is a native `[popover]`, so an ancestor's `overflow` can never cut it off and there is no z-index to arbitrate.
+- **Placement in CSS.** `position-anchor` + `position-area` keep the content glued to its anchor across scroll and resize without a line of JS, and flip it when the chosen side has no room.
+- **Dismissal included.** Light dismiss and Esc come from the platform in the CSS engine, and from `useClickOutside` / `useKeyDown` in the fallback. Either way the consumer writes none of it.
+- **One API, two engines.** The engine is picked per instance by feature detection; callers only describe what they want.
+- **`FzFloating`'s vocabulary.** The same 12 positions, so migrating an existing call site is a copy of the prop.
+
+## Which engine runs
+
+The CSS engine needs three things — the Popover API, CSS anchor positioning (`anchor-name` / `position-anchor`) and `position-area`. The JS engine takes over when:
+
+- any of the three is missing (anchor positioning only reached Baseline in 2026, so older Safari and Firefox are still out);
+- the placement is an `auto` one (`auto`, `auto-vertical`, and their `-start` / `-end` variants) — "the side with the most available space" needs measuring, and CSS only abandons a placement that *overflows*;
+- `forceFallback` is set, which exists for debugging and for visual tests that need to exercise the fallback.
+
+The fallback is meant to die. When anchor positioning is everywhere, the second engine goes and `FzFloating` goes with it.
+
+## Installation
+
+```bash
+npm install @fiscozen/popover
+```
+
+## Basic Usage
+
+The popover attaches no click handler of its own — bind `toggle` (or `open` / `close`) from the `opener` slot. That way an opener that is not a button keeps working.
+
+```vue
+<script setup>
+import { FzPopover } from '@fiscozen/popover'
+import { FzButton } from '@fiscozen/button'
+</script>
+
+<template>
+  <FzPopover position="bottom-end">
+    <template #opener="{ toggle }">
+      <FzButton @click="toggle">Azioni</FzButton>
+    </template>
+    <div class="rounded border border-grey-200 bg-core-white p-12 shadow-md">
+      <p>Contenuto del popover</p>
+    </div>
+  </FzPopover>
+</template>
+```
+
+### Controlled state
+
+`v-model:open` works in both engines, and stays in sync when the platform closes the popover on its own (Esc, click outside).
+
+```vue
+<script setup>
+import { ref } from 'vue'
+const isOpen = ref(false)
+</script>
+
+<template>
+  <FzPopover v-model:open="isOpen">
+    <template #opener="{ toggle }">
+      <FzButton @click="toggle">Apri</FzButton>
+    </template>
+    <template #default="{ close }">
+      <div class="bg-core-white p-12">
+        <FzButton @click="close">Chiudi</FzButton>
+      </div>
+    </template>
+  </FzPopover>
+</template>
+```
+
+### Anchoring somewhere else
+
+When the thing that opens the popover is not the thing it should hang off — a menu opened by a toolbar button but anchored to a table row, say — pass the element as `anchor`. It is the equivalent of `FzFloating`'s `overrideOpener`.
+
+```vue
+<FzPopover :anchor="rowElement" position="bottom-start">
+  <template #opener="{ toggle }">
+    <FzIconButton icon-name="ellipsis-vertical" @click="toggle" />
+  </template>
+  …
+</FzPopover>
+```
+
+## API Reference
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `open` | `boolean` | `false` | Open state, usable as `v-model:open`. An `open` that is already true at mount renders open |
+| `position` | `FzFloatingPosition` | `'bottom-start'` | Same vocabulary as `FzFloating`. `auto` variants always take the JS engine |
+| `offset` | `number` | `4` | Gap between anchor and content, in px |
+| `matchOpenerWidth` | `boolean` | `false` | Give the content at least the anchor's width — `anchor-size()` in the CSS engine, the measured opener rect in the JS one |
+| `anchor` | `HTMLElement \| null` | `null` | Anchor to this element instead of the `opener` slot |
+| `contentClass` | `string \| string[] \| Record<string, boolean>` | `undefined` | Class applied to the content box |
+| `forceFallback` | `boolean` | `false` | Force the JS engine even where the browser could do it in CSS |
+
+### Slots
+
+| Slot | Props | Description |
+|------|-------|-------------|
+| `opener` | `isOpen`, `toggle`, `open`, `close` | The element the popover hangs off |
+| `default` | `isOpen`, `close` | The floating content |
+
+### Events
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `fzpopover:toggle` | `isOpen: boolean` | Fired after the popover opened or closed, whatever the cause |
+
+## Sizing the content
+
+`FzPopover` does **not** cap the height of its content, and that is a deliberate trade-off rather than an omission.
+
+CSS can do one of two things, not both. `position-area` plus `max-height: 100%` gives the content exactly the available space and lets it scroll — the equivalent of Floating UI's `size` middleware, for free. But a box that shrinks never *overflows*, and `position-try-fallbacks` only abandons a placement that overflows: with a cap in place, a menu near the bottom of the viewport stays squeezed into whatever slot it has instead of flipping above. Verified in Chromium 143, where a 40-item menu resolved to a 22px sliver; neither `position-try-order: most-block-size` nor a `min-height` rescues it.
+
+Flipping is the more useful half for a popover, so that is what the CSS engine does. In practice:
+
+- **Content that fits the viewport** (a handful of menu items, a small form): nothing to do.
+- **Content that may not fit** (a long option list): cap it yourself, or use the JS engine — `FzSelect` and `FzTypeahead` compute a max-height from the measured rects, which is why they sit on that engine.
+
+## Accessibility
+
+The popover manages the layer, not the semantics. What it gives you:
+
+- Esc and click-outside close it, in both engines.
+- The opener slot receives `isOpen`, so you can bind `aria-expanded` yourself.
+
+What it does **not** do yet, and you should add at the call site if your content is a menu: a `role` and an accessible name on the content, `aria-controls` on the opener, moving focus into the content on open, arrow-key navigation between items, and returning focus to the opener on close.
+
+## Testing notes
+
+Two things will bite you when writing tests around this component.
+
+**Native dismissal only answers trusted input.** `userEvent.keyboard('{Escape}')` does *not* close a native popover — light dismiss and Esc are platform behaviours reserved for real input events. In a play function, close through the opener instead, and cover Esc with a browser driver that sends real keys. In the JS engine the same synthetic event works fine, because dismissal there is our own listener.
+
+**jsdom has neither the Popover API nor `window.CSS`.** Unit tests therefore exercise the JS engine by default, which is useful — the fallback gets covered for free — but it means the CSS engine has to be either stubbed or checked in a real browser.
+
+## Learn More
+
+### Interactive Examples
+
+See the [FzPopover stories](/story/overlay-fzpopover--default) for both engines side by side, `matchOpenerWidth`, and an `auto` placement.

--- a/apps/storybook/src/stories/overlay/Popover.stories.ts
+++ b/apps/storybook/src/stories/overlay/Popover.stories.ts
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test'
+import { FzPopover } from '@fiscozen/popover'
+import { FzButton } from '@fiscozen/button'
+
+/**
+ * FzPopover picks between two engines: a native `[popover]` placed in CSS
+ * (`position-anchor` + `position-area`) where the browser supports anchor
+ * positioning, and `FzFloating` — the design system's measured-rect
+ * implementation — everywhere else, for `auto` placements, or on `forceFallback`.
+ */
+const meta = {
+  title: 'Overlay/FzPopover',
+  component: FzPopover,
+  tags: ['autodocs'],
+  argTypes: {
+    position: {
+      control: 'select',
+      options: [
+        'bottom-start',
+        'bottom',
+        'bottom-end',
+        'top-start',
+        'top',
+        'top-end',
+        'left',
+        'right',
+        'auto',
+        'auto-vertical-start'
+      ],
+      description:
+        'Same vocabulary as FzFloating. The `auto` variants always take the JS engine: "the side with the most space" needs measuring.'
+    },
+    offset: { control: 'number', description: 'Gap between anchor and content, in px' },
+    matchOpenerWidth: {
+      control: 'boolean',
+      description: "Give the content at least the anchor's width"
+    },
+    forceFallback: {
+      control: 'boolean',
+      description: 'Force the JS engine even where the browser could do it in CSS'
+    }
+  }
+} satisfies Meta<typeof FzPopover>
+export default meta
+
+type PopoverStory = StoryObj<typeof FzPopover>
+
+const template = `
+  <div class="flex justify-center p-32">
+    <FzPopover v-bind="args" @fzpopover:toggle="args['onFzpopover:toggle']">
+      <template #opener="{ toggle }">
+        <FzButton @click="toggle">Apri</FzButton>
+      </template>
+      <div class="rounded border border-grey-200 bg-core-white p-12 shadow-md min-w-[200px]">
+        <p>Contenuto del popover</p>
+      </div>
+    </FzPopover>
+  </div>`
+
+const render = (args: Record<string, unknown>) => ({
+  components: { FzPopover, FzButton },
+  setup() {
+    return { args }
+  },
+  template
+})
+
+export const Default: PopoverStory = {
+  render,
+  args: {
+    position: 'bottom-start',
+    'onFzpopover:toggle': fn()
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText('Contenuto del popover')).not.toBeVisible()
+    await userEvent.click(canvas.getByRole('button', { name: 'Apri' }))
+    await waitFor(() => expect(canvas.getByText('Contenuto del popover')).toBeVisible())
+    await expect(args['onFzpopover:toggle']).toHaveBeenCalledWith(true)
+
+    // Closing goes through the opener, not Esc: light dismiss and Esc are platform
+    // behaviours that only trusted input triggers, and userEvent dispatches
+    // synthetic events. They are covered by a Playwright probe with real keys.
+    await userEvent.click(canvas.getByRole('button', { name: 'Apri' }))
+    await waitFor(() => expect(canvas.getByText('Contenuto del popover')).not.toBeVisible())
+    await expect(args['onFzpopover:toggle']).toHaveBeenCalledWith(false)
+  }
+}
+
+/** Same component, same assertions, JS engine — the fallback must behave alike. */
+export const ForcedFallback: PopoverStory = {
+  render,
+  args: {
+    position: 'bottom-start',
+    forceFallback: true,
+    'onFzpopover:toggle': fn()
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText('Contenuto del popover')).not.toBeVisible()
+    await userEvent.click(canvas.getByRole('button', { name: 'Apri' }))
+    await waitFor(() => expect(canvas.getByText('Contenuto del popover')).toBeVisible())
+    await expect(args['onFzpopover:toggle']).toHaveBeenCalledWith(true)
+
+    // Here Esc *is* assertable: dismissal in the JS engine is our own keydown
+    // listener, which a synthetic event reaches just fine.
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(canvas.getByText('Contenuto del popover')).not.toBeVisible())
+  }
+}
+
+/** `auto` is not expressible in CSS, so this story runs on the JS engine too. */
+export const AutoPosition: PopoverStory = {
+  render,
+  args: {
+    position: 'auto-vertical-start',
+    'onFzpopover:toggle': fn()
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: 'Apri' }))
+    await waitFor(() => expect(canvas.getByText('Contenuto del popover')).toBeVisible())
+  }
+}
+
+export const MatchOpenerWidth: PopoverStory = {
+  render,
+  args: {
+    position: 'bottom-start',
+    matchOpenerWidth: true,
+    'onFzpopover:toggle': fn()
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const opener = canvas.getByRole('button', { name: 'Apri' })
+    await userEvent.click(opener)
+    await waitFor(() => expect(canvas.getByText('Contenuto del popover')).toBeVisible())
+    // The content is at least as wide as the thing it hangs off.
+    const content = canvas.getByText('Contenuto del popover').closest('div')!
+    await expect(content.getBoundingClientRect().width).toBeGreaterThanOrEqual(
+      opener.getBoundingClientRect().width
+    )
+  }
+}

--- a/apps/storybook/src/stories/overlay/Popover.stories.ts
+++ b/apps/storybook/src/stories/overlay/Popover.stories.ts
@@ -126,6 +126,60 @@ export const AutoPosition: PopoverStory = {
   }
 }
 
+/**
+ * Both engines, open on mount, so a visual snapshot covers them side by side: the
+ * left one is the native popover placed in CSS, the right one is `FzFloating`. They
+ * should look the same — same offset from the opener, same alignment.
+ */
+export const BothEnginesOpen: PopoverStory = {
+  render: (args) => ({
+    components: { FzPopover, FzButton },
+    setup() {
+      return { args }
+    },
+    template: `
+    <div class="flex justify-center gap-[220px] p-32 pb-[220px]">
+      <FzPopover v-bind="args" :open="true">
+        <template #opener="{ toggle }">
+          <FzButton @click="toggle">Motore CSS</FzButton>
+        </template>
+        <div class="rounded border border-grey-200 bg-core-white p-12 shadow-md min-w-[200px]">
+          <p data-engine="css">Stesso contenuto, stesso offset</p>
+        </div>
+      </FzPopover>
+
+      <FzPopover v-bind="args" :open="true" :force-fallback="true">
+        <template #opener="{ toggle }">
+          <FzButton @click="toggle">Motore JS</FzButton>
+        </template>
+        <div class="rounded border border-grey-200 bg-core-white p-12 shadow-md min-w-[200px]">
+          <p data-engine="js">Stesso contenuto, stesso offset</p>
+        </div>
+      </FzPopover>
+    </div>`
+  }),
+  args: {
+    position: 'bottom-start'
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Both are open without anyone clicking: `open` was already true at mount.
+    const content = (engine: string) =>
+      canvasElement.querySelector<HTMLElement>(`[data-engine="${engine}"]`)!
+    await waitFor(() => expect(content('css')).toBeVisible())
+    await expect(content('js')).toBeVisible()
+
+    // And they agree on where the content sits relative to its opener.
+    const offsetFromOpener = (openerName: string, engine: string) => {
+      const opener = canvas.getByRole('button', { name: openerName })
+      const box = content(engine).closest('div')!
+      return Math.round(box.getBoundingClientRect().top - opener.getBoundingClientRect().bottom)
+    }
+    await expect(offsetFromOpener('Motore CSS', 'css')).toBe(offsetFromOpener('Motore JS', 'js'))
+  }
+}
+
 export const MatchOpenerWidth: PopoverStory = {
   render,
   args: {

--- a/apps/storybook/src/stories/panel/CardListItem.stories.ts
+++ b/apps/storybook/src/stories/panel/CardListItem.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
-import { expect, fn, within } from 'storybook/test'
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test'
 import { FzCardListItem } from '@fiscozen/card-list'
 import { FzActionProps } from '@fiscozen/action'
 
@@ -28,7 +28,7 @@ const meta = {
     actions: {
       control: 'object',
       description:
-        'Row actions: omit or `[]` for none (no trailing control); one `type: "link"` item shows a clickable arrow row; one or more `type: "action"` items show an ellipsis dropdown (`fzaction:click`)'
+        'Row actions: omit or `[]` for none (no trailing control); one `type: "link"` item shows a clickable arrow row; one or more `type: "action"` items show an ellipsis actions menu (`fzaction:click`)'
     },
     showIndicator: {
       control: 'boolean',
@@ -213,6 +213,65 @@ export const CardWithSingleNonLinkAction: CardListItemStory = {
 
     const menuButtons = canvas.getAllByRole('button')
     await expect(menuButtons.length).toBeGreaterThanOrEqual(1)
+  }
+}
+
+/**
+ * Two or more actions collapse into an ellipsis menu. On browsers with the
+ * Popover API + CSS anchor positioning (this test runs in Chromium) the menu is
+ * a native popover placed in the top layer; elsewhere the component falls back
+ * to FzIconDropdown, with the same actions and the same `fzaction:click` payload.
+ */
+export const CardWithActionsMenu: CardListItemStory = {
+  render: (args) => ({
+    components: { FzCardListItem },
+    setup() {
+      return { args }
+    },
+    template: `
+    <div class="min-w-[355px]">
+      <FzCardListItem
+        v-bind="args"
+        @fzaction:click="args['onFzaction:click']"
+      />
+    </div>`
+  }),
+  args: {
+    title: 'Fattura #001',
+    value: '1.200,00 €',
+    descriptions: ['Cliente: Rossi S.r.l.'],
+    actions: [
+      {
+        type: 'action',
+        variant: 'textLeft',
+        label: 'Apri'
+      },
+      {
+        type: 'action',
+        variant: 'textLeft',
+        label: 'Elimina'
+      }
+    ] as FzActionProps[],
+    'onFzaction:click': fn()
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const opener = canvas.getByRole('button', { name: 'Mostra azioni' })
+    await expect(canvas.getByText('Apri')).not.toBeVisible()
+
+    await userEvent.click(opener)
+    await waitFor(() => expect(canvas.getByText('Apri')).toBeVisible())
+    await expect(canvas.getByText('Elimina')).toBeVisible()
+
+    await userEvent.click(canvas.getByText('Elimina'))
+    await expect(args['onFzaction:click']).toHaveBeenCalledWith(1, {
+      type: 'action',
+      variant: 'textLeft',
+      label: 'Elimina'
+    })
+    // Picking an action closes the menu.
+    await waitFor(() => expect(canvas.getByText('Elimina')).not.toBeVisible())
   }
 }
 

--- a/packages/card-list/package.json
+++ b/packages/card-list/package.json
@@ -16,9 +16,9 @@
     "@fiscozen/action": "workspace:*",
     "@fiscozen/badge": "workspace:*",
     "@fiscozen/button": "workspace:*",
+    "@fiscozen/container": "workspace:*",
     "@fiscozen/divider": "workspace:*",
-    "@fiscozen/dropdown": "workspace:*",
-    "@fiscozen/container": "workspace:*"
+    "@fiscozen/popover": "workspace:*"
   },
   "peerDependencies": {
     "@fiscozen/icons": "workspace:^",

--- a/packages/card-list/src/__tests__/FzCardListItem.spec.ts
+++ b/packages/card-list/src/__tests__/FzCardListItem.spec.ts
@@ -1,7 +1,27 @@
 import { mount, config } from "@vue/test-utils";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { FzActionProps } from "@fiscozen/action";
 import FzCardListItem from "../FzCardListItem.vue";
+
+/**
+ * jsdom ships neither the Popover API nor `window.CSS`, so FzCardMultiActions
+ * feature-detects its way to the FzIconDropdown fallback in unit tests. These
+ * helpers fake the two capabilities so the native-popover path is covered too
+ * (the real thing runs in Chromium via the Storybook play functions).
+ */
+function enableAnchoredPopoverSupport() {
+  Object.defineProperty(HTMLElement.prototype, "popover", {
+    value: null,
+    writable: true,
+    configurable: true,
+  });
+  vi.stubGlobal("CSS", { supports: () => true });
+}
+
+function restoreAnchoredPopoverSupport() {
+  delete (HTMLElement.prototype as unknown as Record<string, unknown>).popover;
+  vi.unstubAllGlobals();
+}
 
 const actionA: FzActionProps = {
   type: "action",
@@ -148,9 +168,6 @@ describe("FzCardListItem", () => {
       expect(wrapper.findComponent({ name: "FzIconButton" }).exists()).toBe(
         false,
       );
-      expect(wrapper.findComponent({ name: "FzIconDropdown" }).exists()).toBe(
-        false,
-      );
     });
 
     it("should not render a trailing control when actions is an empty array", async () => {
@@ -159,9 +176,6 @@ describe("FzCardListItem", () => {
       });
       await wrapper.vm.$nextTick();
       expect(wrapper.findComponent({ name: "FzIconButton" }).exists()).toBe(
-        false,
-      );
-      expect(wrapper.findComponent({ name: "FzIconDropdown" }).exists()).toBe(
         false,
       );
     });
@@ -195,14 +209,14 @@ describe("FzCardListItem", () => {
       expect(one.find(".cursor-pointer").exists()).toBe(true);
     });
 
-    it("should render dropdown when more than one action is passed", async () => {
+    it("should render an ellipsis opener when more than one action is passed", async () => {
       const wrapper = mount(FzCardListItem, {
         props: { title: "Item", actions: [actionA, actionB] },
       });
       await wrapper.vm.$nextTick();
-      const dropdown = wrapper.findComponent({ name: "FzIconDropdown" });
-      expect(dropdown.exists()).toBe(true);
-      expect(dropdown.props("actions")).toEqual([actionA, actionB]);
+      const opener = wrapper.findComponent({ name: "FzIconButton" });
+      expect(opener.exists()).toBe(true);
+      expect(opener.props("iconName")).toBe("ellipsis-vertical");
     });
 
     it("should ignore section markers when deciding actions mode", async () => {
@@ -219,23 +233,11 @@ describe("FzCardListItem", () => {
       });
       await Promise.all([sectionOnly.vm.$nextTick(), sectionPlusOneLink.vm.$nextTick()]);
       expect(sectionOnly.findComponent({ name: "FzIconButton" }).exists()).toBe(false);
-      expect(sectionOnly.findComponent({ name: "FzIconDropdown" }).exists()).toBe(false);
       expect(
         sectionPlusOneLink
           .findAllComponents({ name: "FzIcon" })
           .some((w) => w.props("name") === "chevron-right"),
       ).toBe(true);
-    });
-
-    it("should pass section markers through to the dropdown", async () => {
-      const section = { type: "section" as const, label: "Scarica" };
-      const wrapper = mount(FzCardListItem, {
-        props: { title: "Item", actions: [actionA, section, actionB] },
-      });
-      await wrapper.vm.$nextTick();
-      const dropdown = wrapper.findComponent({ name: "FzIconDropdown" });
-      expect(dropdown.exists()).toBe(true);
-      expect(dropdown.props("actions")).toEqual([actionA, section, actionB]);
     });
 
     it("should render badge in the top row when badge is provided", async () => {
@@ -438,7 +440,133 @@ describe("FzCardListItem", () => {
       }
     });
 
-    it("should forward fzaction:click from dropdown", async () => {
+  });
+
+  /**
+   * The multi-action menu has two interchangeable implementations, picked by
+   * feature detection: the native popover (preferred) and the FzIconDropdown
+   * fallback. Both must render the same actions and emit the same payload.
+   */
+  describe("Actions menu — native popover path", () => {
+    beforeEach(enableAnchoredPopoverSupport);
+    afterEach(restoreAnchoredPopoverSupport);
+
+    it("should render the actions inside a native popover instead of the dropdown", async () => {
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+
+      const opener = wrapper.findComponent({ name: "FzIconButton" });
+      expect(opener.props("iconName")).toBe("ellipsis-vertical");
+      expect(wrapper.findComponent({ name: "FzIconDropdown" }).exists()).toBe(
+        false,
+      );
+
+      // Matched by class, not `[popover]`: once the stub puts `popover` on
+      // HTMLElement.prototype, Vue writes it as a DOM property, and jsdom's fake
+      // property doesn't reflect back to an attribute the way a browser does.
+      const menu = wrapper.find(".fz-card-actions__popover");
+      expect(menu.exists()).toBe(true);
+      // The opener toggles that very popover — no JS wiring in between.
+      expect(wrapper.get("button").attributes("popovertarget")).toBe(
+        menu.attributes("id"),
+      );
+
+      const actions = wrapper.findAllComponents({ name: "FzAction" });
+      expect(actions.map((a) => a.props("label"))).toEqual([
+        "Action A",
+        "Action B",
+      ]);
+    });
+
+    it("should render section markers as group headers in the menu", async () => {
+      const section = { type: "section" as const, label: "Scarica" };
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, section, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+
+      // The marker opens a labelled group; its following action lands under it.
+      const sectionLabels = wrapper
+        .findAllComponents({ name: "FzActionSection" })
+        .map((s) => s.props("label"));
+      expect(sectionLabels).toContain("Scarica");
+      const actionLabels = wrapper
+        .findAllComponents({ name: "FzAction" })
+        .map((a) => a.props("label"));
+      expect(actionLabels).toEqual(["Action A", "Action B"]);
+    });
+
+    it("should emit fzaction:click with the action index when a menu action is clicked", async () => {
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+
+      const actions = wrapper.findAllComponents({ name: "FzAction" });
+      await actions[1].trigger("click");
+
+      expect(wrapper.emitted("fzaction:click")).toBeTruthy();
+      expect(wrapper.emitted("fzaction:click")![0]).toEqual([1, actionB]);
+    });
+
+    it("should label the opener in Italian", async () => {
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+      expect(wrapper.get("button").attributes("aria-label")).toBe(
+        "Mostra azioni",
+      );
+    });
+  });
+
+  describe("Actions menu — FzIconDropdown fallback", () => {
+    it("should fall back to the dropdown when the Popover API is missing", async () => {
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+
+      const dropdown = wrapper.findComponent({ name: "FzIconDropdown" });
+      expect(dropdown.exists()).toBe(true);
+      expect(dropdown.props("actions")).toEqual([actionA, actionB]);
+      expect(dropdown.props("iconName")).toBe("ellipsis-vertical");
+      expect(wrapper.find(".fz-card-actions__popover").exists()).toBe(false);
+    });
+
+    it("should fall back to the dropdown when CSS anchor positioning is unsupported", async () => {
+      Object.defineProperty(HTMLElement.prototype, "popover", {
+        value: null,
+        writable: true,
+        configurable: true,
+      });
+      vi.stubGlobal("CSS", { supports: () => false });
+
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.findComponent({ name: "FzIconDropdown" }).exists()).toBe(
+        true,
+      );
+      restoreAnchoredPopoverSupport();
+    });
+
+    it("should pass section markers through to the dropdown", async () => {
+      const section = { type: "section" as const, label: "Scarica" };
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, section, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+
+      const dropdown = wrapper.findComponent({ name: "FzIconDropdown" });
+      expect(dropdown.props("actions")).toEqual([actionA, section, actionB]);
+    });
+
+    it("should forward fzaction:click from the dropdown", async () => {
       const wrapper = mount(FzCardListItem, {
         props: { title: "Item", actions: [actionA, actionB] },
       });
@@ -449,6 +577,21 @@ describe("FzCardListItem", () => {
 
       expect(wrapper.emitted("fzaction:click")).toBeTruthy();
       expect(wrapper.emitted("fzaction:click")![0]).toEqual([1, actionB]);
+    });
+
+    it("should label the dropdown opener in Italian", async () => {
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+      // `label` is the prop FzIconDropdown forwards to the icon button's
+      // aria-label (an `aria-label` attribute would land on the wrapper).
+      expect(
+        wrapper.findComponent({ name: "FzIconDropdown" }).props("label"),
+      ).toBe("Mostra azioni");
+      expect(wrapper.get("button").attributes("aria-label")).toBe(
+        "Mostra azioni",
+      );
     });
   });
 

--- a/packages/card-list/src/__tests__/FzCardListItem.spec.ts
+++ b/packages/card-list/src/__tests__/FzCardListItem.spec.ts
@@ -1,27 +1,7 @@
 import { mount, config } from "@vue/test-utils";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { FzActionProps } from "@fiscozen/action";
 import FzCardListItem from "../FzCardListItem.vue";
-
-/**
- * jsdom ships neither the Popover API nor `window.CSS`, so FzCardMultiActions
- * feature-detects its way to the FzIconDropdown fallback in unit tests. These
- * helpers fake the two capabilities so the native-popover path is covered too
- * (the real thing runs in Chromium via the Storybook play functions).
- */
-function enableAnchoredPopoverSupport() {
-  Object.defineProperty(HTMLElement.prototype, "popover", {
-    value: null,
-    writable: true,
-    configurable: true,
-  });
-  vi.stubGlobal("CSS", { supports: () => true });
-}
-
-function restoreAnchoredPopoverSupport() {
-  delete (HTMLElement.prototype as unknown as Record<string, unknown>).popover;
-  vi.unstubAllGlobals();
-}
 
 const actionA: FzActionProps = {
   type: "action",
@@ -454,61 +434,31 @@ describe("FzCardListItem", () => {
    * feature detection: the native popover (preferred) and the FzIconDropdown
    * fallback. Both must render the same actions and emit the same payload.
    */
-  describe("Actions menu — native popover path", () => {
-    beforeEach(enableAnchoredPopoverSupport);
-    afterEach(restoreAnchoredPopoverSupport);
-
-    it("should render the actions inside a native popover instead of the dropdown", async () => {
+  /**
+   * The multi-action menu is an FzPopover now, so which engine renders it — native
+   * popover in CSS, or FzFloating — is the popover package's business and is tested
+   * there. What matters here is that the card wires it up: the ellipsis opens it, the
+   * actions and their sections land inside, and picking one reports its index.
+   */
+  describe("Actions menu", () => {
+    it("should render the actions inside an FzPopover hanging off the ellipsis", async () => {
       const wrapper = mount(FzCardListItem, {
         props: { title: "Item", actions: [actionA, actionB] },
       });
       await wrapper.vm.$nextTick();
 
+      const popover = wrapper.findComponent({ name: "FzPopover" });
+      expect(popover.exists()).toBe(true);
+      expect(popover.props("position")).toBe("bottom-end");
+
       const opener = wrapper.findComponent({ name: "FzIconButton" });
       expect(opener.props("iconName")).toBe("ellipsis-vertical");
-      expect(wrapper.findComponent({ name: "FzIconDropdown" }).exists()).toBe(
-        false,
-      );
-
-      // Matched by class, not `[popover]`: once the stub puts `popover` on
-      // HTMLElement.prototype, Vue writes it as a DOM property, and jsdom's fake
-      // property doesn't reflect back to an attribute the way a browser does.
-      const menu = wrapper.find(".fz-card-actions__popover");
-      expect(menu.exists()).toBe(true);
-      // The opener toggles that very popover — no JS wiring in between.
-      expect(wrapper.get("button").attributes("popovertarget")).toBe(
-        menu.attributes("id"),
-      );
 
       const actions = wrapper.findAllComponents({ name: "FzAction" });
       expect(actions.map((a) => a.props("label"))).toEqual([
         "Action A",
         "Action B",
       ]);
-    });
-
-    it("should give each instance a document-unique popover id", async () => {
-      // Every mount() is its own Vue app, so an app-scoped id (useId()) would
-      // hand out the same value twice: `popovertarget` resolves by id and takes
-      // the first match, and every opener ends up toggling the first card's menu.
-      const first = mount(FzCardListItem, {
-        props: { title: "First", actions: [actionA, actionB] },
-      });
-      const second = mount(FzCardListItem, {
-        props: { title: "Second", actions: [actionA, actionB] },
-      });
-      await Promise.all([first.vm.$nextTick(), second.vm.$nextTick()]);
-
-      const menuId = (w: typeof first) =>
-        w.get(".fz-card-actions__popover").attributes("id");
-      expect(menuId(first)).not.toBe(menuId(second));
-      // …and each opener still points at its own menu.
-      expect(first.get("button").attributes("popovertarget")).toBe(
-        menuId(first),
-      );
-      expect(second.get("button").attributes("popovertarget")).toBe(
-        menuId(second),
-      );
     });
 
     it("should render section markers as group headers in the menu", async () => {
@@ -518,28 +468,40 @@ describe("FzCardListItem", () => {
       });
       await wrapper.vm.$nextTick();
 
-      // The marker opens a labelled group; its following action lands under it.
       const sectionLabels = wrapper
         .findAllComponents({ name: "FzActionSection" })
         .map((s) => s.props("label"));
       expect(sectionLabels).toContain("Scarica");
-      const actionLabels = wrapper
-        .findAllComponents({ name: "FzAction" })
-        .map((a) => a.props("label"));
-      expect(actionLabels).toEqual(["Action A", "Action B"]);
+      expect(
+        wrapper.findAllComponents({ name: "FzAction" }).map((a) => a.props("label")),
+      ).toEqual(["Action A", "Action B"]);
     });
 
-    it("should emit fzaction:click with the action index when a menu action is clicked", async () => {
+    it("should report the menu state on the opener", async () => {
       const wrapper = mount(FzCardListItem, {
         props: { title: "Item", actions: [actionA, actionB] },
       });
       await wrapper.vm.$nextTick();
 
+      const opener = wrapper.get("button");
+      expect(opener.attributes("aria-expanded")).toBe("false");
+      await opener.trigger("click");
+      expect(opener.attributes("aria-expanded")).toBe("true");
+    });
+
+    it("should emit fzaction:click with the action index and close the menu", async () => {
+      const wrapper = mount(FzCardListItem, {
+        props: { title: "Item", actions: [actionA, actionB] },
+      });
+      await wrapper.vm.$nextTick();
+      await wrapper.get("button").trigger("click");
+
       const actions = wrapper.findAllComponents({ name: "FzAction" });
       await actions[1].trigger("click");
 
-      expect(wrapper.emitted("fzaction:click")).toBeTruthy();
       expect(wrapper.emitted("fzaction:click")![0]).toEqual([1, actionB]);
+      // Picking an action closes the menu.
+      expect(wrapper.get("button").attributes("aria-expanded")).toBe("false");
     });
 
     it("should label the opener in Italian", async () => {
@@ -547,82 +509,7 @@ describe("FzCardListItem", () => {
         props: { title: "Item", actions: [actionA, actionB] },
       });
       await wrapper.vm.$nextTick();
-      expect(wrapper.get("button").attributes("aria-label")).toBe(
-        "Mostra azioni",
-      );
-    });
-  });
-
-  describe("Actions menu — FzIconDropdown fallback", () => {
-    it("should fall back to the dropdown when the Popover API is missing", async () => {
-      const wrapper = mount(FzCardListItem, {
-        props: { title: "Item", actions: [actionA, actionB] },
-      });
-      await wrapper.vm.$nextTick();
-
-      const dropdown = wrapper.findComponent({ name: "FzIconDropdown" });
-      expect(dropdown.exists()).toBe(true);
-      expect(dropdown.props("actions")).toEqual([actionA, actionB]);
-      expect(dropdown.props("iconName")).toBe("ellipsis-vertical");
-      expect(wrapper.find(".fz-card-actions__popover").exists()).toBe(false);
-    });
-
-    it("should fall back to the dropdown when CSS anchor positioning is unsupported", async () => {
-      Object.defineProperty(HTMLElement.prototype, "popover", {
-        value: null,
-        writable: true,
-        configurable: true,
-      });
-      vi.stubGlobal("CSS", { supports: () => false });
-
-      const wrapper = mount(FzCardListItem, {
-        props: { title: "Item", actions: [actionA, actionB] },
-      });
-      await wrapper.vm.$nextTick();
-
-      expect(wrapper.findComponent({ name: "FzIconDropdown" }).exists()).toBe(
-        true,
-      );
-      restoreAnchoredPopoverSupport();
-    });
-
-    it("should pass section markers through to the dropdown", async () => {
-      const section = { type: "section" as const, label: "Scarica" };
-      const wrapper = mount(FzCardListItem, {
-        props: { title: "Item", actions: [actionA, section, actionB] },
-      });
-      await wrapper.vm.$nextTick();
-
-      const dropdown = wrapper.findComponent({ name: "FzIconDropdown" });
-      expect(dropdown.props("actions")).toEqual([actionA, section, actionB]);
-    });
-
-    it("should forward fzaction:click from the dropdown", async () => {
-      const wrapper = mount(FzCardListItem, {
-        props: { title: "Item", actions: [actionA, actionB] },
-      });
-      await wrapper.vm.$nextTick();
-
-      const dropdown = wrapper.findComponent({ name: "FzIconDropdown" });
-      await dropdown.vm.$emit("fzaction:click", 1, actionB);
-
-      expect(wrapper.emitted("fzaction:click")).toBeTruthy();
-      expect(wrapper.emitted("fzaction:click")![0]).toEqual([1, actionB]);
-    });
-
-    it("should label the dropdown opener in Italian", async () => {
-      const wrapper = mount(FzCardListItem, {
-        props: { title: "Item", actions: [actionA, actionB] },
-      });
-      await wrapper.vm.$nextTick();
-      // `label` is the prop FzIconDropdown forwards to the icon button's
-      // aria-label (an `aria-label` attribute would land on the wrapper).
-      expect(
-        wrapper.findComponent({ name: "FzIconDropdown" }).props("label"),
-      ).toBe("Mostra azioni");
-      expect(wrapper.get("button").attributes("aria-label")).toBe(
-        "Mostra azioni",
-      );
+      expect(wrapper.get("button").attributes("aria-label")).toBe("Mostra azioni");
     });
   });
 

--- a/packages/card-list/src/__tests__/FzCardListItem.spec.ts
+++ b/packages/card-list/src/__tests__/FzCardListItem.spec.ts
@@ -223,7 +223,10 @@ describe("FzCardListItem", () => {
       // Only a section header + one link action → still arrow (link) mode,
       // not dropdown — markers don't count as interactive actions.
       const sectionOnly = mount(FzCardListItem, {
-        props: { title: "Item", actions: [{ type: "section", label: "Group" }] },
+        props: {
+          title: "Item",
+          actions: [{ type: "section", label: "Group" }],
+        },
       });
       const sectionPlusOneLink = mount(FzCardListItem, {
         props: {
@@ -231,8 +234,13 @@ describe("FzCardListItem", () => {
           actions: [{ type: "section", label: "Group" }, linkAction],
         },
       });
-      await Promise.all([sectionOnly.vm.$nextTick(), sectionPlusOneLink.vm.$nextTick()]);
-      expect(sectionOnly.findComponent({ name: "FzIconButton" }).exists()).toBe(false);
+      await Promise.all([
+        sectionOnly.vm.$nextTick(),
+        sectionPlusOneLink.vm.$nextTick(),
+      ]);
+      expect(sectionOnly.findComponent({ name: "FzIconButton" }).exists()).toBe(
+        false,
+      );
       expect(
         sectionPlusOneLink
           .findAllComponents({ name: "FzIcon" })
@@ -439,7 +447,6 @@ describe("FzCardListItem", () => {
         expect(payload).toEqual([0, linkAction]);
       }
     });
-
   });
 
   /**
@@ -478,6 +485,30 @@ describe("FzCardListItem", () => {
         "Action A",
         "Action B",
       ]);
+    });
+
+    it("should give each instance a document-unique popover id", async () => {
+      // Every mount() is its own Vue app, so an app-scoped id (useId()) would
+      // hand out the same value twice: `popovertarget` resolves by id and takes
+      // the first match, and every opener ends up toggling the first card's menu.
+      const first = mount(FzCardListItem, {
+        props: { title: "First", actions: [actionA, actionB] },
+      });
+      const second = mount(FzCardListItem, {
+        props: { title: "Second", actions: [actionA, actionB] },
+      });
+      await Promise.all([first.vm.$nextTick(), second.vm.$nextTick()]);
+
+      const menuId = (w: typeof first) =>
+        w.get(".fz-card-actions__popover").attributes("id");
+      expect(menuId(first)).not.toBe(menuId(second));
+      // …and each opener still points at its own menu.
+      expect(first.get("button").attributes("popovertarget")).toBe(
+        menuId(first),
+      );
+      expect(second.get("button").attributes("popovertarget")).toBe(
+        menuId(second),
+      );
     });
 
     it("should render section markers as group headers in the menu", async () => {

--- a/packages/card-list/src/__tests__/FzCardListItem.spec.ts
+++ b/packages/card-list/src/__tests__/FzCardListItem.spec.ts
@@ -645,6 +645,31 @@ describe("FzCardListItem", () => {
       expect(row.attributes("aria-labelledby")).toBeTruthy();
       expect(wrapper.get("p.truncate").text()).toBe("Pay invoice");
     });
+
+    it("should point aria-labelledby at its own title, with a document-unique id", async () => {
+      // Each mount() is its own Vue app: an app-scoped id (useId()) repeats
+      // across apps, and a screen reader then announces the first card's title
+      // for every row.
+      const first = mount(FzCardListItem, {
+        props: { title: "First invoice", actions: [linkAction] },
+      });
+      const second = mount(FzCardListItem, {
+        props: { title: "Second invoice", actions: [linkAction] },
+      });
+      await Promise.all([first.vm.$nextTick(), second.vm.$nextTick()]);
+
+      const labelId = (w: typeof first) =>
+        w.get('[role="button"]').attributes("aria-labelledby");
+      expect(labelId(first)).not.toBe(labelId(second));
+      // Each row's label id resolves to that row's own title.
+      for (const [wrapper, title] of [
+        [first, "First invoice"],
+        [second, "Second invoice"],
+      ] as const) {
+        const target = wrapper.get(`#${labelId(wrapper)}`);
+        expect(target.text()).toBe(title);
+      }
+    });
   });
 
   describe("Edge Cases", () => {

--- a/packages/card-list/src/__tests__/__snapshots__/FzCardListItem.spec.ts.snap
+++ b/packages/card-list/src/__tests__/__snapshots__/FzCardListItem.spec.ts.snap
@@ -1,23 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzCardListItem > Snapshots > should match snapshot - full featured item 1`] = `
-"<div data-v-da7f5873="" class="fz-container fz-container--vertical gap-section-content-xs align-items-stretch p-8 hover:bg-semantic-info-50 hover:rounded">
+"<div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--vertical gap-section-content-xs align-items-stretch p-8 hover:bg-semantic-info-50 hover:rounded">
   <!--
       Header row layout:
       - badge present → badge + actions
       - hasTitleOnly (no badge, no value) → title + actions (inline)
       - value present, no badge → actions only; title + value are in the second row
     -->
-  <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-base align-items-center layout-default">
+  <div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--horizontal gap-section-content-base align-items-center layout-default">
     <!-- Badge -->
-    <div class="flex items-center justify-center truncate max-w-full gap-4 py-4 px-12 h-24 w-fit rounded-2xl bg-grey-500 text-core-white" title="Bozza">
+    <div data-v-57bcf431="" class="flex items-center justify-center truncate max-w-full gap-4 py-4 px-12 h-24 w-fit rounded-2xl bg-grey-500 text-core-white" title="Bozza">
       <!--v-if-->
       <p class="text-[inherit] text-sm">Bozza</p>
       <!--v-if-->
-    </div><!-- Multiple actions dropdown -->
-    <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-center layout-expand-last shrink-0 ml-auto">
-      <div iconname="ellipsis-vertical" hasnotification="false" label="Open dropdown" variant="invisible" aria-label="Mostra azioni">
-        <div class="inline-flex w-full sm:w-auto"><span data-v-8090b1b6="" class="fz-icon-button-wrapper relative fz-icon-button-wrapper--frontoffice"><button data-v-8090b1b6="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200" aria-label="Open dropdown"><div class="flex items-center justify-items-center"><span role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px]"><svg class="svg-inline--fa fa-ellipsis-vertical h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="ellipsis-vertical" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M64 368a48 48 0 1 0 0 96 48 48 0 1 0 0-96zm0-160a48 48 0 1 0 0 96 48 48 0 1 0 0-96zM112 96A48 48 0 1 0 16 96a48 48 0 1 0 96 0z"></path></svg></span></div>
+    </div><!-- Multiple actions popover -->
+    <div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-center layout-expand-last shrink-0 ml-auto">
+      <!--
+          Fallback for browsers without the Popover API / CSS anchor positioning:
+          the JS-positioned dropdown this component used before. Same opener look
+          (FzIconDropdown defaults to the secondary icon button) and same
+          \`fzaction:click\` payload.
+        -->
+      <div data-v-57bcf431="" iconname="ellipsis-vertical" hasnotification="false" label="Mostra azioni">
+        <div class="inline-flex w-full sm:w-auto"><span data-v-8090b1b6="" class="fz-icon-button-wrapper relative fz-icon-button-wrapper--frontoffice"><button data-v-8090b1b6="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200" aria-label="Mostra azioni"><div class="flex items-center justify-items-center"><span role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px]"><svg class="svg-inline--fa fa-ellipsis-vertical h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="ellipsis-vertical" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M64 368a48 48 0 1 0 0 96 48 48 0 1 0 0-96zm0-160a48 48 0 1 0 0 96 48 48 0 1 0 0-96zM112 96A48 48 0 1 0 16 96a48 48 0 1 0 96 0z"></path></svg></span></div>
         <!--v-if-->
         <!--v-if--></button>
         <!--v-if--></span>
@@ -29,7 +35,7 @@ exports[`FzCardListItem > Snapshots > should match snapshot - full featured item
   </div>
 </div><!-- Title + value row (when badge or value is present) -->
 <!-- Title Only -->
-<div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-space-between">
+<div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-space-between">
   <!-- Title and indicator -->
   <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-center layout-default min-w-0">
     <!-- Indicator --><span role="presentation" class="flex items-center justify-center shrink-0 size-[12.5px]"><svg class="svg-inline--fa fa-circle-small fa-xs h-[10px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle-small" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path class="" fill="currentColor" d="M0 256a160 160 0 1 1 320 0A160 160 0 1 1 0 256z"></path></svg></span><!-- Title -->
@@ -37,12 +43,12 @@ exports[`FzCardListItem > Snapshots > should match snapshot - full featured item
   </div><!-- Value -->
   <p class="text-base whitespace-nowrap">1.200,00 €</p>
 </div>
-<div data-v-da7f5873="" class="fz-container fz-container--vertical gap-section-content-none align-items-stretch">
+<div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--vertical gap-section-content-none align-items-stretch">
   <p>Cliente: Rossi S.r.l.</p>
   <p>Scadenza: 31/03/2024</p>
 </div>
 </div>
-<div class="w-full my-0">
+<div data-v-57bcf431="" class="w-full my-0">
   <div class="border-solid border-t-1 border-grey-200"></div>
 </div>"
 `;

--- a/packages/card-list/src/__tests__/__snapshots__/FzCardListItem.spec.ts.snap
+++ b/packages/card-list/src/__tests__/__snapshots__/FzCardListItem.spec.ts.snap
@@ -1,41 +1,64 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzCardListItem > Snapshots > should match snapshot - full featured item 1`] = `
-"<div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--vertical gap-section-content-xs align-items-stretch p-8 hover:bg-semantic-info-50 hover:rounded">
+"<div data-v-da7f5873="" class="fz-container fz-container--vertical gap-section-content-xs align-items-stretch p-8 hover:bg-semantic-info-50 hover:rounded">
   <!--
       Header row layout:
       - badge present → badge + actions
       - hasTitleOnly (no badge, no value) → title + actions (inline)
       - value present, no badge → actions only; title + value are in the second row
     -->
-  <div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--horizontal gap-section-content-base align-items-center layout-default">
+  <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-base align-items-center layout-default">
     <!-- Badge -->
-    <div data-v-57bcf431="" class="flex items-center justify-center truncate max-w-full gap-4 py-4 px-12 h-24 w-fit rounded-2xl bg-grey-500 text-core-white" title="Bozza">
+    <div class="flex items-center justify-center truncate max-w-full gap-4 py-4 px-12 h-24 w-fit rounded-2xl bg-grey-500 text-core-white" title="Bozza">
       <!--v-if-->
       <p class="text-[inherit] text-sm">Bozza</p>
       <!--v-if-->
     </div><!-- Multiple actions popover -->
-    <div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-center layout-expand-last shrink-0 ml-auto">
+    <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-center layout-expand-last shrink-0 ml-auto">
       <!--
-          Fallback for browsers without the Popover API / CSS anchor positioning:
-          the JS-positioned dropdown this component used before. Same opener look
-          (FzIconDropdown defaults to the secondary icon button) and same
-          \`fzaction:click\` payload.
+          The engine choice lives in FzPopover: a native popover placed in CSS where
+          the browser can, FzFloating everywhere else. \`bottom-end\` keeps the menu
+          hanging down-and-left from the ellipsis, inside the card's right edge.
         -->
-      <div data-v-57bcf431="" iconname="ellipsis-vertical" hasnotification="false" label="Mostra azioni">
-        <div class="inline-flex w-full sm:w-auto"><span data-v-8090b1b6="" class="fz-icon-button-wrapper relative fz-icon-button-wrapper--frontoffice"><button data-v-8090b1b6="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200" aria-label="Mostra azioni"><div class="flex items-center justify-items-center"><span role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px]"><svg class="svg-inline--fa fa-ellipsis-vertical h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="ellipsis-vertical" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M64 368a48 48 0 1 0 0 96 48 48 0 1 0 0-96zm0-160a48 48 0 1 0 0 96 48 48 0 1 0 0-96zM112 96A48 48 0 1 0 16 96a48 48 0 1 0 96 0z"></path></svg></span></div>
+      <div data-v-a9c08781="" class="fz-popover">
+        <!--
+      \`use-viewport\` makes FzFloating resolve auto placements against the viewport
+      rather than the container. The collision boundary is already the viewport when
+      the container is \`document.body\` — LIB-2825 fixed that upstream.
+    -->
+        <div data-v-a9c08781="">
+          <div class="inline-flex w-full sm:w-auto"><span data-v-8090b1b6="" class="fz-icon-button-wrapper relative fz-icon-button-wrapper--frontoffice"><button data-v-8090b1b6="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200" aria-expanded="false" aria-label="Mostra azioni"><div class="flex items-center justify-items-center"><span role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px]"><svg class="svg-inline--fa fa-ellipsis-vertical h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="ellipsis-vertical" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M64 368a48 48 0 1 0 0 96 48 48 0 1 0 0-96zm0-160a48 48 0 1 0 0 96 48 48 0 1 0 0-96zM112 96A48 48 0 1 0 16 96a48 48 0 1 0 96 0z"></path></svg></span></div>
+          <!--v-if-->
+          <!--v-if--></button>
+          <!--v-if--></span>
+        </div>
+        <div class="fz__floating__content w-full sm:w-auto bg-core-white fixed mt-4 fz-card-actions__menu" style="display: none;">
+          <div data-v-ca7f3405="" class="fz__actionlist bg-core-white rounded flex flex-col gap-20 p-4 min-w-[240px]">
+            <div class="flex flex-col gap-4" role="group" aria-labelledby="fz-action-section-label-2a84k84" environment="frontoffice">
+              <!--v-if--><button data-v-f322a564="" aria-disabled="false" aria-selected="false" type="button" class="group inline-flex max-w-full rounded border border-transparent border-2 transition-colors duration-200 gap-2 p-12 flex-row gap-8 text-core-black hover:bg-background-alice-blue hover:!text-blue-500 focus:!border-blue-200 focus:!outline-none focus:text-core-black">
+                <!--v-if-->
+                <div data-v-f322a564="" class="flex flex-1 flex-col gap-4 overflow-hidden"><span data-v-f322a564="" class="text-base text-left" title="Action A">Action A</span>
+                  <!--v-if-->
+                </div>
+                <!--v-if-->
+              </button><button data-v-f322a564="" aria-disabled="false" aria-selected="false" type="button" class="group inline-flex max-w-full rounded border border-transparent border-2 transition-colors duration-200 gap-2 p-12 flex-row gap-8 text-core-black hover:bg-background-alice-blue hover:!text-blue-500 focus:!border-blue-200 focus:!outline-none focus:text-core-black">
+                <!--v-if-->
+                <div data-v-f322a564="" class="flex flex-1 flex-col gap-4 overflow-hidden"><span data-v-f322a564="" class="text-base text-left" title="Action B">Action B</span>
+                  <!--v-if-->
+                </div>
+                <!--v-if-->
+              </button>
+            </div>
+          </div>
+        </div>
         <!--v-if-->
-        <!--v-if--></button>
-        <!--v-if--></span>
       </div>
-      <!--v-if-->
-      <!--teleport start-->
-      <!--teleport end-->
     </div>
   </div>
 </div><!-- Title + value row (when badge or value is present) -->
 <!-- Title Only -->
-<div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-space-between">
+<div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-space-between">
   <!-- Title and indicator -->
   <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-center layout-default min-w-0">
     <!-- Indicator --><span role="presentation" class="flex items-center justify-center shrink-0 size-[12.5px]"><svg class="svg-inline--fa fa-circle-small fa-xs h-[10px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle-small" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path class="" fill="currentColor" d="M0 256a160 160 0 1 1 320 0A160 160 0 1 1 0 256z"></path></svg></span><!-- Title -->
@@ -43,12 +66,12 @@ exports[`FzCardListItem > Snapshots > should match snapshot - full featured item
   </div><!-- Value -->
   <p class="text-base whitespace-nowrap">1.200,00 €</p>
 </div>
-<div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--vertical gap-section-content-none align-items-stretch">
+<div data-v-da7f5873="" class="fz-container fz-container--vertical gap-section-content-none align-items-stretch">
   <p>Cliente: Rossi S.r.l.</p>
   <p>Scadenza: 31/03/2024</p>
 </div>
 </div>
-<div data-v-57bcf431="" class="w-full my-0">
+<div class="w-full my-0">
   <div class="border-solid border-t-1 border-grey-200"></div>
 </div>"
 `;

--- a/packages/card-list/src/__tests__/__snapshots__/FzCardListItem.spec.ts.snap
+++ b/packages/card-list/src/__tests__/__snapshots__/FzCardListItem.spec.ts.snap
@@ -1,41 +1,65 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzCardListItem > Snapshots > should match snapshot - full featured item 1`] = `
-"<div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--vertical gap-section-content-xs align-items-stretch p-8 hover:bg-semantic-info-50 hover:rounded">
+"<div data-v-da7f5873="" class="fz-container fz-container--vertical gap-section-content-xs align-items-stretch p-8 hover:bg-semantic-info-50 hover:rounded">
   <!--
       Header row layout:
       - badge present → badge + actions
       - hasTitleOnly (no badge, no value) → title + actions (inline)
       - value present, no badge → actions only; title + value are in the second row
     -->
-  <div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--horizontal gap-section-content-base align-items-center layout-default">
+  <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-base align-items-center layout-default">
     <!-- Badge -->
-    <div data-v-57bcf431="" class="flex items-center justify-center truncate max-w-full gap-4 py-4 px-12 h-24 w-fit rounded-2xl bg-grey-500 text-core-white" title="Bozza">
+    <div class="flex items-center justify-center truncate max-w-full gap-4 py-4 px-12 h-24 w-fit rounded-2xl bg-grey-500 text-core-white" title="Bozza">
       <!--v-if-->
       <p class="text-[inherit] text-sm">Bozza</p>
       <!--v-if-->
     </div><!-- Multiple actions popover -->
-    <div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-center layout-expand-last shrink-0 ml-auto">
+    <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-center layout-expand-last shrink-0 ml-auto">
       <!--
-          Fallback for browsers without the Popover API / CSS anchor positioning:
-          the JS-positioned dropdown this component used before. Same opener look
-          (FzIconDropdown defaults to the secondary icon button) and same
-          \`fzaction:click\` payload.
+          The engine choice lives in FzPopover: a native popover placed in CSS where
+          the browser can, FzFloating everywhere else. \`bottom-end\` keeps the menu
+          hanging down-and-left from the ellipsis, inside the card's right edge.
         -->
-      <div data-v-57bcf431="" iconname="ellipsis-vertical" hasnotification="false" label="Mostra azioni">
-        <div class="inline-flex w-full sm:w-auto"><span data-v-8090b1b6="" class="fz-icon-button-wrapper relative fz-icon-button-wrapper--frontoffice"><button data-v-8090b1b6="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200" aria-label="Mostra azioni"><div class="flex items-center justify-items-center"><span role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px]"><svg class="svg-inline--fa fa-ellipsis-vertical h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="ellipsis-vertical" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M64 368a48 48 0 1 0 0 96 48 48 0 1 0 0-96zm0-160a48 48 0 1 0 0 96 48 48 0 1 0 0-96zM112 96A48 48 0 1 0 16 96a48 48 0 1 0 96 0z"></path></svg></span></div>
+      <div data-v-a9c08781="" class="fz-popover">
+        <!--
+      \`use-viewport\` asks FzFloating to clamp against the viewport rather than
+      \`document.body\`: the body's height is not a boundary for fixed content, and on
+      a page shorter than the viewport the clamp would drag the content over its own
+      opener.
+    -->
+        <div data-v-a9c08781="">
+          <div class="inline-flex w-full sm:w-auto"><span data-v-8090b1b6="" class="fz-icon-button-wrapper relative fz-icon-button-wrapper--frontoffice"><button data-v-8090b1b6="" type="button" aria-disabled="false" class="fz-button relative rounded flex flex-shrink items-center justify-center font-normal !text-[16px] !leading-[20px] border-1 border-solid border-transparent appearance-none gap-8 h-44 px-12 min-w-96 bg-core-white text-grey-500 !border-grey-200 hover:bg-grey-100 hover:!border-grey-200 focus:bg-core-white focus:!border-blue-600 disabled:bg-grey-50 disabled:text-grey-200 disabled:!border-grey-200" aria-expanded="false" aria-label="Mostra azioni"><div class="flex items-center justify-items-center"><span role="presentation" class="flex items-center justify-center shrink-0 w-[20px] h-[20px]"><svg class="svg-inline--fa fa-ellipsis-vertical h-[16px]" aria-hidden="true" focusable="false" data-prefix="far" data-icon="ellipsis-vertical" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512"><path class="" fill="currentColor" d="M64 368a48 48 0 1 0 0 96 48 48 0 1 0 0-96zm0-160a48 48 0 1 0 0 96 48 48 0 1 0 0-96zM112 96A48 48 0 1 0 16 96a48 48 0 1 0 96 0z"></path></svg></span></div>
+          <!--v-if-->
+          <!--v-if--></button>
+          <!--v-if--></span>
+        </div>
+        <div class="fz__floating__content w-full sm:w-auto bg-core-white fixed mt-4 fz-card-actions__menu" style="display: none;">
+          <div data-v-ca7f3405="" class="fz__actionlist bg-core-white rounded flex flex-col gap-20 p-4 min-w-[240px]">
+            <div class="flex flex-col gap-4" role="group" aria-labelledby="fz-action-section-label-2a84k84" environment="frontoffice">
+              <!--v-if--><button data-v-f322a564="" aria-disabled="false" aria-selected="false" type="button" class="group inline-flex max-w-full rounded border border-transparent border-2 transition-colors duration-200 gap-2 p-12 flex-row gap-8 text-core-black hover:bg-background-alice-blue hover:!text-blue-500 focus:!border-blue-200 focus:!outline-none focus:text-core-black">
+                <!--v-if-->
+                <div data-v-f322a564="" class="flex flex-1 flex-col gap-4 overflow-hidden"><span data-v-f322a564="" class="text-base text-left" title="Action A">Action A</span>
+                  <!--v-if-->
+                </div>
+                <!--v-if-->
+              </button><button data-v-f322a564="" aria-disabled="false" aria-selected="false" type="button" class="group inline-flex max-w-full rounded border border-transparent border-2 transition-colors duration-200 gap-2 p-12 flex-row gap-8 text-core-black hover:bg-background-alice-blue hover:!text-blue-500 focus:!border-blue-200 focus:!outline-none focus:text-core-black">
+                <!--v-if-->
+                <div data-v-f322a564="" class="flex flex-1 flex-col gap-4 overflow-hidden"><span data-v-f322a564="" class="text-base text-left" title="Action B">Action B</span>
+                  <!--v-if-->
+                </div>
+                <!--v-if-->
+              </button>
+            </div>
+          </div>
+        </div>
         <!--v-if-->
-        <!--v-if--></button>
-        <!--v-if--></span>
       </div>
-      <!--v-if-->
-      <!--teleport start-->
-      <!--teleport end-->
     </div>
   </div>
 </div><!-- Title + value row (when badge or value is present) -->
 <!-- Title Only -->
-<div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-space-between">
+<div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-sm align-items-center layout-space-between">
   <!-- Title and indicator -->
   <div data-v-da7f5873="" class="fz-container fz-container--horizontal gap-section-content-xs align-items-center layout-default min-w-0">
     <!-- Indicator --><span role="presentation" class="flex items-center justify-center shrink-0 size-[12.5px]"><svg class="svg-inline--fa fa-circle-small fa-xs h-[10px]" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle-small" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path class="" fill="currentColor" d="M0 256a160 160 0 1 1 320 0A160 160 0 1 1 0 256z"></path></svg></span><!-- Title -->
@@ -43,12 +67,12 @@ exports[`FzCardListItem > Snapshots > should match snapshot - full featured item
   </div><!-- Value -->
   <p class="text-base whitespace-nowrap">1.200,00 €</p>
 </div>
-<div data-v-da7f5873="" data-v-57bcf431="" class="fz-container fz-container--vertical gap-section-content-none align-items-stretch">
+<div data-v-da7f5873="" class="fz-container fz-container--vertical gap-section-content-none align-items-stretch">
   <p>Cliente: Rossi S.r.l.</p>
   <p>Scadenza: 31/03/2024</p>
 </div>
 </div>
-<div data-v-57bcf431="" class="w-full my-0">
+<div class="w-full my-0">
   <div class="border-solid border-t-1 border-grey-200"></div>
 </div>"
 `;

--- a/packages/card-list/src/__tests__/utils.spec.ts
+++ b/packages/card-list/src/__tests__/utils.spec.ts
@@ -1,51 +1,26 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { supportsAnchoredPopover } from "../utils";
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, h } from "vue";
+import { useUniqueId } from "../utils";
 
-function fakePopoverSupport() {
-  Object.defineProperty(HTMLElement.prototype, "popover", {
-    value: null,
-    writable: true,
-    configurable: true,
-  });
-}
-
-afterEach(() => {
-  delete (HTMLElement.prototype as unknown as Record<string, unknown>).popover;
-  vi.unstubAllGlobals();
+const Probe = defineComponent({
+  setup() {
+    const id = useUniqueId("probe");
+    return () => h("span", { id }, id);
+  },
 });
 
-describe("supportsAnchoredPopover", () => {
-  it("should return false in an environment without the Popover API (jsdom as-is)", () => {
-    expect(supportsAnchoredPopover()).toBe(false);
+describe("useUniqueId", () => {
+  it("should prefix the id with the given string", () => {
+    const wrapper = mount(Probe);
+    expect(wrapper.get("span").attributes("id")).toMatch(/^probe-\d+$/);
   });
 
-  it("should return false when CSS.supports is unavailable", () => {
-    fakePopoverSupport();
-    expect(supportsAnchoredPopover()).toBe(false);
-  });
-
-  it("should return false when anchor positioning is unsupported", () => {
-    fakePopoverSupport();
-    vi.stubGlobal("CSS", { supports: () => false });
-    expect(supportsAnchoredPopover()).toBe(false);
-  });
-
-  it("should return false when the Popover API is missing even if anchor positioning is supported", () => {
-    vi.stubGlobal("CSS", { supports: () => true });
-    expect(supportsAnchoredPopover()).toBe(false);
-  });
-
-  it("should return true when both the Popover API and anchor positioning are supported", () => {
-    fakePopoverSupport();
-    vi.stubGlobal("CSS", { supports: () => true });
-    expect(supportsAnchoredPopover()).toBe(true);
-  });
-
-  it("should probe anchor positioning support with an anchor-name declaration", () => {
-    fakePopoverSupport();
-    const supports = vi.fn().mockReturnValue(true);
-    vi.stubGlobal("CSS", { supports });
-    supportsAnchoredPopover();
-    expect(supports).toHaveBeenCalledWith("anchor-name: --fz");
+  it("should not repeat across Vue apps", () => {
+    // Each mount() is its own app, which is exactly where useId() repeats itself.
+    const ids = Array.from({ length: 5 }, () =>
+      mount(Probe).get("span").attributes("id"),
+    );
+    expect(new Set(ids).size).toBe(5);
   });
 });

--- a/packages/card-list/src/__tests__/utils.spec.ts
+++ b/packages/card-list/src/__tests__/utils.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { supportsAnchoredPopover } from "../utils";
+
+function fakePopoverSupport() {
+  Object.defineProperty(HTMLElement.prototype, "popover", {
+    value: null,
+    writable: true,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  delete (HTMLElement.prototype as unknown as Record<string, unknown>).popover;
+  vi.unstubAllGlobals();
+});
+
+describe("supportsAnchoredPopover", () => {
+  it("should return false in an environment without the Popover API (jsdom as-is)", () => {
+    expect(supportsAnchoredPopover()).toBe(false);
+  });
+
+  it("should return false when CSS.supports is unavailable", () => {
+    fakePopoverSupport();
+    expect(supportsAnchoredPopover()).toBe(false);
+  });
+
+  it("should return false when anchor positioning is unsupported", () => {
+    fakePopoverSupport();
+    vi.stubGlobal("CSS", { supports: () => false });
+    expect(supportsAnchoredPopover()).toBe(false);
+  });
+
+  it("should return false when the Popover API is missing even if anchor positioning is supported", () => {
+    vi.stubGlobal("CSS", { supports: () => true });
+    expect(supportsAnchoredPopover()).toBe(false);
+  });
+
+  it("should return true when both the Popover API and anchor positioning are supported", () => {
+    fakePopoverSupport();
+    vi.stubGlobal("CSS", { supports: () => true });
+    expect(supportsAnchoredPopover()).toBe(true);
+  });
+
+  it("should probe anchor positioning support with an anchor-name declaration", () => {
+    fakePopoverSupport();
+    const supports = vi.fn().mockReturnValue(true);
+    vi.stubGlobal("CSS", { supports });
+    supportsAnchoredPopover();
+    expect(supports).toHaveBeenCalledWith("anchor-name: --fz");
+  });
+});

--- a/packages/card-list/src/components/FzCardActionLink.vue
+++ b/packages/card-list/src/components/FzCardActionLink.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useId } from "vue";
+import { computed } from "vue";
 import { FzBadge } from "@fiscozen/badge";
 import { FzContainer } from "@fiscozen/container";
 import { FzDivider } from "@fiscozen/divider";
@@ -7,6 +7,7 @@ import { FzIcon } from "@fiscozen/icons";
 import type { FzCardSingleActionEmits, FzCardSingleActionProps } from "./types";
 import FzCardHeader from "./FzCardHeader.vue";
 import FzCardFooter from "./FzCardFooter.vue";
+import { useUniqueId } from "../utils";
 
 const props = defineProps<FzCardSingleActionProps>();
 
@@ -15,7 +16,9 @@ const emit = defineEmits<FzCardSingleActionEmits>();
 const hasTitleOnly = computed(() => !props.badge && !props.value);
 const noAction = computed(() => !props.action);
 
-const rowTitleId = useId();
+// The row's `aria-labelledby` points at the title, so this id must be unique
+// document-wide, not just per app — see useUniqueId.
+const rowTitleId = useUniqueId("fz-card-title");
 
 function handleRowInteraction(e: MouseEvent | KeyboardEvent) {
   if (noAction.value) return;
@@ -46,7 +49,12 @@ function handleRowInteraction(e: MouseEvent | KeyboardEvent) {
     -->
     <FzContainer horizontal alignItems="center">
       <!-- Badge -->
-      <FzBadge v-if="badge" :left-icon="badge.icon" :tone="badge.tone" variant="text">
+      <FzBadge
+        v-if="badge"
+        :left-icon="badge.icon"
+        :tone="badge.tone"
+        variant="text"
+      >
         {{ badge.text }}
       </FzBadge>
       <!-- Title only (inline with action) -->

--- a/packages/card-list/src/components/FzCardMultiActions.vue
+++ b/packages/card-list/src/components/FzCardMultiActions.vue
@@ -1,42 +1,21 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { FzBadge } from "@fiscozen/badge";
 import { FzContainer } from "@fiscozen/container";
 import { FzDivider } from "@fiscozen/divider";
 import { FzIconButton } from "@fiscozen/button";
-import { FzIconDropdown } from "@fiscozen/dropdown";
+import { FzPopover } from "@fiscozen/popover";
 import { FzAction, FzActionList, FzActionSection } from "@fiscozen/action";
 import type { FzActionProps } from "@fiscozen/action";
 import type { FzCardMultiActionsProps, FzCardMultiActionsEmits } from "./types";
 import FzCardHeader from "./FzCardHeader.vue";
 import FzCardFooter from "./FzCardFooter.vue";
-import { supportsAnchoredPopover, useUniqueId } from "../utils";
 
 const props = defineProps<FzCardMultiActionsProps>();
 
 const emit = defineEmits<FzCardMultiActionsEmits>();
 
 const hasTitleOnly = computed(() => !props.badge && !props.value);
-
-/**
- * Which actions menu to render: the native popover where the browser supports
- * it, `FzIconDropdown` everywhere else. Read once per instance — browser
- * capabilities don't change at runtime, so this needs no reactivity.
- */
-const anchoredPopover = supportsAnchoredPopover();
-
-/**
- * Target id for the native Popover API. The ellipsis button references it via
- * `popovertarget`, which (a) lets the browser toggle + light-dismiss the menu
- * with no JS, and (b) makes that button the popover's *implicit anchor* for CSS
- * anchor positioning — so `.fz-card-actions__popover` can position itself with
- * `anchor()` without a per-instance `anchor-name`.
- *
- * Because `popovertarget` resolves this id in the DOM, it has to be unique across
- * the document and not merely within the app — see useUniqueId.
- */
-const popoverId = useUniqueId("fz-card-actions");
-const popover = ref<HTMLElement>();
 
 /**
  * Group actions into labelled sections (mirrors FzDropdown): a `type: "section"`
@@ -56,25 +35,18 @@ const groupedActions = computed(() => {
 });
 
 /**
- * Resolves the clicked action back to its index in the `actions` prop. Same
- * lookup FzDropdown does internally, on purpose: both menus must emit the same
- * index for the same action, quirks included (with two identical actions both
- * report the first match).
+ * Resolves the clicked action back to its index in the `actions` prop. Same lookup
+ * FzDropdown does internally, on purpose: a caller that migrates from the dropdown
+ * keeps receiving the same index for the same action, quirks included (with two
+ * identical actions both report the first match).
  */
-function handleActionClick(action: FzActionProps) {
+function handleActionClick(action: FzActionProps, close: () => void) {
   const stringified = JSON.stringify(action);
   const index = props.actions.findIndex(
     (candidate) => JSON.stringify(candidate) === stringified,
   );
   emit("fzaction:click", index, action);
-  // Optional chaining: `hidePopover` is absent in the jsdom test env (the
-  // Popover API only lands in jsdom 24); the real browser closes the menu here.
-  popover.value?.hidePopover?.();
-}
-
-/** Fallback path: FzIconDropdown already resolves the index for us. */
-function emitActionClick(actionIndex: number, action: FzActionProps) {
-  emit("fzaction:click", actionIndex, action);
+  close();
 }
 </script>
 
@@ -111,24 +83,22 @@ function emitActionClick(actionIndex: number, action: FzActionProps) {
         layout="expand-last"
         class="shrink-0 ml-auto"
       >
-        <template v-if="anchoredPopover">
-          <!--
-            Ellipsis opener. `popovertarget` toggles the native popover below and
-            makes this button the popover's implicit anchor: the menu is placed
-            entirely in CSS (see `.fz-card-actions__popover`), no JS positioning.
-          -->
-          <FzIconButton
-            iconName="ellipsis-vertical"
-            variant="secondary"
-            aria-label="Mostra azioni"
-            :popovertarget="popoverId"
-          />
-          <div
-            :id="popoverId"
-            ref="popover"
-            popover
-            class="fz-card-actions__popover"
-          >
+        <!--
+          The engine choice lives in FzPopover: a native popover placed in CSS where
+          the browser can, FzFloating everywhere else. `bottom-end` keeps the menu
+          hanging down-and-left from the ellipsis, inside the card's right edge.
+        -->
+        <FzPopover position="bottom-end" content-class="fz-card-actions__menu">
+          <template #opener="{ toggle, isOpen }">
+            <FzIconButton
+              iconName="ellipsis-vertical"
+              variant="secondary"
+              aria-label="Mostra azioni"
+              :aria-expanded="isOpen"
+              @click="toggle"
+            />
+          </template>
+          <template #default="{ close }">
             <FzActionList>
               <FzActionSection
                 v-for="(section, label) in groupedActions"
@@ -141,26 +111,12 @@ function emitActionClick(actionIndex: number, action: FzActionProps) {
                   :key="actionIndex"
                   v-bind="action"
                   environment="frontoffice"
-                  @click="handleActionClick(action)"
+                  @click="handleActionClick(action, close)"
                 />
               </FzActionSection>
             </FzActionList>
-          </div>
-        </template>
-        <!--
-          Fallback for browsers without the Popover API / CSS anchor positioning:
-          the JS-positioned dropdown this component used before. Same opener look
-          (FzIconDropdown defaults to the secondary icon button) and same
-          `fzaction:click` payload.
-        -->
-        <FzIconDropdown
-          v-else
-          :actions="actions!"
-          iconName="ellipsis-vertical"
-          buttonVariant="secondary"
-          label="Mostra azioni"
-          @fzaction:click="emitActionClick"
-        />
+          </template>
+        </FzPopover>
       </FzContainer>
     </FzContainer>
 
@@ -177,28 +133,3 @@ function emitActionClick(actionIndex: number, action: FzActionProps) {
   <FzDivider margin="none" />
 </template>
 
-<style scoped>
-.fz-card-actions__popover {
-  /* Reset the UA popover box (`inset: 0; margin: auto`) — we drive placement
-     ourselves through anchor(). Kept `fixed` so it lives in the top layer and
-     is never clipped by the card's overflow. */
-  position: fixed;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  overflow: visible;
-  width: max-content;
-
-  /* Anchor to the ellipsis button (implicit anchor via `popovertarget`):
-     drop below it with right edges aligned, so the menu grows down-and-left. */
-  top: anchor(bottom);
-  right: anchor(right);
-  bottom: auto;
-  left: auto;
-  margin-top: 4px; /* gap — mirrors the previous `mt-4` (4px in the DS scale) */
-
-  /* Flip above the button when there isn't room below. */
-  position-try-fallbacks: flip-block;
-}
-</style>

--- a/packages/card-list/src/components/FzCardMultiActions.vue
+++ b/packages/card-list/src/components/FzCardMultiActions.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, useId } from "vue";
 import { FzBadge } from "@fiscozen/badge";
 import { FzContainer } from "@fiscozen/container";
 import { FzDivider } from "@fiscozen/divider";
+import { FzIconButton } from "@fiscozen/button";
 import { FzIconDropdown } from "@fiscozen/dropdown";
-import type { FzCardMultiActionsProps, FzCardMultiActionsEmits } from "./types";
+import { FzAction, FzActionList, FzActionSection } from "@fiscozen/action";
 import type { FzActionProps } from "@fiscozen/action";
+import type { FzCardMultiActionsProps, FzCardMultiActionsEmits } from "./types";
 import FzCardHeader from "./FzCardHeader.vue";
 import FzCardFooter from "./FzCardFooter.vue";
+import { supportsAnchoredPopover } from "../utils";
 
 const props = defineProps<FzCardMultiActionsProps>();
 
@@ -15,6 +18,58 @@ const emit = defineEmits<FzCardMultiActionsEmits>();
 
 const hasTitleOnly = computed(() => !props.badge && !props.value);
 
+/**
+ * Which actions menu to render: the native popover where the browser supports
+ * it, `FzIconDropdown` everywhere else. Read once per instance — browser
+ * capabilities don't change at runtime, so this needs no reactivity.
+ */
+const anchoredPopover = supportsAnchoredPopover();
+
+/**
+ * Target id for the native Popover API. The ellipsis button references it via
+ * `popovertarget`, which (a) lets the browser toggle + light-dismiss the menu
+ * with no JS, and (b) makes that button the popover's *implicit anchor* for CSS
+ * anchor positioning — so `.fz-card-actions__popover` can position itself with
+ * `anchor()` without a per-instance `anchor-name`.
+ */
+const popoverId = `fz-card-actions-${useId()}`;
+const popover = ref<HTMLElement>();
+
+/**
+ * Group actions into labelled sections (mirrors FzDropdown): a `type: "section"`
+ * marker opens a new group and the following actions accumulate under it.
+ */
+const groupedActions = computed(() => {
+  const sections: Record<string, FzActionProps[]> = {};
+  let section = "__default__";
+  props.actions.forEach((action) => {
+    if (action.type === "section") {
+      section = action.label || "__default__";
+      return;
+    }
+    (sections[section] ??= []).push(action);
+  });
+  return sections;
+});
+
+/**
+ * Resolves the clicked action back to its index in the `actions` prop. Same
+ * lookup FzDropdown does internally, on purpose: both menus must emit the same
+ * index for the same action, quirks included (with two identical actions both
+ * report the first match).
+ */
+function handleActionClick(action: FzActionProps) {
+  const stringified = JSON.stringify(action);
+  const index = props.actions.findIndex(
+    (candidate) => JSON.stringify(candidate) === stringified,
+  );
+  emit("fzaction:click", index, action);
+  // Optional chaining: `hidePopover` is absent in the jsdom test env (the
+  // Popover API only lands in jsdom 24); the real browser closes the menu here.
+  popover.value?.hidePopover?.();
+}
+
+/** Fallback path: FzIconDropdown already resolves the index for us. */
 function emitActionClick(actionIndex: number, action: FzActionProps) {
   emit("fzaction:click", actionIndex, action);
 }
@@ -40,7 +95,7 @@ function emitActionClick(actionIndex: number, action: FzActionProps) {
         :show-indicator="showIndicator"
         :title="title"
       />
-      <!-- Multiple actions dropdown -->
+      <!-- Multiple actions popover -->
       <FzContainer
         horizontal
         gap="xs"
@@ -48,11 +103,49 @@ function emitActionClick(actionIndex: number, action: FzActionProps) {
         layout="expand-last"
         class="shrink-0 ml-auto"
       >
+        <template v-if="anchoredPopover">
+          <!--
+            Ellipsis opener. `popovertarget` toggles the native popover below and
+            makes this button the popover's implicit anchor: the menu is placed
+            entirely in CSS (see `.fz-card-actions__popover`), no JS positioning.
+          -->
+          <FzIconButton
+            iconName="ellipsis-vertical"
+            variant="secondary"
+            aria-label="Mostra azioni"
+            :popovertarget="popoverId"
+          />
+          <div :id="popoverId" ref="popover" popover class="fz-card-actions__popover">
+            <FzActionList>
+              <FzActionSection
+                v-for="(section, label) in groupedActions"
+                :key="label"
+                :label="label !== '__default__' ? label : undefined"
+                environment="frontoffice"
+              >
+                <FzAction
+                  v-for="(action, actionIndex) in section"
+                  :key="actionIndex"
+                  v-bind="action"
+                  environment="frontoffice"
+                  @click="handleActionClick(action)"
+                />
+              </FzActionSection>
+            </FzActionList>
+          </div>
+        </template>
+        <!--
+          Fallback for browsers without the Popover API / CSS anchor positioning:
+          the JS-positioned dropdown this component used before. Same opener look
+          (FzIconDropdown defaults to the secondary icon button) and same
+          `fzaction:click` payload.
+        -->
         <FzIconDropdown
+          v-else
           :actions="actions!"
           iconName="ellipsis-vertical"
-          variant="invisible"
-          aria-label="Mostra azioni"
+          buttonVariant="secondary"
+          label="Mostra azioni"
           @fzaction:click="emitActionClick"
         />
       </FzContainer>
@@ -70,3 +163,29 @@ function emitActionClick(actionIndex: number, action: FzActionProps) {
 
   <FzDivider margin="none" />
 </template>
+
+<style scoped>
+.fz-card-actions__popover {
+  /* Reset the UA popover box (`inset: 0; margin: auto`) — we drive placement
+     ourselves through anchor(). Kept `fixed` so it lives in the top layer and
+     is never clipped by the card's overflow. */
+  position: fixed;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  overflow: visible;
+  width: max-content;
+
+  /* Anchor to the ellipsis button (implicit anchor via `popovertarget`):
+     drop below it with right edges aligned, so the menu grows down-and-left. */
+  top: anchor(bottom);
+  right: anchor(right);
+  bottom: auto;
+  left: auto;
+  margin-top: 4px; /* gap — mirrors the previous `mt-4` (4px in the DS scale) */
+
+  /* Flip above the button when there isn't room below. */
+  position-try-fallbacks: flip-block;
+}
+</style>

--- a/packages/card-list/src/components/FzCardMultiActions.vue
+++ b/packages/card-list/src/components/FzCardMultiActions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, getCurrentInstance, ref } from "vue";
+import { computed, ref } from "vue";
 import { FzBadge } from "@fiscozen/badge";
 import { FzContainer } from "@fiscozen/container";
 import { FzDivider } from "@fiscozen/divider";
@@ -10,7 +10,7 @@ import type { FzActionProps } from "@fiscozen/action";
 import type { FzCardMultiActionsProps, FzCardMultiActionsEmits } from "./types";
 import FzCardHeader from "./FzCardHeader.vue";
 import FzCardFooter from "./FzCardFooter.vue";
-import { supportsAnchoredPopover } from "../utils";
+import { supportsAnchoredPopover, useUniqueId } from "../utils";
 
 const props = defineProps<FzCardMultiActionsProps>();
 
@@ -32,14 +32,10 @@ const anchoredPopover = supportsAnchoredPopover();
  * anchor positioning — so `.fz-card-actions__popover` can position itself with
  * `anchor()` without a per-instance `anchor-name`.
  *
- * The suffix is the instance's `uid` and NOT `useId()`: `useId()` is scoped to
- * the Vue *app*, so two apps in the same document (Storybook docs mode, or a page
- * with several mount points) both hand out `v-0`. `popovertarget` resolves by id
- * and takes the first match, so every opener would toggle the first card's menu,
- * anchored to a button the user never clicked. `uid` is a counter inside the Vue
- * runtime, shared across apps, so it is unique document-wide.
+ * Because `popovertarget` resolves this id in the DOM, it has to be unique across
+ * the document and not merely within the app — see useUniqueId.
  */
-const popoverId = `fz-card-actions-${getCurrentInstance()!.uid}`;
+const popoverId = useUniqueId("fz-card-actions");
 const popover = ref<HTMLElement>();
 
 /**

--- a/packages/card-list/src/components/FzCardMultiActions.vue
+++ b/packages/card-list/src/components/FzCardMultiActions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, useId } from "vue";
+import { computed, getCurrentInstance, ref } from "vue";
 import { FzBadge } from "@fiscozen/badge";
 import { FzContainer } from "@fiscozen/container";
 import { FzDivider } from "@fiscozen/divider";
@@ -31,8 +31,15 @@ const anchoredPopover = supportsAnchoredPopover();
  * with no JS, and (b) makes that button the popover's *implicit anchor* for CSS
  * anchor positioning — so `.fz-card-actions__popover` can position itself with
  * `anchor()` without a per-instance `anchor-name`.
+ *
+ * The suffix is the instance's `uid` and NOT `useId()`: `useId()` is scoped to
+ * the Vue *app*, so two apps in the same document (Storybook docs mode, or a page
+ * with several mount points) both hand out `v-0`. `popovertarget` resolves by id
+ * and takes the first match, so every opener would toggle the first card's menu,
+ * anchored to a button the user never clicked. `uid` is a counter inside the Vue
+ * runtime, shared across apps, so it is unique document-wide.
  */
-const popoverId = `fz-card-actions-${useId()}`;
+const popoverId = `fz-card-actions-${getCurrentInstance()!.uid}`;
 const popover = ref<HTMLElement>();
 
 /**
@@ -85,7 +92,12 @@ function emitActionClick(actionIndex: number, action: FzActionProps) {
     -->
     <FzContainer horizontal alignItems="center">
       <!-- Badge -->
-      <FzBadge v-if="badge" :left-icon="badge.icon" :tone="badge.tone" variant="text">
+      <FzBadge
+        v-if="badge"
+        :left-icon="badge.icon"
+        :tone="badge.tone"
+        variant="text"
+      >
         {{ badge.text }}
       </FzBadge>
       <!-- Title only (inline with actions) -->
@@ -115,7 +127,12 @@ function emitActionClick(actionIndex: number, action: FzActionProps) {
             aria-label="Mostra azioni"
             :popovertarget="popoverId"
           />
-          <div :id="popoverId" ref="popover" popover class="fz-card-actions__popover">
+          <div
+            :id="popoverId"
+            ref="popover"
+            popover
+            class="fz-card-actions__popover"
+          >
             <FzActionList>
               <FzActionSection
                 v-for="(section, label) in groupedActions"

--- a/packages/card-list/src/utils.ts
+++ b/packages/card-list/src/utils.ts
@@ -21,31 +21,3 @@ export function useUniqueId(prefix: string): string {
   return `${prefix}-${getCurrentInstance()!.uid}`;
 }
 
-/**
- * Feature-detects the two platform features the anchored actions menu of
- * `FzCardMultiActions` is built on:
- *
- * 1. the **Popover API** (`[popover]` + `popovertarget`) — top layer, light
- *    dismiss and Esc handling for free, no JS;
- * 2. **CSS anchor positioning** (`anchor()`) — places the menu against its
- *    opener without measuring anything in JS.
- *
- * (1) has been broadly available since 2024; (2) only reached Baseline in 2026,
- * so a non-trivial slice of users (slightly older Safari and Firefox) is still
- * without it. Browsers missing either feature get the `FzIconDropdown` fallback
- * (JS-positioned `FzFloating`) — the menu this component used before.
- *
- * Deliberately not memoized: the checks are two cheap lookups, and keeping them
- * live lets tests toggle support per case. `window.CSS` is guarded because it is
- * absent in jsdom.
- */
-export function supportsAnchoredPopover(): boolean {
-  if (typeof HTMLElement === "undefined" || typeof window === "undefined") {
-    return false;
-  }
-  if (!("popover" in HTMLElement.prototype)) return false;
-  return (
-    typeof window.CSS?.supports === "function" &&
-    window.CSS.supports("anchor-name: --fz")
-  );
-}

--- a/packages/card-list/src/utils.ts
+++ b/packages/card-list/src/utils.ts
@@ -1,3 +1,26 @@
+import { getCurrentInstance } from "vue";
+
+/**
+ * A DOM id that is unique across the whole document, for ids that something else
+ * resolves — `popovertarget`, `aria-labelledby`.
+ *
+ * Deliberately NOT `useId()`: that is scoped to the Vue *app*, and a document can
+ * hold several (Storybook docs mode mounts one app per story; an app can have
+ * several mount points), each handing out `v-0` again. Duplicated ids fail
+ * silently in whoever resolves them — `popovertarget` toggles the first match, so
+ * an ellipsis button opens another card's menu; `aria-labelledby` resolves to the
+ * first match, so a screen reader announces another card's title. `uid` is a
+ * counter inside the Vue runtime itself, shared across apps.
+ *
+ * `useId()` would be the better choice for SSR (it is built to survive
+ * hydration); this package has no SSR target, so document uniqueness wins.
+ *
+ * Call from `setup()` — it needs the current instance.
+ */
+export function useUniqueId(prefix: string): string {
+  return `${prefix}-${getCurrentInstance()!.uid}`;
+}
+
 /**
  * Feature-detects the two platform features the anchored actions menu of
  * `FzCardMultiActions` is built on:

--- a/packages/card-list/src/utils.ts
+++ b/packages/card-list/src/utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Feature-detects the two platform features the anchored actions menu of
+ * `FzCardMultiActions` is built on:
+ *
+ * 1. the **Popover API** (`[popover]` + `popovertarget`) — top layer, light
+ *    dismiss and Esc handling for free, no JS;
+ * 2. **CSS anchor positioning** (`anchor()`) — places the menu against its
+ *    opener without measuring anything in JS.
+ *
+ * (1) has been broadly available since 2024; (2) only reached Baseline in 2026,
+ * so a non-trivial slice of users (slightly older Safari and Firefox) is still
+ * without it. Browsers missing either feature get the `FzIconDropdown` fallback
+ * (JS-positioned `FzFloating`) — the menu this component used before.
+ *
+ * Deliberately not memoized: the checks are two cheap lookups, and keeping them
+ * live lets tests toggle support per case. `window.CSS` is guarded because it is
+ * absent in jsdom.
+ */
+export function supportsAnchoredPopover(): boolean {
+  if (typeof HTMLElement === "undefined" || typeof window === "undefined") {
+    return false;
+  }
+  if (!("popover" in HTMLElement.prototype)) return false;
+  return (
+    typeof window.CSS?.supports === "function" &&
+    window.CSS.supports("anchor-name: --fz")
+  );
+}

--- a/packages/card-list/vite.config.ts
+++ b/packages/card-list/vite.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         "@fiscozen/badge",
         "@fiscozen/button",
         "@fiscozen/divider",
-        "@fiscozen/dropdown",
+        "@fiscozen/popover",
         "@fiscozen/container",
       ],
       output: {

--- a/packages/composables/src/composables/useFloating.ts
+++ b/packages/composables/src/composables/useFloating.ts
@@ -1,41 +1,41 @@
 /**
  * @module useFloating
  * @description Composable for managing floating/popover element positioning
- * 
+ *
  * ## Why This Refactoring?
- * 
+ *
  * The previous implementation had several issues:
- * 
+ *
  * 1. **Monolithic function**: All positioning logic was in a single function
  *    making it hard to test individual positioning strategies
- * 
+ *
  * 2. **Inconsistent margin handling**: Margins were calculated differently for
  *    different positions, leading to visual inconsistencies
- * 
+ *
  * 3. **No reactive repositioning**: The floating element didn't respond to
  *    opener/content size changes or scroll events
- * 
+ *
  * 4. **Layout shift on open**: The floating element was added to document flow
  *    before positioning, causing visual jumps
- * 
+ *
  * ## Architecture
- * 
+ *
  * The new implementation uses:
- * 
+ *
  * - **Pure position calculators**: Each position (top, bottom, left, right and
  *   their variants) has a dedicated calculator function stored in lookup tables
- * 
- * - **Lookup tables**: `positionCalculators` (with opener) and 
+ *
+ * - **Lookup tables**: `positionCalculators` (with opener) and
  *   `containerPositionCalculators` (without opener) provide O(1) access
- * 
+ *
  * - **Immediate fixed positioning**: Elements are set to `position: fixed`
  *   immediately to prevent layout shift
- * 
+ *
  * - **Reactive repositioning**: ResizeObserver and scroll/resize event listeners
  *   ensure the floating stays positioned correctly during dynamic changes
- * 
+ *
  * ## Usage
- * 
+ *
  * ```typescript
  * const { float, setPosition, actualPosition } = useFloating({
  *   element: toRef(props, 'element'),
@@ -43,22 +43,22 @@
  *   position: toRef(props, 'position'),
  *   container: toRef(props, 'container')
  * })
- * 
+ *
  * // Position is set automatically, or call manually:
  * await setPosition()
- * 
+ *
  * // Access computed position values:
  * console.log(float.position.x, float.position.y)
  * console.log(actualPosition.value) // Resolved position for 'auto' modes
  * ```
- * 
+ *
  * ## Position Types
- * 
+ *
  * - Explicit: top, bottom, left, right and variants (-start, -end)
  * - Auto: auto, auto-vertical, auto-start, auto-end, etc.
- * 
+ *
  * Auto positions are resolved based on available space around the opener
- * 
+ *
  * @see FzFloating.vue - The component that uses this composable
  */
 
@@ -128,7 +128,7 @@ const isRectPositionable = (rect: DOMRect | null): boolean =>
 
 const positionCalculators: Record<string, PositionCalculator> = {
   // Bottom positions - content below opener
-  'bottom': (opener, margins) => ({
+  bottom: (opener, margins) => ({
     position: {
       x: opener.left - margins.left + opener.width / 2,
       y: opener.bottom
@@ -153,7 +153,7 @@ const positionCalculators: Record<string, PositionCalculator> = {
   }),
 
   // Top positions - content above opener
-  'top': (opener, margins) => ({
+  top: (opener, margins) => ({
     position: {
       x: opener.left - margins.left + opener.width / 2,
       y: opener.top - margins.bottom
@@ -178,7 +178,7 @@ const positionCalculators: Record<string, PositionCalculator> = {
   }),
 
   // Left positions - content to left of opener
-  'left': (opener, margins) => ({
+  left: (opener, margins) => ({
     position: {
       x: opener.left - margins.right,
       y: opener.top - margins.top + opener.height / 2
@@ -203,7 +203,7 @@ const positionCalculators: Record<string, PositionCalculator> = {
   }),
 
   // Right positions - content to right of opener
-  'right': (opener, margins) => ({
+  right: (opener, margins) => ({
     position: {
       x: opener.right + margins.left,
       y: opener.top - margins.top + opener.height / 2
@@ -246,98 +246,98 @@ const calculatePositionWithOpener = (
 type ContainerPositionCalculator = (container: DOMRect, element: DOMRect) => PositionResult
 
 const containerPositionCalculators: Record<string, ContainerPositionCalculator> = {
-  'bottom': (container, element) => ({
-    position: { 
-      x: container.left + container.width / 2, 
-      y: container.bottom - element.height 
+  bottom: (container, element) => ({
+    position: {
+      x: container.left + container.width / 2,
+      y: container.bottom - element.height
     },
     transform: { x: -50, y: 0 }
   }),
 
   'bottom-start': (container, element) => ({
-    position: { 
-      x: container.left, 
-      y: container.bottom - element.height 
+    position: {
+      x: container.left,
+      y: container.bottom - element.height
     },
     transform: { x: 0, y: 0 }
   }),
 
   'bottom-end': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.bottom - element.height 
+    position: {
+      x: container.right - element.width,
+      y: container.bottom - element.height
     },
     transform: { x: 0, y: 0 }
   }),
 
-  'top': (container) => ({
-    position: { 
-      x: container.left + container.width / 2, 
-      y: container.top 
+  top: (container) => ({
+    position: {
+      x: container.left + container.width / 2,
+      y: container.top
     },
     transform: { x: -50, y: 0 }
   }),
 
   'top-start': (container) => ({
-    position: { 
-      x: container.left, 
-      y: container.top 
+    position: {
+      x: container.left,
+      y: container.top
     },
     transform: { x: 0, y: 0 }
   }),
 
   'top-end': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.top 
+    position: {
+      x: container.right - element.width,
+      y: container.top
     },
     transform: { x: 0, y: 0 }
   }),
 
-  'left': (container, element) => ({
-    position: { 
-      x: container.left, 
-      y: container.top + (container.height - element.height) / 2 
+  left: (container, element) => ({
+    position: {
+      x: container.left,
+      y: container.top + (container.height - element.height) / 2
     },
     transform: { x: 0, y: 0 }
   }),
 
   'left-start': (container) => ({
-    position: { 
-      x: container.left, 
-      y: container.top 
+    position: {
+      x: container.left,
+      y: container.top
     },
     transform: { x: 0, y: 0 }
   }),
 
   'left-end': (container, element) => ({
-    position: { 
-      x: container.left, 
-      y: container.bottom - element.height 
+    position: {
+      x: container.left,
+      y: container.bottom - element.height
     },
     transform: { x: 0, y: 0 }
   }),
 
-  'right': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.top + (container.height - element.height) / 2 
+  right: (container, element) => ({
+    position: {
+      x: container.right - element.width,
+      y: container.top + (container.height - element.height) / 2
     },
     transform: { x: 0, y: 0 }
   }),
 
   'right-start': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.top 
+    position: {
+      x: container.right - element.width,
+      y: container.top
     },
     transform: { x: 0, y: 0 }
   }),
 
   'right-end': (container, element) => ({
-    position: { 
-      x: container.right - element.width, 
-      y: container.bottom - element.height 
+    position: {
+      x: container.right - element.width,
+      y: container.bottom - element.height
     },
     transform: { x: 0, y: 0 }
   })
@@ -349,7 +349,7 @@ const calculatePositionWithoutOpener = (
   element: DOMRect
 ): PositionResult => {
   const calculator = containerPositionCalculators[position]
-  return calculator 
+  return calculator
     ? calculator(container, element)
     : { position: { x: 0, y: 0 }, transform: { x: 0, y: 0 } }
 }
@@ -444,7 +444,13 @@ const applyBoundaryCorrections = (
 // Auto Position Resolution - Pure Function
 // ============================================================================
 
-type AutoPositionType = 'auto' | 'auto-vertical' | 'auto-start' | 'auto-vertical-start' | 'auto-end' | 'auto-vertical-end'
+type AutoPositionType =
+  | 'auto'
+  | 'auto-vertical'
+  | 'auto-start'
+  | 'auto-vertical-start'
+  | 'auto-end'
+  | 'auto-vertical-end'
 
 const resolveAutoPosition = (
   autoType: AutoPositionType,
@@ -524,12 +530,10 @@ export const useFloating = (
     }
 
     const container = args.container?.value
-      ? resolveElement(args.container.value.domRef.value) ?? document.body
+      ? (resolveElement(args.container.value.domRef.value) ?? document.body)
       : document.body
 
-    const opener = args.opener?.value
-      ? resolveElement(args.opener.value.domRef.value)
-      : null
+    const opener = args.opener?.value ? resolveElement(args.opener.value.domRef.value) : null
 
     return { element, container, opener }
   }
@@ -588,10 +592,11 @@ export const useFloating = (
 
       // Step 7: Calculate position
       const margins = getMargins(window.getComputedStyle(refs.element))
-      
-      const positionResult = refs.opener && rects.opener
-        ? calculatePositionWithOpener(actualPosition.value!, rects.opener, margins)
-        : calculatePositionWithoutOpener(actualPosition.value!, rects.container, rects.element)
+
+      const positionResult =
+        refs.opener && rects.opener
+          ? calculatePositionWithOpener(actualPosition.value!, rects.opener, margins)
+          : calculatePositionWithoutOpener(actualPosition.value!, rects.container, rects.element)
 
       // Step 8: Apply transform to get real position
       const realPosition = calcRealPos(
@@ -602,10 +607,23 @@ export const useFloating = (
       )
 
       // Step 9: Apply boundary corrections
+      //
+      // The collision boundary is the container ∩ viewport (see getCollisionBounds),
+      // which is right for a real container but wrong for the implicit
+      // `document.body` default: body is not a clipping box for fixed content, and
+      // whenever the page is shorter than the viewport its rect shrinks the usable
+      // area. The clamp then pulls the content up over its own opener — on a 108px
+      // tall page a 48px menu resolves maxTop = 108 - 8 - 48 = 52, above an opener
+      // whose bottom is at 76. Callers that asked for viewport semantics get the
+      // viewport, so the body's height stops deciding where a menu may sit.
+      const collisionContainer = args.useViewport?.value
+        ? new DOMRect(0, 0, window.innerWidth, window.innerHeight)
+        : rects.container
+
       const corrected = applyBoundaryCorrections(
         realPosition,
         rects.element,
-        rects.container,
+        collisionContainer,
         positionResult.transform
       )
 

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -1,0 +1,3 @@
+# @fiscozen/popover
+
+TODO

--- a/packages/popover/eslintrc.cjs
+++ b/packages/popover/eslintrc.cjs
@@ -1,0 +1,18 @@
+/* eslint-env node */
+require('@rushstack/eslint-patch/modern-module-resolution')
+
+module.exports = {
+  root: true,
+  'extends': ['@fiscozen/eslint-config', 'plugin:storybook/recommended'],
+  overrides: [
+    {
+      files: [
+        'cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}',
+        'cypress/support/**/*.{js,ts,jsx,tsx}'
+      ],
+      'extends': [
+        'plugin:cypress/recommended'
+      ]
+    }
+  ]
+}

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@fiscozen/popover",
+  "version": "0.1.0",
+  "description": "Design System Popover component",
+  "scripts": {
+    "coverage": "vitest run --coverage",
+    "format": "prettier --write src/",
+    "test:unit": "vitest run",
+    "build": "vue-tsc && vite build"
+  },
+  "main": "src/index.ts",
+  "type": "module",
+  "keywords": [],
+  "author": "Francesca Vago",
+  "dependencies": {
+    "@fiscozen/composables": "workspace:*"
+  },
+  "peerDependencies": {
+    "tailwindcss": "^3.4.1",
+    "vue": "^3.4.13"
+  },
+  "devDependencies": {
+    "@fiscozen/eslint-config": "workspace:^",
+    "@fiscozen/prettier-config": "workspace:^",
+    "@fiscozen/tsconfig": "workspace:^",
+    "@rushstack/eslint-patch": "^1.3.3",
+    "@types/jsdom": "^21.1.6",
+    "@types/node": "^18.19.3",
+    "@vitejs/plugin-vue": "^6.0.5",
+    "@vitest/coverage-v8": "^4.1.1",
+    "@vue/test-utils": "^2.4.3",
+    "@vue/tsconfig": "^0.5.0",
+    "eslint": "^8.49.0",
+    "jsdom": "^23.0.1",
+    "prettier": "^3.0.3",
+    "typescript": "~5.7.0",
+    "vite": "^8.0.0",
+    "vite-plugin-dts": "^4.5.0",
+    "vitest": "^4.1.1",
+    "vue-tsc": "^2.2.12"
+  },
+  "license": "MIT"
+}

--- a/packages/popover/prettierrc.js
+++ b/packages/popover/prettierrc.js
@@ -1,0 +1,5 @@
+import fiscozenPrettierConfig from '@fiscozen/prettier-config';
+
+export default {
+    ...fiscozenPrettierConfig
+};

--- a/packages/popover/src/FzPopover.vue
+++ b/packages/popover/src/FzPopover.vue
@@ -17,7 +17,14 @@
  * The fallback is meant to die: when CSS anchor positioning is everywhere, this
  * component drops the second engine and `FzFloating` goes with it.
  */
-import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+} from "vue";
 import { FzFloating, useClickOutside, useKeyDown } from "@fiscozen/composables";
 import type { FzPopoverEmits, FzPopoverProps, FzPopoverSlots } from "./types";
 import {
@@ -106,8 +113,7 @@ onBeforeUnmount(() => {
   namedAnchor = null;
 });
 
-watch(isOpen, async (value) => {
-  emit("fzpopover:toggle", value);
+async function syncEngineWithModel(value: boolean) {
   if (!cssEngine) {
     // The JS engine only needs the width sync; FzFloating reacts to isOpen itself.
     if (value && props.matchOpenerWidth) await syncFallbackWidth();
@@ -124,6 +130,20 @@ watch(isOpen, async (value) => {
   // Popover API before v24.
   if (value && !nativeShown) element.showPopover?.();
   if (!value && nativeShown) element.hidePopover?.();
+}
+
+watch(isOpen, (value) => {
+  emit("fzpopover:toggle", value);
+  syncEngineWithModel(value);
+});
+
+/**
+ * An `open` that is already true at mount needs the same push: the watcher only
+ * fires on change, so a popover that starts open — a docs example, a visual
+ * snapshot, a menu restored from state — would otherwise render closed.
+ */
+onMounted(() => {
+  if (isOpen.value) syncEngineWithModel(true);
 });
 
 /**
@@ -131,7 +151,7 @@ watch(isOpen, async (value) => {
  * without going through us, so this — and the model — are synced from the platform's
  * own toggle event.
  */
-let nativeShown = false
+let nativeShown = false;
 function onNativeToggle(event: Event) {
   const next = (event as ToggleEvent).newState === "open";
   nativeShown = next;

--- a/packages/popover/src/FzPopover.vue
+++ b/packages/popover/src/FzPopover.vue
@@ -1,0 +1,235 @@
+<script setup lang="ts">
+/**
+ * FzPopover — floating content that prefers the platform.
+ *
+ * Two engines behind one API:
+ *
+ * - **CSS engine** (default where the browser allows): a native `[popover]`, so
+ *   the box lives in the top layer — never clipped by an ancestor's overflow, no
+ *   z-index to arbitrate — and its placement is CSS (`position-anchor` +
+ *   `position-area`), so the browser keeps it glued to its anchor on scroll and
+ *   resize without a line of JS. Light dismiss and Esc come from the platform.
+ * - **JS engine** (fallback): `FzFloating`, the measured-rect implementation the
+ *   design system already ships, plus `useClickOutside` / `useKeyDown` for
+ *   dismissal. Taken when the browser lacks CSS anchor positioning, when the
+ *   placement is an `auto` one (see isAutoPosition), or on `forceFallback`.
+ *
+ * The fallback is meant to die: when CSS anchor positioning is everywhere, this
+ * component drops the second engine and `FzFloating` goes with it.
+ */
+import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { FzFloating, useClickOutside, useKeyDown } from "@fiscozen/composables";
+import type { FzPopoverEmits, FzPopoverProps, FzPopoverSlots } from "./types";
+import {
+  anchoredContentStyle,
+  isAutoPosition,
+  supportsCssAnchoring,
+  useUniqueId,
+} from "./utils";
+
+const props = withDefaults(defineProps<FzPopoverProps>(), {
+  position: "bottom-start",
+  offset: 4,
+  matchOpenerWidth: false,
+  anchor: null,
+  forceFallback: false,
+});
+
+const emit = defineEmits<FzPopoverEmits>();
+defineSlots<FzPopoverSlots>();
+
+const isOpen = defineModel<boolean>("open", { default: false });
+
+/**
+ * Which engine runs. Read once per instance: browser capabilities don't change at
+ * runtime, and `position` changing between an auto and a fixed placement would be
+ * an odd thing for a caller to do mid-life — if it happens, the engine stays put
+ * rather than tearing the popover down and rebuilding it.
+ */
+const cssEngine =
+  !props.forceFallback &&
+  !isAutoPosition(props.position) &&
+  supportsCssAnchoring();
+
+/** Dashed ident for `anchor-name`; unique per document, not per app. */
+const anchorName = `--${useUniqueId("fz-popover")}`;
+const contentId = useUniqueId("fz-popover-content");
+
+const root = ref<HTMLElement>();
+const openerWrapper = ref<HTMLElement>();
+const content = ref<HTMLElement>();
+
+const anchorElement = computed(
+  () => props.anchor ?? openerWrapper.value ?? null,
+);
+
+const contentStyle = computed(() =>
+  anchoredContentStyle(
+    props.position,
+    props.offset,
+    anchorName,
+    props.matchOpenerWidth,
+  ),
+);
+
+function open() {
+  isOpen.value = true;
+}
+function close() {
+  isOpen.value = false;
+}
+function toggle() {
+  isOpen.value = !isOpen.value;
+}
+
+/**
+ * `anchor-name` has to sit on the anchor itself, which may be an element we were
+ * handed (`anchor` prop) rather than one we render — hence the imperative set,
+ * and the cleanup when it changes so we don't leave a stale name behind.
+ */
+let namedAnchor: HTMLElement | null = null;
+function applyAnchorName() {
+  if (!cssEngine) return;
+  if (namedAnchor && namedAnchor !== anchorElement.value) {
+    namedAnchor.style.removeProperty("anchor-name");
+  }
+  const element = anchorElement.value;
+  if (!element) return;
+  element.style.setProperty("anchor-name", anchorName);
+  namedAnchor = element;
+}
+
+watch(anchorElement, applyAnchorName, { immediate: true, flush: "post" });
+
+onBeforeUnmount(() => {
+  namedAnchor?.style.removeProperty("anchor-name");
+  namedAnchor = null;
+});
+
+watch(isOpen, async (value) => {
+  emit("fzpopover:toggle", value);
+  if (!cssEngine) {
+    // The JS engine only needs the width sync; FzFloating reacts to isOpen itself.
+    if (value && props.matchOpenerWidth) await syncFallbackWidth();
+    return;
+  }
+  await nextTick();
+  const element = content.value;
+  if (!element?.isConnected) return;
+  // Guarded against the current state because showPopover/hidePopover throw when
+  // called against it. The flag is tracked rather than read back with
+  // `matches(':popover-open')`: that pseudo-class is unknown to jsdom, where the
+  // selector throws. `onNativeToggle` keeps the flag honest, since it fires however
+  // the popover opened or closed. The optional calls cover jsdom too, which has no
+  // Popover API before v24.
+  if (value && !nativeShown) element.showPopover?.();
+  if (!value && nativeShown) element.hidePopover?.();
+});
+
+/**
+ * Whether the native popover is currently showing. Esc and light dismiss close it
+ * without going through us, so this — and the model — are synced from the platform's
+ * own toggle event.
+ */
+let nativeShown = false
+function onNativeToggle(event: Event) {
+  const next = (event as ToggleEvent).newState === "open";
+  nativeShown = next;
+  if (isOpen.value !== next) isOpen.value = next;
+}
+
+/**
+ * `matchOpenerWidth` is `anchor-size()` in the CSS engine. FzFloating only matches
+ * the opener's width below the xs breakpoint, so in the fallback we set it
+ * ourselves on its content box — reached by class because FzFloating exposes only
+ * `setPosition`.
+ */
+async function syncFallbackWidth() {
+  await nextTick();
+  const box = root.value?.querySelector<HTMLElement>(".fz__floating__content");
+  // FzFloating's own opener box — we don't wrap the slot in this engine.
+  const width = root.value
+    ?.querySelector<HTMLElement>(".inline-flex")
+    ?.getBoundingClientRect().width;
+  if (box && width) box.style.minWidth = `${width}px`;
+}
+
+// Dismissal for the JS engine. Both composables attach on mount and would throw on
+// an empty ref, so they always get the real root and no-op when CSS is driving.
+useClickOutside(root, () => {
+  if (!cssEngine && isOpen.value) close();
+});
+useKeyDown(root, (event) => {
+  if (!cssEngine && event.key === "Escape" && isOpen.value) close();
+});
+
+defineExpose({ open, close, toggle });
+</script>
+
+<template>
+  <div ref="root" class="fz-popover">
+    <template v-if="cssEngine">
+      <span ref="openerWrapper" class="fz-popover__opener inline-flex">
+        <slot
+          name="opener"
+          :is-open="isOpen"
+          :toggle="toggle"
+          :open="open"
+          :close="close"
+        />
+      </span>
+      <div
+        ref="content"
+        :id="contentId"
+        popover
+        class="fz-popover__content"
+        :class="contentClass"
+        :style="contentStyle"
+        @toggle="onNativeToggle"
+      >
+        <slot :is-open="isOpen" :close="close" />
+      </div>
+    </template>
+
+    <!--
+      `use-viewport` makes FzFloating resolve auto placements against the viewport
+      rather than the container. The collision boundary is already the viewport when
+      the container is `document.body` — LIB-2825 fixed that upstream.
+    -->
+    <FzFloating
+      v-else
+      :is-open="isOpen"
+      :position="position"
+      :content-class="contentClass"
+      :use-viewport="true"
+    >
+      <!--
+        The slot goes straight through: FzFloating already wraps it in the box it
+        measures, so a wrapper of ours would only add a layer. The width sync below
+        reads that same box.
+      -->
+      <template #opener>
+        <slot
+          name="opener"
+          :is-open="isOpen"
+          :toggle="toggle"
+          :open="open"
+          :close="close"
+        />
+      </template>
+      <slot :is-open="isOpen" :close="close" />
+    </FzFloating>
+  </div>
+</template>
+
+<style scoped>
+.fz-popover__content {
+  /* Reset the UA popover box (`inset: 0; margin: auto`, a border): placement comes
+     from the inline style, chrome from the caller. */
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  overflow: visible;
+}
+</style>

--- a/packages/popover/src/FzPopover.vue
+++ b/packages/popover/src/FzPopover.vue
@@ -1,0 +1,236 @@
+<script setup lang="ts">
+/**
+ * FzPopover — floating content that prefers the platform.
+ *
+ * Two engines behind one API:
+ *
+ * - **CSS engine** (default where the browser allows): a native `[popover]`, so
+ *   the box lives in the top layer — never clipped by an ancestor's overflow, no
+ *   z-index to arbitrate — and its placement is CSS (`position-anchor` +
+ *   `position-area`), so the browser keeps it glued to its anchor on scroll and
+ *   resize without a line of JS. Light dismiss and Esc come from the platform.
+ * - **JS engine** (fallback): `FzFloating`, the measured-rect implementation the
+ *   design system already ships, plus `useClickOutside` / `useKeyDown` for
+ *   dismissal. Taken when the browser lacks CSS anchor positioning, when the
+ *   placement is an `auto` one (see isAutoPosition), or on `forceFallback`.
+ *
+ * The fallback is meant to die: when CSS anchor positioning is everywhere, this
+ * component drops the second engine and `FzFloating` goes with it.
+ */
+import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { FzFloating, useClickOutside, useKeyDown } from "@fiscozen/composables";
+import type { FzPopoverEmits, FzPopoverProps, FzPopoverSlots } from "./types";
+import {
+  anchoredContentStyle,
+  isAutoPosition,
+  supportsCssAnchoring,
+  useUniqueId,
+} from "./utils";
+
+const props = withDefaults(defineProps<FzPopoverProps>(), {
+  position: "bottom-start",
+  offset: 4,
+  matchOpenerWidth: false,
+  anchor: null,
+  forceFallback: false,
+});
+
+const emit = defineEmits<FzPopoverEmits>();
+defineSlots<FzPopoverSlots>();
+
+const isOpen = defineModel<boolean>("open", { default: false });
+
+/**
+ * Which engine runs. Read once per instance: browser capabilities don't change at
+ * runtime, and `position` changing between an auto and a fixed placement would be
+ * an odd thing for a caller to do mid-life — if it happens, the engine stays put
+ * rather than tearing the popover down and rebuilding it.
+ */
+const cssEngine =
+  !props.forceFallback &&
+  !isAutoPosition(props.position) &&
+  supportsCssAnchoring();
+
+/** Dashed ident for `anchor-name`; unique per document, not per app. */
+const anchorName = `--${useUniqueId("fz-popover")}`;
+const contentId = useUniqueId("fz-popover-content");
+
+const root = ref<HTMLElement>();
+const openerWrapper = ref<HTMLElement>();
+const content = ref<HTMLElement>();
+
+const anchorElement = computed(
+  () => props.anchor ?? openerWrapper.value ?? null,
+);
+
+const contentStyle = computed(() =>
+  anchoredContentStyle(
+    props.position,
+    props.offset,
+    anchorName,
+    props.matchOpenerWidth,
+  ),
+);
+
+function open() {
+  isOpen.value = true;
+}
+function close() {
+  isOpen.value = false;
+}
+function toggle() {
+  isOpen.value = !isOpen.value;
+}
+
+/**
+ * `anchor-name` has to sit on the anchor itself, which may be an element we were
+ * handed (`anchor` prop) rather than one we render — hence the imperative set,
+ * and the cleanup when it changes so we don't leave a stale name behind.
+ */
+let namedAnchor: HTMLElement | null = null;
+function applyAnchorName() {
+  if (!cssEngine) return;
+  if (namedAnchor && namedAnchor !== anchorElement.value) {
+    namedAnchor.style.removeProperty("anchor-name");
+  }
+  const element = anchorElement.value;
+  if (!element) return;
+  element.style.setProperty("anchor-name", anchorName);
+  namedAnchor = element;
+}
+
+watch(anchorElement, applyAnchorName, { immediate: true, flush: "post" });
+
+onBeforeUnmount(() => {
+  namedAnchor?.style.removeProperty("anchor-name");
+  namedAnchor = null;
+});
+
+watch(isOpen, async (value) => {
+  emit("fzpopover:toggle", value);
+  if (!cssEngine) {
+    // The JS engine only needs the width sync; FzFloating reacts to isOpen itself.
+    if (value && props.matchOpenerWidth) await syncFallbackWidth();
+    return;
+  }
+  await nextTick();
+  const element = content.value;
+  if (!element?.isConnected) return;
+  // Guarded against the current state because showPopover/hidePopover throw when
+  // called against it. The flag is tracked rather than read back with
+  // `matches(':popover-open')`: that pseudo-class is unknown to jsdom, where the
+  // selector throws. `onNativeToggle` keeps the flag honest, since it fires however
+  // the popover opened or closed. The optional calls cover jsdom too, which has no
+  // Popover API before v24.
+  if (value && !nativeShown) element.showPopover?.();
+  if (!value && nativeShown) element.hidePopover?.();
+});
+
+/**
+ * Whether the native popover is currently showing. Esc and light dismiss close it
+ * without going through us, so this — and the model — are synced from the platform's
+ * own toggle event.
+ */
+let nativeShown = false
+function onNativeToggle(event: Event) {
+  const next = (event as ToggleEvent).newState === "open";
+  nativeShown = next;
+  if (isOpen.value !== next) isOpen.value = next;
+}
+
+/**
+ * `matchOpenerWidth` is `anchor-size()` in the CSS engine. FzFloating only matches
+ * the opener's width below the xs breakpoint, so in the fallback we set it
+ * ourselves on its content box — reached by class because FzFloating exposes only
+ * `setPosition`.
+ */
+async function syncFallbackWidth() {
+  await nextTick();
+  const box = root.value?.querySelector<HTMLElement>(".fz__floating__content");
+  // FzFloating's own opener box — we don't wrap the slot in this engine.
+  const width = root.value
+    ?.querySelector<HTMLElement>(".inline-flex")
+    ?.getBoundingClientRect().width;
+  if (box && width) box.style.minWidth = `${width}px`;
+}
+
+// Dismissal for the JS engine. Both composables attach on mount and would throw on
+// an empty ref, so they always get the real root and no-op when CSS is driving.
+useClickOutside(root, () => {
+  if (!cssEngine && isOpen.value) close();
+});
+useKeyDown(root, (event) => {
+  if (!cssEngine && event.key === "Escape" && isOpen.value) close();
+});
+
+defineExpose({ open, close, toggle });
+</script>
+
+<template>
+  <div ref="root" class="fz-popover">
+    <template v-if="cssEngine">
+      <span ref="openerWrapper" class="fz-popover__opener inline-flex">
+        <slot
+          name="opener"
+          :is-open="isOpen"
+          :toggle="toggle"
+          :open="open"
+          :close="close"
+        />
+      </span>
+      <div
+        ref="content"
+        :id="contentId"
+        popover
+        class="fz-popover__content"
+        :class="contentClass"
+        :style="contentStyle"
+        @toggle="onNativeToggle"
+      >
+        <slot :is-open="isOpen" :close="close" />
+      </div>
+    </template>
+
+    <!--
+      `use-viewport` asks FzFloating to clamp against the viewport rather than
+      `document.body`: the body's height is not a boundary for fixed content, and on
+      a page shorter than the viewport the clamp would drag the content over its own
+      opener.
+    -->
+    <FzFloating
+      v-else
+      :is-open="isOpen"
+      :position="position"
+      :content-class="contentClass"
+      :use-viewport="true"
+    >
+      <!--
+        The slot goes straight through: FzFloating already wraps it in the box it
+        measures, so a wrapper of ours would only add a layer. The width sync below
+        reads that same box.
+      -->
+      <template #opener>
+        <slot
+          name="opener"
+          :is-open="isOpen"
+          :toggle="toggle"
+          :open="open"
+          :close="close"
+        />
+      </template>
+      <slot :is-open="isOpen" :close="close" />
+    </FzFloating>
+  </div>
+</template>
+
+<style scoped>
+.fz-popover__content {
+  /* Reset the UA popover box (`inset: 0; margin: auto`, a border): placement comes
+     from the inline style, chrome from the caller. */
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  overflow: visible;
+}
+</style>

--- a/packages/popover/src/__tests__/FzPopover.spec.ts
+++ b/packages/popover/src/__tests__/FzPopover.spec.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import { FzPopover } from '..'
+import { anchoredContentStyle, isAutoPosition, supportsCssAnchoring } from '../utils'
+
+/**
+ * jsdom has neither the Popover API nor `window.CSS`, so FzPopover feature-detects
+ * its way to the JS engine here — which makes the fallback the default subject of
+ * these tests. The CSS engine is exercised by faking the two capabilities; its real
+ * behaviour (placement, light dismiss, Esc) can only be checked in a browser, and
+ * lives in the Storybook play functions plus a Playwright probe.
+ */
+function enableCssAnchoring() {
+  Object.defineProperty(HTMLElement.prototype, 'popover', {
+    value: null,
+    writable: true,
+    configurable: true
+  })
+  HTMLElement.prototype.showPopover = vi.fn()
+  HTMLElement.prototype.hidePopover = vi.fn()
+  vi.stubGlobal('CSS', { supports: () => true })
+}
+
+function restoreCssAnchoring() {
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>
+  delete proto.popover
+  delete proto.showPopover
+  delete proto.hidePopover
+  vi.unstubAllGlobals()
+}
+
+const slots = {
+  opener: '<button>Apri</button>',
+  default: '<div>Contenuto</div>'
+}
+
+beforeEach(() => {
+  // FzFloating needs both, and jsdom provides neither.
+  global.IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof IntersectionObserver
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  })
+})
+
+describe('supportsCssAnchoring', () => {
+  afterEach(restoreCssAnchoring)
+
+  it('should be false in an environment without the Popover API', () => {
+    expect(supportsCssAnchoring()).toBe(false)
+  })
+
+  it('should be false when the browser knows the Popover API but not anchor positioning', () => {
+    enableCssAnchoring()
+    vi.stubGlobal('CSS', { supports: (value: string) => !value.startsWith('anchor-name') })
+    expect(supportsCssAnchoring()).toBe(false)
+  })
+
+  it('should be false when position-area is unsupported', () => {
+    enableCssAnchoring()
+    vi.stubGlobal('CSS', { supports: (value: string) => !value.startsWith('position-area') })
+    expect(supportsCssAnchoring()).toBe(false)
+  })
+
+  it('should be true when all three features are present', () => {
+    enableCssAnchoring()
+    expect(supportsCssAnchoring()).toBe(true)
+  })
+})
+
+describe('isAutoPosition', () => {
+  it.each(['auto', 'auto-vertical', 'auto-start', 'auto-vertical-end'] as const)(
+    'should treat %s as auto',
+    (position) => {
+      expect(isAutoPosition(position)).toBe(true)
+    }
+  )
+
+  it.each(['bottom', 'bottom-start', 'top-end', 'left', 'right-start'] as const)(
+    'should treat %s as a fixed placement',
+    (position) => {
+      expect(isAutoPosition(position)).toBe(false)
+    }
+  )
+})
+
+describe('anchoredContentStyle', () => {
+  it('should map each placement to its position-area', () => {
+    const area = (position: Parameters<typeof anchoredContentStyle>[0]) =>
+      anchoredContentStyle(position, 4, '--a', false).positionArea
+
+    expect(area('bottom-start')).toBe('block-end span-inline-end')
+    expect(area('bottom-end')).toBe('block-end span-inline-start')
+    expect(area('bottom')).toBe('block-end center')
+    expect(area('top-start')).toBe('block-start span-inline-end')
+    expect(area('left')).toBe('inline-start center')
+    expect(area('right-end')).toBe('inline-end span-block-start')
+  })
+
+  it('should put the offset on the side that faces the anchor', () => {
+    expect(anchoredContentStyle('bottom-start', 8, '--a', false).marginTop).toBe('8px')
+    expect(anchoredContentStyle('top-start', 8, '--a', false).marginBottom).toBe('8px')
+    expect(anchoredContentStyle('left', 8, '--a', false).marginRight).toBe('8px')
+    expect(anchoredContentStyle('right', 8, '--a', false).marginLeft).toBe('8px')
+  })
+
+  it('should flip along the axis the placement uses', () => {
+    expect(anchoredContentStyle('bottom-start', 4, '--a', false).positionTryFallbacks).toBe(
+      'flip-block'
+    )
+    expect(anchoredContentStyle('right', 4, '--a', false).positionTryFallbacks).toBe('flip-inline')
+  })
+
+  it('should ask for the anchor width only when matchOpenerWidth is set', () => {
+    expect(anchoredContentStyle('bottom-start', 4, '--a', false).minWidth).toBeUndefined()
+    expect(anchoredContentStyle('bottom-start', 4, '--a', true).minWidth).toBe(
+      'anchor-size(--a width)'
+    )
+  })
+
+  it('should never cap the height: a box that cannot overflow never flips', () => {
+    const style = anchoredContentStyle('bottom-start', 4, '--a', false)
+    expect(style.maxHeight).toBeUndefined()
+  })
+})
+
+describe('FzPopover — JS engine (jsdom default)', () => {
+  it('should render FzFloating, not a native popover', () => {
+    const wrapper = mount(FzPopover, { slots })
+    expect(wrapper.findComponent({ name: 'FzFloating' }).exists()).toBe(true)
+    expect(wrapper.find('.fz-popover__content').exists()).toBe(false)
+  })
+
+  it('should clamp against the viewport rather than the body', () => {
+    // Regression lock: FzFloating's default boundary is document.body ∩ viewport,
+    // and on a page shorter than the viewport that drags the content over its own
+    // opener. The popover always asks for viewport semantics.
+    const wrapper = mount(FzPopover, { slots })
+    expect(wrapper.findComponent({ name: 'FzFloating' }).props('useViewport')).toBe(true)
+  })
+
+  it('should open and close through the slot props', async () => {
+    // A string slot gets no slot props, so the opener is a render function: this is
+    // also the shape a consumer writes, since the popover attaches no handler itself.
+    const wrapper = mount(FzPopover, {
+      slots: {
+        opener: (params: { toggle: () => void }) =>
+          h('button', { onClick: params.toggle }, 'Apri'),
+        default: '<div>Contenuto</div>'
+      }
+    })
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.emitted('fzpopover:toggle')![0]).toEqual([true])
+    expect(wrapper.emitted('update:open')![0]).toEqual([true])
+
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.emitted('fzpopover:toggle')![1]).toEqual([false])
+  })
+
+  it('should honour v-model:open from the outside', async () => {
+    const wrapper = mount(FzPopover, { slots, props: { open: false } })
+    await wrapper.setProps({ open: true })
+    expect(wrapper.emitted('fzpopover:toggle')![0]).toEqual([true])
+  })
+
+  it('should take the JS engine for auto placements', () => {
+    const wrapper = mount(FzPopover, { slots, props: { position: 'auto-vertical-start' } })
+    expect(wrapper.findComponent({ name: 'FzFloating' }).exists()).toBe(true)
+  })
+})
+
+describe('FzPopover — CSS engine', () => {
+  beforeEach(enableCssAnchoring)
+  afterEach(restoreCssAnchoring)
+
+  it('should render a native popover instead of FzFloating', () => {
+    const wrapper = mount(FzPopover, { slots })
+    expect(wrapper.find('.fz-popover__content').exists()).toBe(true)
+    expect(wrapper.findComponent({ name: 'FzFloating' }).exists()).toBe(false)
+  })
+
+  it('should anchor the content to the opener', async () => {
+    const wrapper = mount(FzPopover, { slots })
+    // The name is written after the flush, once the opener ref is populated.
+    await wrapper.vm.$nextTick()
+    const anchorName = wrapper.get('.fz-popover__opener').element.style.getPropertyValue(
+      'anchor-name'
+    )
+    expect(anchorName).toMatch(/^--fz-popover-\d+$/)
+    expect(wrapper.get('.fz-popover__content').attributes('style')).toContain(
+      `position-anchor: ${anchorName}`
+    )
+  })
+
+  it('should give each instance its own anchor name and id', async () => {
+    // Every mount() is its own Vue app: an app-scoped id (useId()) would repeat, and
+    // two popovers would anchor to the same opener.
+    const first = mount(FzPopover, { slots })
+    const second = mount(FzPopover, { slots })
+    await Promise.all([first.vm.$nextTick(), second.vm.$nextTick()])
+
+    const anchorOf = (w: typeof first) =>
+      w.get('.fz-popover__opener').element.style.getPropertyValue('anchor-name')
+    const idOf = (w: typeof first) => w.get('.fz-popover__content').attributes('id')
+
+    expect(anchorOf(first)).not.toBe(anchorOf(second))
+    expect(idOf(first)).not.toBe(idOf(second))
+  })
+
+  it('should drive the native popover when the model changes', async () => {
+    // Attached on purpose: showPopover() throws on a disconnected element, so the
+    // component skips it — and Vue Test Utils mounts detached by default.
+    const wrapper = mount(FzPopover, {
+      slots,
+      props: { open: false },
+      attachTo: document.body
+    })
+    await wrapper.setProps({ open: true })
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.get('.fz-popover__content').element.showPopover).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('should fall back to FzFloating on forceFallback', () => {
+    const wrapper = mount(FzPopover, { slots, props: { forceFallback: true } })
+    expect(wrapper.findComponent({ name: 'FzFloating' }).exists()).toBe(true)
+  })
+})

--- a/packages/popover/src/__tests__/FzPopover.spec.ts
+++ b/packages/popover/src/__tests__/FzPopover.spec.ts
@@ -1,8 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mount } from '@vue/test-utils'
-import { h } from 'vue'
-import { FzPopover } from '..'
-import { anchoredContentStyle, isAutoPosition, supportsCssAnchoring } from '../utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { h } from "vue";
+import { FzPopover } from "..";
+import {
+  anchoredContentStyle,
+  isAutoPosition,
+  supportsCssAnchoring,
+} from "../utils";
 
 /**
  * jsdom has neither the Popover API nor `window.CSS`, so FzPopover feature-detects
@@ -12,28 +16,28 @@ import { anchoredContentStyle, isAutoPosition, supportsCssAnchoring } from '../u
  * lives in the Storybook play functions plus a Playwright probe.
  */
 function enableCssAnchoring() {
-  Object.defineProperty(HTMLElement.prototype, 'popover', {
+  Object.defineProperty(HTMLElement.prototype, "popover", {
     value: null,
     writable: true,
-    configurable: true
-  })
-  HTMLElement.prototype.showPopover = vi.fn()
-  HTMLElement.prototype.hidePopover = vi.fn()
-  vi.stubGlobal('CSS', { supports: () => true })
+    configurable: true,
+  });
+  HTMLElement.prototype.showPopover = vi.fn();
+  HTMLElement.prototype.hidePopover = vi.fn();
+  vi.stubGlobal("CSS", { supports: () => true });
 }
 
 function restoreCssAnchoring() {
-  const proto = HTMLElement.prototype as unknown as Record<string, unknown>
-  delete proto.popover
-  delete proto.showPopover
-  delete proto.hidePopover
-  vi.unstubAllGlobals()
+  const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+  delete proto.popover;
+  delete proto.showPopover;
+  delete proto.hidePopover;
+  vi.unstubAllGlobals();
 }
 
 const slots = {
-  opener: '<button>Apri</button>',
-  default: '<div>Contenuto</div>'
-}
+  opener: "<button>Apri</button>",
+  default: "<div>Contenuto</div>",
+};
 
 beforeEach(() => {
   // FzFloating needs both, and jsdom provides neither.
@@ -41,8 +45,8 @@ beforeEach(() => {
     observe() {}
     unobserve() {}
     disconnect() {}
-  } as unknown as typeof IntersectionObserver
-  Object.defineProperty(window, 'matchMedia', {
+  } as unknown as typeof IntersectionObserver;
+  Object.defineProperty(window, "matchMedia", {
     writable: true,
     configurable: true,
     value: vi.fn().mockImplementation((query) => ({
@@ -52,192 +56,241 @@ beforeEach(() => {
       removeEventListener: vi.fn(),
       addListener: vi.fn(),
       removeListener: vi.fn(),
-      dispatchEvent: vi.fn()
-    }))
-  })
-})
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
-describe('supportsCssAnchoring', () => {
-  afterEach(restoreCssAnchoring)
+describe("supportsCssAnchoring", () => {
+  afterEach(restoreCssAnchoring);
 
-  it('should be false in an environment without the Popover API', () => {
-    expect(supportsCssAnchoring()).toBe(false)
-  })
+  it("should be false in an environment without the Popover API", () => {
+    expect(supportsCssAnchoring()).toBe(false);
+  });
 
-  it('should be false when the browser knows the Popover API but not anchor positioning', () => {
-    enableCssAnchoring()
-    vi.stubGlobal('CSS', { supports: (value: string) => !value.startsWith('anchor-name') })
-    expect(supportsCssAnchoring()).toBe(false)
-  })
+  it("should be false when the browser knows the Popover API but not anchor positioning", () => {
+    enableCssAnchoring();
+    vi.stubGlobal("CSS", {
+      supports: (value: string) => !value.startsWith("anchor-name"),
+    });
+    expect(supportsCssAnchoring()).toBe(false);
+  });
 
-  it('should be false when position-area is unsupported', () => {
-    enableCssAnchoring()
-    vi.stubGlobal('CSS', { supports: (value: string) => !value.startsWith('position-area') })
-    expect(supportsCssAnchoring()).toBe(false)
-  })
+  it("should be false when position-area is unsupported", () => {
+    enableCssAnchoring();
+    vi.stubGlobal("CSS", {
+      supports: (value: string) => !value.startsWith("position-area"),
+    });
+    expect(supportsCssAnchoring()).toBe(false);
+  });
 
-  it('should be true when all three features are present', () => {
-    enableCssAnchoring()
-    expect(supportsCssAnchoring()).toBe(true)
-  })
-})
+  it("should be true when all three features are present", () => {
+    enableCssAnchoring();
+    expect(supportsCssAnchoring()).toBe(true);
+  });
+});
 
-describe('isAutoPosition', () => {
-  it.each(['auto', 'auto-vertical', 'auto-start', 'auto-vertical-end'] as const)(
-    'should treat %s as auto',
-    (position) => {
-      expect(isAutoPosition(position)).toBe(true)
-    }
-  )
+describe("isAutoPosition", () => {
+  it.each([
+    "auto",
+    "auto-vertical",
+    "auto-start",
+    "auto-vertical-end",
+  ] as const)("should treat %s as auto", (position) => {
+    expect(isAutoPosition(position)).toBe(true);
+  });
 
-  it.each(['bottom', 'bottom-start', 'top-end', 'left', 'right-start'] as const)(
-    'should treat %s as a fixed placement',
-    (position) => {
-      expect(isAutoPosition(position)).toBe(false)
-    }
-  )
-})
+  it.each([
+    "bottom",
+    "bottom-start",
+    "top-end",
+    "left",
+    "right-start",
+  ] as const)("should treat %s as a fixed placement", (position) => {
+    expect(isAutoPosition(position)).toBe(false);
+  });
+});
 
-describe('anchoredContentStyle', () => {
-  it('should map each placement to its position-area', () => {
+describe("anchoredContentStyle", () => {
+  it("should map each placement to its position-area", () => {
     const area = (position: Parameters<typeof anchoredContentStyle>[0]) =>
-      anchoredContentStyle(position, 4, '--a', false).positionArea
+      anchoredContentStyle(position, 4, "--a", false).positionArea;
 
-    expect(area('bottom-start')).toBe('block-end span-inline-end')
-    expect(area('bottom-end')).toBe('block-end span-inline-start')
-    expect(area('bottom')).toBe('block-end center')
-    expect(area('top-start')).toBe('block-start span-inline-end')
-    expect(area('left')).toBe('inline-start center')
-    expect(area('right-end')).toBe('inline-end span-block-start')
-  })
+    expect(area("bottom-start")).toBe("block-end span-inline-end");
+    expect(area("bottom-end")).toBe("block-end span-inline-start");
+    expect(area("bottom")).toBe("block-end center");
+    expect(area("top-start")).toBe("block-start span-inline-end");
+    expect(area("left")).toBe("inline-start center");
+    expect(area("right-end")).toBe("inline-end span-block-start");
+  });
 
-  it('should put the offset on the side that faces the anchor', () => {
-    expect(anchoredContentStyle('bottom-start', 8, '--a', false).marginTop).toBe('8px')
-    expect(anchoredContentStyle('top-start', 8, '--a', false).marginBottom).toBe('8px')
-    expect(anchoredContentStyle('left', 8, '--a', false).marginRight).toBe('8px')
-    expect(anchoredContentStyle('right', 8, '--a', false).marginLeft).toBe('8px')
-  })
+  it("should put the offset on the side that faces the anchor", () => {
+    expect(
+      anchoredContentStyle("bottom-start", 8, "--a", false).marginTop,
+    ).toBe("8px");
+    expect(
+      anchoredContentStyle("top-start", 8, "--a", false).marginBottom,
+    ).toBe("8px");
+    expect(anchoredContentStyle("left", 8, "--a", false).marginRight).toBe(
+      "8px",
+    );
+    expect(anchoredContentStyle("right", 8, "--a", false).marginLeft).toBe(
+      "8px",
+    );
+  });
 
-  it('should flip along the axis the placement uses', () => {
-    expect(anchoredContentStyle('bottom-start', 4, '--a', false).positionTryFallbacks).toBe(
-      'flip-block'
-    )
-    expect(anchoredContentStyle('right', 4, '--a', false).positionTryFallbacks).toBe('flip-inline')
-  })
+  it("should flip along the axis the placement uses", () => {
+    expect(
+      anchoredContentStyle("bottom-start", 4, "--a", false)
+        .positionTryFallbacks,
+    ).toBe("flip-block");
+    expect(
+      anchoredContentStyle("right", 4, "--a", false).positionTryFallbacks,
+    ).toBe("flip-inline");
+  });
 
-  it('should ask for the anchor width only when matchOpenerWidth is set', () => {
-    expect(anchoredContentStyle('bottom-start', 4, '--a', false).minWidth).toBeUndefined()
-    expect(anchoredContentStyle('bottom-start', 4, '--a', true).minWidth).toBe(
-      'anchor-size(--a width)'
-    )
-  })
+  it("should ask for the anchor width only when matchOpenerWidth is set", () => {
+    expect(
+      anchoredContentStyle("bottom-start", 4, "--a", false).minWidth,
+    ).toBeUndefined();
+    expect(anchoredContentStyle("bottom-start", 4, "--a", true).minWidth).toBe(
+      "anchor-size(--a width)",
+    );
+  });
 
-  it('should never cap the height: a box that cannot overflow never flips', () => {
-    const style = anchoredContentStyle('bottom-start', 4, '--a', false)
-    expect(style.maxHeight).toBeUndefined()
-  })
-})
+  it("should never cap the height: a box that cannot overflow never flips", () => {
+    const style = anchoredContentStyle("bottom-start", 4, "--a", false);
+    expect(style.maxHeight).toBeUndefined();
+  });
+});
 
-describe('FzPopover — JS engine (jsdom default)', () => {
-  it('should render FzFloating, not a native popover', () => {
-    const wrapper = mount(FzPopover, { slots })
-    expect(wrapper.findComponent({ name: 'FzFloating' }).exists()).toBe(true)
-    expect(wrapper.find('.fz-popover__content').exists()).toBe(false)
-  })
+describe("FzPopover — JS engine (jsdom default)", () => {
+  it("should render FzFloating, not a native popover", () => {
+    const wrapper = mount(FzPopover, { slots });
+    expect(wrapper.findComponent({ name: "FzFloating" }).exists()).toBe(true);
+    expect(wrapper.find(".fz-popover__content").exists()).toBe(false);
+  });
 
-  it('should clamp against the viewport rather than the body', () => {
+  it("should clamp against the viewport rather than the body", () => {
     // Regression lock: FzFloating's default boundary is document.body ∩ viewport,
     // and on a page shorter than the viewport that drags the content over its own
     // opener. The popover always asks for viewport semantics.
-    const wrapper = mount(FzPopover, { slots })
-    expect(wrapper.findComponent({ name: 'FzFloating' }).props('useViewport')).toBe(true)
-  })
+    const wrapper = mount(FzPopover, { slots });
+    expect(
+      wrapper.findComponent({ name: "FzFloating" }).props("useViewport"),
+    ).toBe(true);
+  });
 
-  it('should open and close through the slot props', async () => {
+  it("should open and close through the slot props", async () => {
     // A string slot gets no slot props, so the opener is a render function: this is
     // also the shape a consumer writes, since the popover attaches no handler itself.
     const wrapper = mount(FzPopover, {
       slots: {
         opener: (params: { toggle: () => void }) =>
-          h('button', { onClick: params.toggle }, 'Apri'),
-        default: '<div>Contenuto</div>'
-      }
-    })
-    await wrapper.get('button').trigger('click')
-    expect(wrapper.emitted('fzpopover:toggle')![0]).toEqual([true])
-    expect(wrapper.emitted('update:open')![0]).toEqual([true])
+          h("button", { onClick: params.toggle }, "Apri"),
+        default: "<div>Contenuto</div>",
+      },
+    });
+    await wrapper.get("button").trigger("click");
+    expect(wrapper.emitted("fzpopover:toggle")![0]).toEqual([true]);
+    expect(wrapper.emitted("update:open")![0]).toEqual([true]);
 
-    await wrapper.get('button').trigger('click')
-    expect(wrapper.emitted('fzpopover:toggle')![1]).toEqual([false])
-  })
+    await wrapper.get("button").trigger("click");
+    expect(wrapper.emitted("fzpopover:toggle")![1]).toEqual([false]);
+  });
 
-  it('should honour v-model:open from the outside', async () => {
-    const wrapper = mount(FzPopover, { slots, props: { open: false } })
-    await wrapper.setProps({ open: true })
-    expect(wrapper.emitted('fzpopover:toggle')![0]).toEqual([true])
-  })
+  it("should honour v-model:open from the outside", async () => {
+    const wrapper = mount(FzPopover, { slots, props: { open: false } });
+    await wrapper.setProps({ open: true });
+    expect(wrapper.emitted("fzpopover:toggle")![0]).toEqual([true]);
+  });
 
-  it('should take the JS engine for auto placements', () => {
-    const wrapper = mount(FzPopover, { slots, props: { position: 'auto-vertical-start' } })
-    expect(wrapper.findComponent({ name: 'FzFloating' }).exists()).toBe(true)
-  })
-})
+  it("should take the JS engine for auto placements", () => {
+    const wrapper = mount(FzPopover, {
+      slots,
+      props: { position: "auto-vertical-start" },
+    });
+    expect(wrapper.findComponent({ name: "FzFloating" }).exists()).toBe(true);
+  });
+});
 
-describe('FzPopover — CSS engine', () => {
-  beforeEach(enableCssAnchoring)
-  afterEach(restoreCssAnchoring)
+describe("FzPopover — CSS engine", () => {
+  beforeEach(enableCssAnchoring);
+  afterEach(restoreCssAnchoring);
 
-  it('should render a native popover instead of FzFloating', () => {
-    const wrapper = mount(FzPopover, { slots })
-    expect(wrapper.find('.fz-popover__content').exists()).toBe(true)
-    expect(wrapper.findComponent({ name: 'FzFloating' }).exists()).toBe(false)
-  })
+  it("should render a native popover instead of FzFloating", () => {
+    const wrapper = mount(FzPopover, { slots });
+    expect(wrapper.find(".fz-popover__content").exists()).toBe(true);
+    expect(wrapper.findComponent({ name: "FzFloating" }).exists()).toBe(false);
+  });
 
-  it('should anchor the content to the opener', async () => {
-    const wrapper = mount(FzPopover, { slots })
+  it("should anchor the content to the opener", async () => {
+    const wrapper = mount(FzPopover, { slots });
     // The name is written after the flush, once the opener ref is populated.
-    await wrapper.vm.$nextTick()
-    const anchorName = wrapper.get('.fz-popover__opener').element.style.getPropertyValue(
-      'anchor-name'
-    )
-    expect(anchorName).toMatch(/^--fz-popover-\d+$/)
-    expect(wrapper.get('.fz-popover__content').attributes('style')).toContain(
-      `position-anchor: ${anchorName}`
-    )
-  })
+    await wrapper.vm.$nextTick();
+    const anchorName = wrapper
+      .get(".fz-popover__opener")
+      .element.style.getPropertyValue("anchor-name");
+    expect(anchorName).toMatch(/^--fz-popover-\d+$/);
+    expect(wrapper.get(".fz-popover__content").attributes("style")).toContain(
+      `position-anchor: ${anchorName}`,
+    );
+  });
 
-  it('should give each instance its own anchor name and id', async () => {
+  it("should give each instance its own anchor name and id", async () => {
     // Every mount() is its own Vue app: an app-scoped id (useId()) would repeat, and
     // two popovers would anchor to the same opener.
-    const first = mount(FzPopover, { slots })
-    const second = mount(FzPopover, { slots })
-    await Promise.all([first.vm.$nextTick(), second.vm.$nextTick()])
+    const first = mount(FzPopover, { slots });
+    const second = mount(FzPopover, { slots });
+    await Promise.all([first.vm.$nextTick(), second.vm.$nextTick()]);
 
     const anchorOf = (w: typeof first) =>
-      w.get('.fz-popover__opener').element.style.getPropertyValue('anchor-name')
-    const idOf = (w: typeof first) => w.get('.fz-popover__content').attributes('id')
+      w
+        .get(".fz-popover__opener")
+        .element.style.getPropertyValue("anchor-name");
+    const idOf = (w: typeof first) =>
+      w.get(".fz-popover__content").attributes("id");
 
-    expect(anchorOf(first)).not.toBe(anchorOf(second))
-    expect(idOf(first)).not.toBe(idOf(second))
-  })
+    expect(anchorOf(first)).not.toBe(anchorOf(second));
+    expect(idOf(first)).not.toBe(idOf(second));
+  });
 
-  it('should drive the native popover when the model changes', async () => {
+  it("should drive the native popover when the model changes", async () => {
     // Attached on purpose: showPopover() throws on a disconnected element, so the
     // component skips it — and Vue Test Utils mounts detached by default.
     const wrapper = mount(FzPopover, {
       slots,
       props: { open: false },
-      attachTo: document.body
-    })
-    await wrapper.setProps({ open: true })
-    await wrapper.vm.$nextTick()
-    await wrapper.vm.$nextTick()
-    expect(wrapper.get('.fz-popover__content').element.showPopover).toHaveBeenCalled()
-    wrapper.unmount()
-  })
+      attachTo: document.body,
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+    expect(
+      wrapper.get(".fz-popover__content").element.showPopover,
+    ).toHaveBeenCalled();
+    wrapper.unmount();
+  });
 
-  it('should fall back to FzFloating on forceFallback', () => {
-    const wrapper = mount(FzPopover, { slots, props: { forceFallback: true } })
-    expect(wrapper.findComponent({ name: 'FzFloating' }).exists()).toBe(true)
-  })
-})
+  it("should show a popover that starts open", async () => {
+    // The watcher only fires on change, so an `open` that is already true at mount
+    // needs its own push — otherwise a docs example or a visual snapshot renders
+    // closed while the model says open.
+    const wrapper = mount(FzPopover, {
+      slots,
+      props: { open: true },
+      attachTo: document.body,
+    });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+    expect(
+      wrapper.get(".fz-popover__content").element.showPopover,
+    ).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it("should fall back to FzFloating on forceFallback", () => {
+    const wrapper = mount(FzPopover, { slots, props: { forceFallback: true } });
+    expect(wrapper.findComponent({ name: "FzFloating" }).exists()).toBe(true);
+  });
+});

--- a/packages/popover/src/index.ts
+++ b/packages/popover/src/index.ts
@@ -1,0 +1,2 @@
+export { default as FzPopover } from './FzPopover.vue'
+export type * from './types'

--- a/packages/popover/src/types.ts
+++ b/packages/popover/src/types.ts
@@ -1,0 +1,58 @@
+import type { FzFloatingPosition } from "@fiscozen/composables";
+
+export interface FzPopoverProps {
+  /**
+   * Where the content sits relative to its anchor. Same vocabulary as
+   * `FzFloating`, so migrating a call site is a copy of the prop.
+   *
+   * `auto` and `auto-vertical` (and their `-start` / `-end` variants) always take
+   * the JS engine: "the side with the most space" needs measuring.
+   *
+   * @default 'bottom-start'
+   */
+  position?: FzFloatingPosition;
+  /**
+   * Gap between anchor and content, in px.
+   * @default 4
+   */
+  offset?: number;
+  /**
+   * Give the content at least the anchor's width — what a select's listbox wants.
+   * `anchor-size()` in the CSS engine, the measured opener rect in the JS one.
+   */
+  matchOpenerWidth?: boolean;
+  /**
+   * Anchor to this element instead of the `opener` slot. The equivalent of
+   * `FzFloating`'s `overrideOpener` (and of `PopoverAnchor` in Reka UI): use it
+   * when the thing that opens the popover is not the thing it should hang off.
+   */
+  anchor?: HTMLElement | null;
+  /** Class applied to the content box. */
+  contentClass?: string | string[] | Record<string, boolean>;
+  /**
+   * Force the JS engine even where the browser could do it in CSS. Escape hatch
+   * for debugging and for visual tests that need to exercise the fallback.
+   */
+  forceFallback?: boolean;
+}
+
+export interface FzPopoverSlots {
+  /**
+   * The element the popover hangs off. Bind `toggle` (or `open` / `close`) to it —
+   * the popover attaches no click handler of its own, so an opener that is not a
+   * button keeps working.
+   */
+  opener(props: {
+    isOpen: boolean;
+    toggle: () => void;
+    open: () => void;
+    close: () => void;
+  }): unknown;
+  /** The floating content. */
+  default(props: { isOpen: boolean; close: () => void }): unknown;
+}
+
+export interface FzPopoverEmits {
+  /** Fired after the popover opened or closed, whatever the cause. */
+  "fzpopover:toggle": [isOpen: boolean];
+}

--- a/packages/popover/src/utils.ts
+++ b/packages/popover/src/utils.ts
@@ -1,0 +1,119 @@
+import { getCurrentInstance, type CSSProperties } from "vue";
+import type { FzFloatingPosition } from "@fiscozen/composables";
+
+/**
+ * A DOM id / CSS ident unique across the whole document.
+ *
+ * Deliberately NOT `useId()`: that is scoped to the Vue *app*, and a document can
+ * hold several (Storybook docs mode mounts one app per story; an app can have
+ * several mount points), each handing out `v-0` again. Anything another element
+ * resolves — `position-anchor`, `aria-controls` — then points at the wrong box,
+ * silently. `uid` is a counter inside the Vue runtime itself, shared across apps.
+ *
+ * Call from `setup()`.
+ */
+export function useUniqueId(prefix: string): string {
+  return `${prefix}-${getCurrentInstance()!.uid}`;
+}
+
+/**
+ * Feature-detects what the CSS engine of `FzPopover` needs:
+ *
+ * 1. the **Popover API** (`[popover]`) — top layer, light dismiss and Esc for free;
+ * 2. **CSS anchor positioning** (`anchor-name` / `position-anchor`);
+ * 3. **`position-area`** — places the box in one of the 9 areas around its anchor,
+ *    which is how the 12 `FzFloatingPosition` values are expressed without JS.
+ *
+ * The Popover API has been broadly available since 2024; anchor positioning only
+ * reached Baseline in 2026. Where any of the three is missing, `FzPopover` falls
+ * back to `FzFloating` — the JS engine the design system already ships.
+ *
+ * Not memoized: the checks are cheap, and keeping them live lets tests toggle
+ * support per case. `window.CSS` is guarded because jsdom has no such global.
+ */
+export function supportsCssAnchoring(): boolean {
+  if (typeof HTMLElement === "undefined" || typeof window === "undefined")
+    return false;
+  if (!("popover" in HTMLElement.prototype)) return false;
+  if (typeof window.CSS?.supports !== "function") return false;
+  return (
+    window.CSS.supports("anchor-name: --fz") &&
+    window.CSS.supports("position-area: block-end")
+  );
+}
+
+/**
+ * `auto` and `auto-vertical` mean "the side with the most available space", which
+ * needs measuring — `position-try-fallbacks` only abandons a placement that
+ * *overflows*, and `position-try-order` reorders the fallback list without
+ * replacing the base placement. So auto positions always take the JS engine.
+ */
+export function isAutoPosition(position: FzFloatingPosition): boolean {
+  return position.startsWith("auto");
+}
+
+/**
+ * `FzFloatingPosition` → `position-area`.
+ *
+ * The area grid is 3×3 around the anchor. `span-inline-end` occupies the centre
+ * column plus the inline-end one, i.e. it aligns with the anchor's inline-start
+ * edge and grows towards inline-end — which is what `-start` means in the
+ * FzFloating/Floating UI vocabulary. `-end` is its mirror, and a bare side centres.
+ */
+const POSITION_AREA: Record<string, string> = {
+  bottom: "block-end center",
+  "bottom-start": "block-end span-inline-end",
+  "bottom-end": "block-end span-inline-start",
+  top: "block-start center",
+  "top-start": "block-start span-inline-end",
+  "top-end": "block-start span-inline-start",
+  left: "inline-start center",
+  "left-start": "inline-start span-block-end",
+  "left-end": "inline-start span-block-start",
+  right: "inline-end center",
+  "right-start": "inline-end span-block-end",
+  "right-end": "inline-end span-block-start",
+};
+
+/** The offset lives on the side facing the anchor, mirroring FzFloating's margins. */
+function offsetStyle(
+  position: FzFloatingPosition,
+  offset: number,
+): CSSProperties {
+  const px = `${offset}px`;
+  if (position.startsWith("bottom")) return { marginTop: px };
+  if (position.startsWith("top")) return { marginBottom: px };
+  if (position.startsWith("left")) return { marginRight: px };
+  if (position.startsWith("right")) return { marginLeft: px };
+  return { marginTop: px };
+}
+
+/**
+ * Inline style that pins the content to its anchor. Everything about placement
+ * lives here, so the browser keeps the two glued on scroll and resize with no JS.
+ *
+ * No `max-height`: capping the box would make it shrink instead of overflow, and a
+ * box that never overflows never triggers `position-try-fallbacks` — verified in
+ * Chromium 143, where a shrink-to-fit menu stayed in a 22px slot rather than
+ * flipping above. Flipping is the more useful of the two for a popover, so content
+ * that can outgrow the viewport should cap itself (or use the JS engine).
+ */
+export function anchoredContentStyle(
+  position: FzFloatingPosition,
+  offset: number,
+  anchorName: string,
+  matchOpenerWidth: boolean,
+): CSSProperties {
+  const vertical = position.startsWith("bottom") || position.startsWith("top");
+  return {
+    position: "fixed",
+    positionAnchor: anchorName,
+    positionArea: POSITION_AREA[position] ?? POSITION_AREA["bottom-start"],
+    positionTryFallbacks: vertical ? "flip-block" : "flip-inline",
+    width: "max-content",
+    ...(matchOpenerWidth
+      ? { minWidth: `anchor-size(${anchorName} width)` }
+      : {}),
+    ...offsetStyle(position, offset),
+  } as CSSProperties;
+}

--- a/packages/popover/tsconfig.json
+++ b/packages/popover/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@fiscozen/tsconfig",
+  "exclude": ["src/__tests__", "vite.config.ts", "vitest.config.ts"]
+}

--- a/packages/popover/vite.config.ts
+++ b/packages/popover/vite.config.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath, URL } from 'node:url'
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import dts from 'vite-plugin-dts'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    vue(),
+    dts({
+      insertTypesEntry: true,
+    })
+  ],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  build: {
+    lib: {
+      entry: resolve(__dirname, './src/index.ts'),
+      name: 'FzPopover',
+    },
+    rollupOptions: {
+      external: ['vue', '@fiscozen/composables'],
+      output: {
+        globals: {
+          vue: 'Vue',
+        },
+      },
+    }
+  }
+})

--- a/packages/popover/vitest.config.ts
+++ b/packages/popover/vitest.config.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url'
+import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
+import viteConfig from './vite.config'
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: 'jsdom',
+      exclude: [...configDefaults.exclude, 'e2e/*'],
+      root: fileURLToPath(new URL('./', import.meta.url)),
+      setupFiles: ['../vitest.setup.ts'],
+      coverage: {
+        provider: 'v8',
+        include: ['**/src/**'],
+        exclude: ['**/index.ts', '**/__tests__/**', '**/*.stories.ts'],
+        thresholds: {
+          statements: 80,
+          branches: 75,
+          functions: 80,
+          lines: 80
+        }
+      }
+    }
+  })
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -978,12 +978,12 @@ importers:
       '@fiscozen/divider':
         specifier: workspace:*
         version: link:../divider
-      '@fiscozen/dropdown':
-        specifier: workspace:*
-        version: link:../dropdown
       '@fiscozen/icons':
         specifier: workspace:^
         version: link:../icons
+      '@fiscozen/popover':
+        specifier: workspace:*
+        version: link:../popover
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.19(yaml@2.8.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@fiscozen/pdf-viewer':
         specifier: workspace:^
         version: link:../../packages/pdf-viewer
+      '@fiscozen/popover':
+        specifier: workspace:*
+        version: link:../../packages/popover
       '@fiscozen/progress':
         specifier: workspace:^
         version: link:../../packages/progress
@@ -2515,6 +2518,73 @@ importers:
         specifier: ^2.2.12
         version: 2.2.12(typescript@5.7.3)
 
+  packages/popover:
+    dependencies:
+      '@fiscozen/composables':
+        specifier: workspace:*
+        version: link:../composables
+      tailwindcss:
+        specifier: ^3.4.1
+        version: 3.4.19(yaml@2.8.2)
+      vue:
+        specifier: ^3.4.13
+        version: 3.5.26(typescript@5.7.3)
+    devDependencies:
+      '@fiscozen/eslint-config':
+        specifier: workspace:^
+        version: link:../eslint-config
+      '@fiscozen/prettier-config':
+        specifier: workspace:^
+        version: link:../prettier-config
+      '@fiscozen/tsconfig':
+        specifier: workspace:^
+        version: link:../tsconfig
+      '@rushstack/eslint-patch':
+        specifier: ^1.3.3
+        version: 1.15.0
+      '@types/jsdom':
+        specifier: ^21.1.6
+        version: 21.1.7
+      '@types/node':
+        specifier: ^18.19.3
+        version: 18.19.130
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.5
+        version: 6.0.5(vite@8.0.2(@types/node@18.19.130)(jiti@1.21.7)(yaml@2.8.2))(vue@3.5.26(typescript@5.7.3))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.1
+        version: 4.1.1(@vitest/browser@4.1.1(vite@8.0.2(@types/node@18.19.130)(jiti@1.21.7)(yaml@2.8.2))(vitest@4.1.1))(vitest@4.1.1)
+      '@vue/test-utils':
+        specifier: ^2.4.3
+        version: 2.4.6
+      '@vue/tsconfig':
+        specifier: ^0.5.0
+        version: 0.5.1
+      eslint:
+        specifier: ^8.49.0
+        version: 8.57.1
+      jsdom:
+        specifier: ^23.0.1
+        version: 23.2.0
+      prettier:
+        specifier: ^3.0.3
+        version: 3.7.4
+      typescript:
+        specifier: ~5.7.0
+        version: 5.7.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.2(@types/node@18.19.130)(jiti@1.21.7)(yaml@2.8.2)
+      vite-plugin-dts:
+        specifier: ^4.5.0
+        version: 4.5.4(@types/node@18.19.130)(rollup@4.55.1)(typescript@5.7.3)(vite@8.0.2(@types/node@18.19.130)(jiti@1.21.7)(yaml@2.8.2))
+      vitest:
+        specifier: ^4.1.1
+        version: 4.1.1(@types/node@18.19.130)(@vitest/browser-playwright@4.1.1)(@vitest/ui@4.1.1)(jsdom@23.2.0)(vite@8.0.2(@types/node@18.19.130)(jiti@1.21.7)(yaml@2.8.2))
+      vue-tsc:
+        specifier: ^2.2.12
+        version: 2.2.12(typescript@5.7.3)
+
   packages/prettier-config:
     devDependencies:
       prettier-plugin-tailwindcss:
@@ -3805,6 +3875,9 @@ packages:
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -7370,6 +7443,9 @@ packages:
     resolution: {integrity: sha512-tn+OxutdqhvoByKJ7p84FZBSUDfUB76bcvj0ugLBvgE9V52LFcnz8cauCDKi6otnctvFCqa9XkrU35pBY5Baig==}
     engines: {node: '>=18'}
 
+  node-readable-to-web-readable-stream@0.4.2:
+    resolution: {integrity: sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -8764,8 +8840,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.2.7:
-    resolution: {integrity: sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==}
+  vue-component-type-helpers@3.3.9:
+    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -9250,9 +9326,14 @@ snapshots:
 
   '@emnapi/core@1.8.1':
     dependencies:
+      '@emnapi/wasi-threads': 1.1.0
       tslib: 2.8.1
 
   '@emnapi/runtime@1.8.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
 
@@ -10036,7 +10117,7 @@ snapshots:
       storybook: 10.3.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@5.7.3)
-      vue-component-type-helpers: 3.2.7
+      vue-component-type-helpers: 3.3.9
 
   '@tato30/vue-pdf@2.0.2(vue@3.5.26(typescript@5.7.3))':
     dependencies:
@@ -13108,6 +13189,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  node-readable-to-web-readable-stream@0.4.2:
+    optional: true
+
   node-releases@2.0.27: {}
 
   nopt@7.2.1:
@@ -13380,6 +13464,7 @@ snapshots:
   pdfjs-dist@5.4.624:
     optionalDependencies:
       '@napi-rs/canvas': 0.1.88
+      node-readable-to-web-readable-stream: 0.4.2
 
   pend@1.2.0: {}
 
@@ -14521,7 +14606,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.2.7: {}
+  vue-component-type-helpers@3.3.9: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@5.7.3)):
     dependencies:


### PR DESCRIPTION
Jira: [LIB-2851](https://fiscozen.atlassian.net/browse/LIB-2851)

A spike, and the primitive it produced: an alternative to Floating UI that prefers the platform. New package `@fiscozen/popover`, with `FzCardListItem`'s actions menu as its first consumer.

## The bet

Two engines behind one API:

- **CSS engine** — where the browser has the Popover API, CSS anchor positioning and `position-area`, the content is a native `[popover]` in the top layer (never clipped by an ancestor's overflow, no z-index to arbitrate), placed entirely in CSS, so the browser keeps it glued to its anchor on scroll and resize with no JS. Light dismiss and Esc come from the platform.
- **JS engine** — `FzFloating`, the measured-rect implementation we already ship, plus `useClickOutside` / `useKeyDown`. Taken where anchor positioning is missing, for `auto` placements, or on `forceFallback`.

No new dependency: the fallback is code we already ship, and it is meant to die. When anchor positioning is everywhere, the second engine goes and `FzFloating` goes with it.

The API keeps `FzFloating`'s 12-position vocabulary, so migrating a call site is a copy of the prop, and adds `v-model:open`, `offset`, `matchOpenerWidth` (`anchor-size()` in the CSS engine) and `anchor` for hanging content off something other than the opener.

## What the pilot settled

Three findings that shaped the design, all measured in Chromium 143 rather than assumed:

1. **`position-area` + `max-height: 100%` is the `size` middleware, in CSS** — it caps the box to the available space and scrolls the content. But a box that shrinks never overflows, so `position-try-fallbacks` never fires: a menu near the viewport bottom stayed in a 22px slot instead of flipping. Neither `position-try-order: most-block-size` nor a `min-height` rescues it. Flipping is the more useful half, so content is not capped, and callers with content taller than the viewport use the JS engine.
2. **Light dismiss and Esc only answer trusted input.** `userEvent.keyboard('{Escape}')` does not close a native popover, so the Storybook tier cannot assert native dismissal: those stories close through the opener, and real keys are covered by a Playwright probe.
3. **`popovertarget` makes a DOM id load-bearing.** Vue's `useId()` is app-scoped, so a document with several apps — Storybook docs mode renders one per story — hands out `v-0` repeatedly, and every opener toggled the *first* card's menu, 208px from the button that was clicked. The primitive avoids the class of bug entirely by toggling in JS and anchoring by name; ids that something else resolves come from the instance uid.

## Also in here

- **`FzFloating` bug fix (`useViewport` only).** The collision boundary intersected with `document.body`, which is not a clipping box for fixed content: on a page shorter than the viewport its rect shrank the usable area and the clamp dragged content over its own opener — a 48px menu on a 108px page resolved `maxTop = 108 - 8 - 48 = 52` against an opener bottom of 76. Only `useViewport` callers change (`FzSelect`, `FzTypeahead`, `FzPopover`), for which the viewport is exactly what the prop name promises.
- **card-list a11y fix.** The link row's `aria-labelledby` had the same app-scoped id problem, so a screen reader announced the first card's title on every row. Pre-dates this branch.
- `FzCardMultiActions` drops from 215 to 135 lines and loses its `@fiscozen/dropdown` dependency; its unit tests lose the two engine-specific describes, since which engine renders is now tested in the popover package.

## Verification

- 749 Storybook play functions and the full build pass (pre-push).
- Unit: 28 new in `@fiscozen/popover`, 66 in card-list, 99 in composables.
- Chromium, both engines: anchoring, geometry (`dy 4`, `dx 0`), flip near the viewport edge, Esc with real keys, reopen after Esc, light dismiss, `matchOpenerWidth` measuring the opener exactly, and — on the three-card story — every ellipsis opening its own menu.

## Not in scope

- Migrating `dropdown`, `tooltip`, `tab`, `select`, `typeahead` (9 call sites) — a separate card if this pilot is approved. Worth revisiting there: `select` and `typeahead` default to `auto-vertical-start`, so 6 of those 9 would sit on the JS engine unless we map `auto-vertical-*` to `flip-block`.
- Menu semantics (`role`, accessible name, `aria-controls`) and focus management (focus on open, roving arrows, return to opener). The Reka UI comparison in the card concluded these — not the anchoring — are the reusable pieces still missing.
- MDX docs for the primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-2851]: https://fiscozen.atlassian.net/browse/LIB-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ