### PR TITLE
fix(composables): LIB-2854 keep FzFloating's position prop reactive

### DIFF
--- a/.changeset/floating-reactive-position.md
+++ b/.changeset/floating-reactive-position.md
@@ -1,0 +1,9 @@
+---
+'@fiscozen/composables': patch
+---
+
+FzFloating: react to a `position` that changes while the panel is open.
+
+The engine's options were built with a copy of the prop, so the placement chosen at setup was the only one it ever resolved. A later change was observed — the watcher ran, `setPosition` rewrote the inline `top` — but the panel stayed exactly where it was, on the original side. Only callers that bind `position` to something reactive were affected (`FzTooltip` takes it as a prop, `FzSelect` and `FzTypeahead` pass a computed), so it failed silently rather than loudly.
+
+Note that this changes behaviour for anyone who was living with it unknowingly: a `position` that oscillates will now actually move the panel.

--- a/apps/storybook/src/stories/composables/Floating.stories.ts
+++ b/apps/storybook/src/stories/composables/Floating.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { expect, within, screen, waitFor } from 'storybook/test'
 import { reactive, ref } from 'vue'
 
+import type { FzFloatingPosition } from '@fiscozen/composables'
 import { FzFloating } from '@fiscozen/composables'
 import { FzNavlink } from '@fiscozen/navlink'
 import { FzNavlist } from '@fiscozen/navlist'
@@ -455,6 +456,67 @@ export const PositionBottomStart: Story = {
 
     // Content left should be approximately aligned with opener left (start)
     await expect(Math.abs(contentRect.left - openerRect.left)).toBeLessThan(POSITION_TOLERANCE)
+  }
+}
+
+/**
+ * Regression test for LIB-2854: `position` has to keep working when it changes while
+ * the floating is open. The options were built with a copy of the prop, so the engine
+ * kept resolving the placement chosen at setup — setPosition ran, the inline `top` was
+ * rewritten, and the content stayed exactly where it was.
+ *
+ * Has to live in a browser: jsdom reports every rect as zero, so a unit test would
+ * pass no matter what the code does.
+ */
+export const PositionChangesAtRuntime: Story = {
+  render: (args) => ({
+    setup() {
+      const isOpen = ref(true)
+      const position = ref<FzFloatingPosition>('bottom-start')
+      const flip = () => {
+        position.value = position.value === 'bottom-start' ? 'top-start' : 'bottom-start'
+      }
+      return { args, isOpen, position, flip }
+    },
+    components: { FzFloating, FzButton },
+    template: `
+      <div class="flex h-screen w-screen flex-col items-center justify-center gap-24">
+        <FzFloating :position="position" :isOpen="isOpen">
+          <template #opener>
+            <FzButton data-testid="opener-button" label="Opener" />
+          </template>
+          <div data-testid="floating-content" class="rounded border border-grey-300 bg-grey-100 p-16">
+            <p class="text-sm">Position: {{ position }}</p>
+          </div>
+        </FzFloating>
+        <FzButton data-testid="flip-button" @click="flip" label="Cambia posizione" />
+      </div>`
+  }),
+  args: {
+    position: 'bottom-start',
+    isOpen: true,
+    teleport: false
+  },
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement)
+    const opener = canvas.getByTestId('opener-button')
+    const content = () => getFloatingContent(canvasElement) as Element
+
+    await waitFor(() => expect(content()).toBeVisible())
+
+    // Starts below the opener.
+    await expect(content().getBoundingClientRect().top).toBeGreaterThanOrEqual(
+      opener.getBoundingClientRect().bottom - POSITION_TOLERANCE
+    )
+
+    await userEvent.click(canvas.getByTestId('flip-button'))
+
+    // And moves above it once the prop says top-start.
+    await waitFor(() =>
+      expect(content().getBoundingClientRect().bottom).toBeLessThanOrEqual(
+        opener.getBoundingClientRect().top + POSITION_TOLERANCE
+      )
+    )
   }
 }
 

--- a/packages/composables/src/FzFloating.vue
+++ b/packages/composables/src/FzFloating.vue
@@ -73,7 +73,15 @@ const useFloatingOpts: FzUseFloatingArgs = {
   }
 }
 
-const dynamicOpts = toRefs(useFloatingOpts)
+// `position` has to stay live. It is copied by value into useFloatingOpts above, so
+// toRefs would hand the engine a ref onto that copy: setPosition would keep resolving
+// the placement chosen at setup, and every later change to the prop — a responsive
+// tooltip, a computed on FzSelect — would be silently ignored. A computed reads the
+// prop each time instead.
+const dynamicOpts = {
+  ...toRefs(useFloatingOpts),
+  position: computed(() => props.position)
+}
 if (slots.opener) {
   useFloatingOpts.opener = {
     // @ts-ignore


### PR DESCRIPTION
Jira: [LIB-2854](https://fiscozen.atlassian.net/browse/LIB-2854)

> **Stacked on #432.** `main`'s Storybook suite is red without it, so the pre-push hook cannot pass on a branch based on `main`. Base should be retargeted to `main` once #431 and #432 land; the diff to review is the single commit `222e0c46`.

`FzFloating` never honoured a `position` that changed after setup.

## The defect

The engine's options are built with a copy of the prop, not a getter:

```js
const useFloatingOpts: FzUseFloatingArgs = {
  position: props.position,   // ← value, copied once
  ...
}
const dynamicOpts = toRefs(useFloatingOpts)
```

Nothing ever writes the new value back, so `setPosition` keeps resolving the placement captured at setup. The component *does* observe the prop and re-run positioning — which is what makes this hard to spot: it looks alive. Measured in Chromium, going from `bottom-start` to `top-start` with the panel open:

| | inline `top` | gap class | dy from opener | side |
|---|---|---|---|---|
| initial `bottom-start` | — | `mt-4` | 4 | below ✓ |
| switched to `top-start` | `260px`, recomputed | `mt-4` | 4 | **still below** ✗ |
| back to `bottom-start` | `260px` | `mt-4` | 4 | below |

Only callers binding `position` to something reactive are affected: `FzTooltip` takes it as a prop, `FzSelect` and `FzTypeahead` pass a computed. Everyone else passes a constant, which is why this stayed latent — and silent.

## The fix

One line: a computed that reads the prop each time instead of a ref onto the copy.

## Verification

- New story `PositionChangesAtRuntime` in the FzFloating suite. It lives in a browser on purpose: jsdom reports every rect as zero, so a unit test would pass whatever the code does.
- Confirmed it fails without the fix — `expected 498 to be less than or equal to 399`, the content refusing to move above — and passes with it.
- Composables: 108 unit tests green. Floating + Tooltip stories: 52 green. Full pre-push suite green.

## Worth knowing when reviewing

This changes behaviour for anyone who was living with the bug unknowingly: a `position` bound to something that oscillates will now actually move the panel. If any consumer was relying on the panel staying put, this is where it surfaces — I checked the three non-constant callers and their suites are green, but a real-app pass on tooltip and select placement wouldn't hurt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-2854]: https://fiscozen.atlassian.net/browse/LIB-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ