### PR TITLE
test(storybook): LIB-2860 stop asserting a tooltip position that cannot happen

### DIFF
--- a/apps/storybook/src/stories/overlay/Tooltip.stories.ts
+++ b/apps/storybook/src/stories/overlay/Tooltip.stories.ts
@@ -416,6 +416,7 @@ export const TooltipStylingRegression: Story = {
   }
 }
 
+
 /**
  * Tests tooltip positioning with bottom position and verifies margin class
  */
@@ -454,13 +455,19 @@ export const TooltipBottomPosition: Story = {
 }
 
 /**
- * Tests tooltip positioning with top position and verifies margin class
+ * Tests tooltip positioning with top position and verifies margin class.
+ *
+ * The generous top padding is load-bearing: the tooltip needs somewhere to go. Without
+ * it the trigger sits ~45px from the top of the page, there is no room above, and the
+ * engine — correctly, since LIB-2813 and LIB-2825 — places the panel where it fits
+ * instead of off-screen. This story is about the placement, so it gives it the room to
+ * happen; TooltipTopWithoutRoom covers the cramped case.
  */
 export const TooltipTopPosition: Story = {
   render: () => ({
     components: { FzTooltip, FzButton },
     template: `
-      <div class="p-40 flex items-center justify-center">
+      <div class="p-40 pt-[300px] flex items-center justify-center">
         <FzTooltip position="top" text="Top tooltip">
           <FzButton data-testid="trigger-top">Top</FzButton>
         </FzTooltip>
@@ -487,6 +494,54 @@ export const TooltipTopPosition: Story = {
       // Verify positioning: tooltip should be above trigger
       expect(tooltipRect.bottom).toBeLessThanOrEqual(triggerRect.top + TOLERANCE)
     }, { timeout: 2000 })
+  }
+}
+
+/**
+ * The counterpart: `position="top"` with no room above. The panel must not be pushed
+ * off-screen to honour the requested side — it goes where it fits and stays visible.
+ * This is what LIB-2825 changed, and what the old assertion in TooltipTopPosition was
+ * accidentally testing against.
+ */
+export const TooltipTopWithoutRoom: Story = {
+  render: () => ({
+    components: { FzTooltip, FzButton },
+    template: `
+      <div class="p-8 flex items-start justify-center">
+        <FzTooltip position="top" text="Top tooltip senza spazio sopra">
+          <FzButton data-testid="trigger-cramped">Top</FzButton>
+        </FzTooltip>
+      </div>
+    `
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const TOLERANCE = 8
+    const trigger = canvas.getByTestId('trigger-cramped')
+    await userEvent.hover(trigger)
+
+    await waitFor(
+      () => {
+        const content = document.querySelector('.fz__floating__content')
+        expect(content).toBeVisible()
+
+        const triggerRect = trigger.getBoundingClientRect()
+        const tooltipRect = (content as Element).getBoundingClientRect()
+
+        // Fully on screen: no part of it hidden above the fold.
+        expect(tooltipRect.top).toBeGreaterThanOrEqual(0)
+        expect(tooltipRect.bottom).toBeLessThanOrEqual(window.innerHeight)
+
+        // And still attached to its trigger, on one side or the other. This is the half
+        // that matters: the bug LIB-2825 removed used to pin the panel to the top margin,
+        // which is on screen but detached from the thing it describes.
+        const gapBelow = Math.abs(tooltipRect.top - triggerRect.bottom)
+        const gapAbove = Math.abs(triggerRect.top - tooltipRect.bottom)
+        expect(Math.min(gapBelow, gapAbove)).toBeLessThanOrEqual(TOLERANCE)
+      },
+      { timeout: 2000 }
+    )
   }
 }
 


### PR DESCRIPTION
Jira: [LIB-2860](https://fiscozen.atlassian.net/browse/LIB-2860)

`Tooltip Top Position` fails on `main` — `expected 124 to be less than or equal to 45` — which makes the Storybook suite red and blocks everyone's pre-push. The engine is right and the test is wrong.

## What is actually happening

The story puts its trigger ~45px from the top of the page, so there is no room above it for the tooltip. Since LIB-2813 (#425) and LIB-2825 (#427) the engine places the panel where it fits rather than off-screen, so a `position="top"` tooltip in that layout lands below the trigger — and the assertion demands it be above.

Proof it is the layout and not the engine: add 300px of padding above the trigger, touch nothing else, and the test passes.

**Why it used to pass:** because of the very bug LIB-2825 removed. With the collision bounds collapsed by `body`'s rect, the clamp pinned the panel against the top margin, and `bottom ≈ 48` slipped under the `45 + 5` threshold. The assertion was satisfied by a panel detached from its trigger — it was encoding the defect.

## The change

Two stories instead of one, and no engine code touched:

- `TooltipTopPosition` gets room above it. The padding is load-bearing, and the comment now says so, so nobody "cleans it up" later.
- `TooltipTopWithoutRoom` covers the cramped case and asserts what matters: the panel stays on screen **and** stays attached to its trigger.

That second assertion is the point. My first version only checked "fully on screen", which the old pinned-to-the-top behaviour would also have satisfied — it would not have locked the fix in. Being adjacent to the trigger is what actually changed.

## Verification

- Tooltip stories: 11/11 green.
- Full pre-push suite: 745 tests green, 66 files (it was red before this change).
- Only story files change, so no changeset is due.

## Note for whoever merged the engine fixes

I could not work out how this reached `main`: the pre-push hook runs the whole suite and the failure is deterministic here, across clean `main`, a branch merging it, and retries. Either the storybook gate was skipped through its documented escape hatch, or the geometry differs on another machine. Worth a look — if it is the second case, the old assertion was environment-sensitive in a way the new one is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-2860]: https://fiscozen.atlassian.net/browse/LIB-2860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ