### PR TITLE
fix(storybook): give the top-position tooltip story room above the trigger (LIB-2929)

### DIFF
--- a/apps/storybook/src/stories/overlay/Tooltip.stories.ts
+++ b/apps/storybook/src/stories/overlay/Tooltip.stories.ts
@@ -459,8 +459,14 @@ export const TooltipBottomPosition: Story = {
 export const TooltipTopPosition: Story = {
   render: () => ({
     components: { FzTooltip, FzButton },
+    // More padding than the sibling stories on purpose. An upward tooltip needs
+    // room above the trigger, and `p-40` is 40px in this design system — less
+    // than the tooltip is tall. With too little room `applyBoundaryCorrections`
+    // relocates the tooltip to keep it on screen, it lands below the trigger,
+    // and the assertion below fails having measured the boundary behaviour
+    // instead of top positioning.
     template: `
-      <div class="p-40 flex items-center justify-center">
+      <div class="p-96 flex items-center justify-center">
         <FzTooltip position="top" text="Top tooltip">
           <FzButton data-testid="trigger-top">Top</FzButton>
         </FzTooltip>


### PR DESCRIPTION
Jira: [LIB-2929](https://fiscozen.atlassian.net/browse/LIB-2929)

`TooltipTopPosition` was failing on `main`, and with it the whole pre-push gate:

```
apps/storybook/src/stories/overlay/Tooltip.stories.ts:488
expected 124 to be less than or equal to 45
```

Since this repo has no CI workflows, that hook is the only gate — so a single red story was blocking every push in the repo.

## The story was wrong, not the component

The trigger was wrapped in `p-40`, which is **40px** in this design system — less than the tooltip is tall. An upward tooltip could not fit, so `applyBoundaryCorrections` (step 9 in `useFloating`) relocated it to keep it on screen and it landed below the trigger. The assertion then measured the boundary behaviour and reported it as a positioning bug.

The sibling `TooltipBottomPosition` passes precisely because a downward tooltip has the room.

## The fix

`p-96` gives the tooltip its 96px, plus a comment recording why this story's padding is deliberately more generous than its siblings' — normalising it brings the failure straight back.

Deliberately **not** done: loosening the assertion. Verifying that a `position="top"` tooltip sits above its trigger is exactly what this story is for.

No library change — relocating a floating element that does not fit is the intended behaviour (LIB-2825). Storybook-only, so no changeset is due.

## Verification

Full suite green, no skipped checks: **744 passed, 3 skipped, 0 failed**. The push itself went through the complete pre-push gate (changeset check + full build + Storybook interaction tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-2929]: https://fiscozen.atlassian.net/browse/LIB-2929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ