### PR TITLE
feat(upload): headless useFileSelect + opener slot (LIB-2926)

### DIFF
--- a/.changeset/upload-headless-file-select.md
+++ b/.changeset/upload-headless-file-select.md
@@ -1,0 +1,31 @@
+---
+"@fiscozen/upload": minor
+---
+
+FzUpload: `useFileSelect`, a headless file picker, plus an `opener` slot
+
+`FzUpload` welded the behaviour of picking files to the presentation of picking files. It rendered a hidden `input type="file"` and its own `FzButton` inside a dashed drop zone, and exposed neither, so a control that needed the picker without the widget had exactly one road: render `FzUpload` with `class="hidden"`, bind a `v-model` only to drain it — otherwise the hidden `<ul>` mints object URLs for files nobody will ever see — and reach the input through the component's root element. That is a dependency on private DOM, and it is what the chat composer in `@fzp/customers` currently does.
+
+The fix is a layer down rather than an escape hatch on top. `useFileSelect` is the file-selection behaviour on its own:
+
+```ts
+const { open } = useFileSelect({
+  multiple: true,
+  accept: () => props.accept,
+  onSelect: (files) => emit('attach', files)
+})
+```
+```vue
+<FzIconButton icon-name="paperclip" @click="open" />
+```
+
+Nothing is rendered for that to work. With no `element` passed the composable creates and owns its own input, so there is no hidden component to mount, no model to drain, and no template ref to null-check. The "must work while the component is `display: none`" problem disappears instead of being tested around, and because the input comes from design-system code, a consumer bound by a lint rule against raw `<input>` stays inside it.
+
+`FzUpload` is now built on the same composable, so the widget and a bare `useFileSelect` call cannot drift apart. Its rendered output is unchanged.
+
+Two smaller additions, for when the widget itself is still right:
+
+- **`opener` slot** — replaces the button that opens the picker and receives `open`, the way `FzDropdown`'s `opener` slot works. The drop zone, the file list and the model keep working around it.
+- **`defineExpose({ open })`** — the imperative way in, for a caller that holds a ref to the component.
+
+One behavioural change comes with the refactor: an empty selection no longer reaches the model. Dropping a drag event that carries no files used to emit `fzupload:add`/`fzupload:change`, and with `multiple: false` it pushed `[undefined]` into the model — a limitation the spec had documented rather than fixed. `onSelect` is now never called with an empty list.

--- a/apps/storybook/src/stories/form/Upload.stories.ts
+++ b/apps/storybook/src/stories/form/Upload.stories.ts
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { expect, fn, userEvent, within, waitFor } from 'storybook/test'
-import { FzUpload } from '@fiscozen/upload'
+import { FzUpload, useFileSelect } from '@fiscozen/upload'
+import { FzIconButton } from '@fiscozen/button'
+import { FzContainer } from '@fiscozen/container'
 import { ref } from 'vue'
 
 const meta: Meta<typeof FzUpload> = {
@@ -625,6 +627,168 @@ export const EmptyState: Story = {
       const dropZone = canvasElement.querySelector('.border-dashed')
       await expect(dropZone).toBeInTheDocument()
       await expect(dropZone).toBeVisible()
+    })
+  }
+}
+
+
+// ============================================
+// OPENING THE PICKER FROM SOMEWHERE ELSE
+// ============================================
+
+/**
+ * The picker with no widget around it, through `useFileSelect`.
+ *
+ * This is the shape a chat composer needs: an icon-only clip in a toolbar, no
+ * dashed drop zone, and the picked files handed straight on. Nothing is
+ * rendered for the picker — the composable owns its own input — so there is no
+ * hidden component to mount and no DOM to reach into.
+ */
+export const ComposableTrigger: Story = {
+  render: (args) => ({
+    components: { FzContainer, FzIconButton },
+    inheritAttrs: false,
+    emits: ['update:modelValue'],
+    setup(_props, { emit }) {
+      const attached = ref<File[]>([])
+      const { open } = useFileSelect({
+        multiple: true,
+        accept: () => args.accept,
+        onSelect: (files) => {
+          attached.value = [...attached.value, ...files]
+          emit('update:modelValue', attached.value)
+        }
+      })
+      return { attached, open }
+    },
+    template: `
+      <FzContainer gap="sm">
+        <FzContainer horizontal gap="xs" alignItems="center">
+          <FzIconButton
+            iconName="paperclip"
+            variant="invisible"
+            ariaLabel="Allega un documento"
+            @click="open"
+          />
+          <p>Nessun widget di upload: solo il composable.</p>
+        </FzContainer>
+        <FzContainer gap="none">
+          <p v-for="file in attached" :key="file.name">{{ file.name }}</p>
+        </FzContainer>
+      </FzContainer>
+    `
+  }),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify the trigger is the only affordance', async () => {
+      const trigger = canvas.getByRole('button', { name: /allega un documento/i })
+      await expect(trigger).toBeInTheDocument()
+      await expect(trigger).toBeVisible()
+    })
+
+    await step('Verify no upload widget is rendered', async () => {
+      await expect(canvasElement.querySelector('.border-dashed')).not.toBeInTheDocument()
+      await expect(canvas.queryByRole('button', { name: /carica/i })).not.toBeInTheDocument()
+    })
+
+    await step('Verify the trigger opens an input the composable owns', async () => {
+      // Swallow the click on the picker so no native file dialog is opened.
+      const clicked: HTMLInputElement[] = []
+      const guard = (event: Event) => {
+        const target = event.target as HTMLElement
+        if (target instanceof HTMLInputElement && target.type === 'file') {
+          event.preventDefault()
+          clicked.push(target)
+        }
+      }
+      document.addEventListener('click', guard, true)
+
+      try {
+        const trigger = canvas.getByRole('button', { name: /allega un documento/i })
+        await userEvent.click(trigger)
+
+        await waitFor(() => expect(clicked.length).toBe(1))
+        // Owned by the composable, so it lives outside the story's own markup.
+        await expect(canvasElement.contains(clicked[0])).toBe(false)
+      } finally {
+        document.removeEventListener('click', guard, true)
+      }
+    })
+  }
+}
+
+/**
+ * The widget kept, the button swapped, through the `opener` slot.
+ *
+ * Use this when the drop zone still belongs on the page and only the trigger
+ * has to change. The slot gets `open`, and everything around it — the drop
+ * zone, the file list, the model — keeps working.
+ */
+export const CustomOpener: Story = {
+  render: (args) => ({
+    components: { FzUpload, FzIconButton },
+    setup() {
+      const files = ref<File[]>([])
+      return { files, args }
+    },
+    template: `
+      <FzUpload v-bind="args" v-model="files" multiple>
+        <template #opener="{ open }">
+          <FzIconButton
+            iconName="paperclip"
+            variant="secondary"
+            ariaLabel="Allega un documento"
+            @click="open"
+          />
+        </template>
+      </FzUpload>
+    `
+  }),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify the custom opener replaced the default button', async () => {
+      const trigger = canvas.getByRole('button', { name: /allega un documento/i })
+      await expect(trigger).toBeInTheDocument()
+      await expect(canvas.queryByRole('button', { name: /carica/i })).not.toBeInTheDocument()
+    })
+
+    await step('Verify the drop zone is still rendered', async () => {
+      const dropZone = canvasElement.querySelector('.border-dashed')
+      await expect(dropZone).toBeInTheDocument()
+      await expect(dropZone).toBeVisible()
+    })
+
+    await step('Verify the opener opens the component own input', async () => {
+      const input = canvasElement.querySelector('input[type="file"]') as HTMLInputElement
+      await expect(input).toBeInTheDocument()
+
+      let opened = false
+      input.addEventListener('click', (event) => {
+        event.preventDefault()
+        opened = true
+      })
+
+      const trigger = canvas.getByRole('button', { name: /allega un documento/i })
+      await userEvent.click(trigger)
+
+      await waitFor(() => expect(opened).toBe(true))
+    })
+
+    await step('Verify dropping a file still fills the list', async () => {
+      const dropZone = canvasElement.querySelector('.border-dashed') as HTMLElement
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(new File(['content'], 'opener-drop.txt', { type: 'text/plain' }))
+
+      dropZone.dispatchEvent(
+        new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer })
+      )
+
+      await waitFor(() => {
+        const fileLinks = canvas.getAllByText('opener-drop.txt')
+        expect(fileLinks.length).toBeGreaterThan(0)
+      })
     })
   }
 }

--- a/apps/storybook/src/stories/overlay/Tooltip.stories.ts
+++ b/apps/storybook/src/stories/overlay/Tooltip.stories.ts
@@ -459,8 +459,14 @@ export const TooltipBottomPosition: Story = {
 export const TooltipTopPosition: Story = {
   render: () => ({
     components: { FzTooltip, FzButton },
+    // More padding than the sibling stories on purpose. An upward tooltip needs
+    // room above the trigger, and `p-40` is 40px in this design system — less
+    // than the tooltip is tall. With too little room `applyBoundaryCorrections`
+    // relocates the tooltip to keep it on screen, it lands below the trigger,
+    // and the assertion below fails having measured the boundary behaviour
+    // instead of top positioning.
     template: `
-      <div class="p-40 flex items-center justify-center">
+      <div class="p-96 flex items-center justify-center">
         <FzTooltip position="top" text="Top tooltip">
           <FzButton data-testid="trigger-top">Top</FzButton>
         </FzTooltip>

--- a/packages/upload/src/FzUpload.vue
+++ b/packages/upload/src/FzUpload.vue
@@ -2,7 +2,7 @@
   <div :class="{ 'text-sm': size === 'sm', 'text-md': size === 'md' }">
     <div
       class="relative flex items-center gap-8 p-12 border-1 border-dashed rounded border-grey-300 bg-background-alice-blue"
-      @drop="handleDrop"
+      @drop="onDrop"
       @dragover="$event.preventDefault()"
     >
       <input
@@ -13,20 +13,22 @@
         :name
         :multiple
         :accept
-        @change="handleInputChange"
+        @change="onChange"
       />
-      <FzButton
-        ref="fzButton"
-        variant="secondary"
-        iconName="cloud-arrow-up"
-        iconPosition="before"
-        iconVariant="fas"
-        class="select-none"
-        :size
-        @click="input?.click()"
-      >
-        {{ buttonLabel }}
-      </FzButton>
+      <slot name="opener" :open>
+        <FzButton
+          ref="fzButton"
+          variant="secondary"
+          iconName="cloud-arrow-up"
+          iconPosition="before"
+          iconVariant="fas"
+          class="select-none"
+          :size
+          @click="open"
+        >
+          {{ buttonLabel }}
+        </FzButton>
+      </slot>
       {{ dragAndDropLabel }}
     </div>
 
@@ -60,7 +62,8 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
-import { FzUploadProps } from "./types";
+import { FzUploadProps, FzUploadSlots } from "./types";
+import { useFileSelect } from "./useFileSelect";
 import { FzButton, FzIconButton } from "@fiscozen/button";
 import { FzLink } from "@fiscozen/link";
 
@@ -76,6 +79,7 @@ const emit = defineEmits<{
   "fzupload:delete": [File];
   "fzupload:file-limit-exceeded": [files: File[]];
 }>();
+defineSlots<FzUploadSlots>();
 
 function modelSetter(value: File[]) {
   if (value.length > 1 && !props.multiple) {
@@ -93,6 +97,27 @@ const model = defineModel<File[]>({
 });
 
 const input = ref<HTMLInputElement | null>(null);
+
+/**
+ * The picker, the drop handling and the change handling all come from the
+ * composable, so the widget and a bare `useFileSelect` call behave identically.
+ * The input is passed in because this component renders its own — a caller that
+ * renders nothing gets one created for it.
+ */
+const { open, onChange, onDrop } = useFileSelect({
+  element: input,
+  multiple: () => props.multiple,
+  accept: () => props.accept,
+  onSelect: (files) => addFiles(files),
+});
+
+/**
+ * Imperative escape hatch, for a caller that holds a ref to this component. The
+ * `opener` slot is the declarative way in, and `useFileSelect` is the way to
+ * drive a picker with no widget at all.
+ */
+defineExpose({ open });
+
 const urlByFileMap = ref(new Map<File, string>());
 
 const computedScrollableContainerClass = computed(() => {
@@ -114,22 +139,6 @@ onUnmounted(() => {
     window.URL.revokeObjectURL(value);
   });
 });
-
-function handleDrop(event: DragEvent) {
-  event.preventDefault();
-  if (!event.dataTransfer) return;
-  const draggedFiles = [...event.dataTransfer?.items]
-    .filter((item) => item.kind === "file")
-    .map((item) => item.getAsFile())
-    .filter(Boolean) as File[];
-  addFiles(draggedFiles);
-}
-
-function handleInputChange(event: Event) {
-  if (!input.value?.files) return;
-  addFiles([...input.value.files]);
-  input.value.value = "";
-}
 
 function addFiles(filesToAdd: File[]) {
   let newFiles = [];

--- a/packages/upload/src/__tests__/FzUpload.spec.ts
+++ b/packages/upload/src/__tests__/FzUpload.spec.ts
@@ -791,6 +791,95 @@ describe('FzUpload', () => {
   // ============================================
   // SNAPSHOTS
   // ============================================
+  // ============================================
+  // OPENER SLOT AND EXPOSED API
+  // ============================================
+  describe('Opener slot', () => {
+    it('should pass open to the opener slot', async () => {
+      const wrapper = mount(FzUpload, {
+        slots: {
+          opener: `<template #opener="{ open }">
+            <button class="custom-opener" @click="open">Allega</button>
+          </template>`
+        }
+      })
+      const input = wrapper.find('input[type="file"]').element as HTMLInputElement
+      const clickSpy = vi.spyOn(input, 'click')
+
+      await wrapper.find('.custom-opener').trigger('click')
+
+      expect(clickSpy).toHaveBeenCalled()
+    })
+
+    it('should replace the default button when the slot is used', () => {
+      const wrapper = mount(FzUpload, {
+        slots: {
+          opener: '<button class="custom-opener">Allega</button>'
+        }
+      })
+
+      expect(wrapper.find('.custom-opener').exists()).toBe(true)
+      expect(wrapper.text()).not.toContain('Carica')
+    })
+
+    it('should render the default button when the slot is not used', () => {
+      const wrapper = mount(FzUpload)
+      const button = wrapper.findComponent({ name: 'FzButton' })
+
+      expect(button.exists()).toBe(true)
+      expect(button.text()).toContain('Carica')
+    })
+
+    it('should keep the drop zone working with a custom opener', async () => {
+      const wrapper = mount(FzUpload, {
+        slots: {
+          opener: '<button class="custom-opener">Allega</button>'
+        }
+      })
+      const file = new File(['content'], 'dropped.txt', { type: 'text/plain' })
+      const mockDragEvent = {
+        preventDefault: vi.fn(),
+        dataTransfer: {
+          items: [{ kind: 'file', getAsFile: () => file } as DataTransferItem]
+        }
+      } as unknown as DragEvent
+
+      await wrapper.find('.border-dashed').trigger('drop', mockDragEvent)
+
+      expect(wrapper.emitted('fzupload:add')![0][0]).toEqual([file])
+    })
+  })
+
+  describe('Exposed API', () => {
+    it('should expose open', () => {
+      const wrapper = mount(FzUpload)
+
+      expect(typeof (wrapper.vm as unknown as { open: () => void }).open).toBe('function')
+    })
+
+    it('should open the picker when open is called', () => {
+      const wrapper = mount(FzUpload)
+      const input = wrapper.find('input[type="file"]').element as HTMLInputElement
+      const clickSpy = vi.spyOn(input, 'click')
+
+      ;(wrapper.vm as unknown as { open: () => void }).open()
+
+      expect(clickSpy).toHaveBeenCalled()
+    })
+
+    it('should open the picker while the component is hidden', async () => {
+      const wrapper = mount(FzUpload, {
+        attrs: { style: 'display: none' }
+      })
+      const input = wrapper.find('input[type="file"]').element as HTMLInputElement
+      const clickSpy = vi.spyOn(input, 'click')
+
+      ;(wrapper.vm as unknown as { open: () => void }).open()
+
+      expect(clickSpy).toHaveBeenCalled()
+    })
+  })
+
   describe('Snapshots', () => {
     it('should match snapshot - default state', () => {
       const wrapper = mount(FzUpload)

--- a/packages/upload/src/__tests__/useFileSelect.spec.ts
+++ b/packages/upload/src/__tests__/useFileSelect.spec.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { defineComponent, effectScope, h, nextTick, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useFileSelect } from '..'
+
+const file = (name = 'test.txt') => new File(['content'], name, { type: 'text/plain' })
+
+const dragEvent = (items: Array<{ kind: string; file?: File }>) =>
+  ({
+    preventDefault: vi.fn(),
+    dataTransfer: {
+      items: items.map((item) => ({
+        kind: item.kind,
+        getAsFile: () => item.file ?? null
+      }))
+    }
+  }) as unknown as DragEvent
+
+/** Mounts a component that only exists to give the composable an owner scope. */
+const mountWith = (options: Parameters<typeof useFileSelect>[0]) => {
+  let api: ReturnType<typeof useFileSelect>
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        api = useFileSelect(options)
+        return () => h('div')
+      }
+    })
+  )
+  return { wrapper, api: api! }
+}
+
+const ownedInputs = () =>
+  [...document.body.querySelectorAll('input[type="file"]')] as HTMLInputElement[]
+
+describe('useFileSelect', () => {
+  afterEach(() => {
+    ownedInputs().forEach((input) => input.remove())
+    vi.restoreAllMocks()
+  })
+
+  // ============================================
+  // OWNED INPUT — nothing rendered by the caller
+  // ============================================
+  describe('with no element provided', () => {
+    it('should open the picker without anything being rendered', () => {
+      const { api } = mountWith({ onSelect: vi.fn() })
+
+      expect(ownedInputs()).toHaveLength(0)
+
+      const clicks: HTMLInputElement[] = []
+      const clickSpy = vi
+        .spyOn(HTMLInputElement.prototype, 'click')
+        .mockImplementation(function (this: HTMLInputElement) {
+          clicks.push(this)
+        })
+
+      api.open()
+
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(clicks[0].type).toBe('file')
+    })
+
+    it('should create the input lazily and reuse it across opens', () => {
+      const { api } = mountWith({ onSelect: vi.fn() })
+      vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+
+      expect(ownedInputs()).toHaveLength(0)
+      api.open()
+      api.open()
+      api.open()
+      expect(ownedInputs()).toHaveLength(1)
+    })
+
+    it('should read multiple and accept on every open', () => {
+      const multiple = ref(false)
+      const accept = ref('image/png')
+      const { api } = mountWith({ onSelect: vi.fn(), multiple, accept })
+      vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+
+      api.open()
+      expect(ownedInputs()[0].multiple).toBe(false)
+      expect(ownedInputs()[0].accept).toBe('image/png')
+
+      multiple.value = true
+      accept.value = 'application/pdf'
+      api.open()
+
+      expect(ownedInputs()[0].multiple).toBe(true)
+      expect(ownedInputs()[0].accept).toBe('application/pdf')
+    })
+
+    it('should accept getters for multiple and accept', () => {
+      const { api } = mountWith({
+        onSelect: vi.fn(),
+        multiple: () => true,
+        accept: () => 'image/*'
+      })
+      vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+
+      api.open()
+
+      expect(ownedInputs()[0].multiple).toBe(true)
+      expect(ownedInputs()[0].accept).toBe('image/*')
+    })
+
+    it('should call onSelect when the owned input reports a selection', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+      vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+      api.open()
+
+      const input = ownedInputs()[0]
+      const picked = file()
+      Object.defineProperty(input, 'files', { value: [picked], writable: false })
+      input.dispatchEvent(new Event('change'))
+
+      expect(onSelect).toHaveBeenCalledWith([picked])
+    })
+
+    it('should remove the owned input when the scope is disposed', () => {
+      const { wrapper, api } = mountWith({ onSelect: vi.fn() })
+      vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+      api.open()
+      expect(ownedInputs()).toHaveLength(1)
+
+      wrapper.unmount()
+
+      expect(ownedInputs()).toHaveLength(0)
+    })
+
+    it('should not register a dispose hook outside of a scope', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const api = useFileSelect({ onSelect: vi.fn() })
+
+      expect(warn).not.toHaveBeenCalled()
+      expect(typeof api.open).toBe('function')
+    })
+
+    it('should be disposable from a bare effect scope', () => {
+      const scope = effectScope()
+      let api: ReturnType<typeof useFileSelect>
+      scope.run(() => {
+        api = useFileSelect({ onSelect: vi.fn() })
+      })
+      vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(() => {})
+      api!.open()
+      expect(ownedInputs()).toHaveLength(1)
+
+      scope.stop()
+
+      expect(ownedInputs()).toHaveLength(0)
+    })
+  })
+
+  // ============================================
+  // PROVIDED INPUT — the caller renders its own
+  // ============================================
+  describe('with an element provided', () => {
+    it('should click the provided input instead of creating one', () => {
+      const provided = document.createElement('input')
+      provided.type = 'file'
+      const clickSpy = vi.spyOn(provided, 'click').mockImplementation(() => {})
+      const { api } = mountWith({ onSelect: vi.fn(), element: ref(provided) })
+
+      api.open()
+
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(ownedInputs()).toHaveLength(0)
+    })
+
+    it('should leave multiple and accept on the provided input alone', () => {
+      const provided = document.createElement('input')
+      provided.type = 'file'
+      provided.multiple = true
+      provided.accept = 'image/png'
+      vi.spyOn(provided, 'click').mockImplementation(() => {})
+      const { api } = mountWith({
+        onSelect: vi.fn(),
+        element: ref(provided),
+        multiple: false,
+        accept: 'application/pdf'
+      })
+
+      api.open()
+
+      expect(provided.multiple).toBe(true)
+      expect(provided.accept).toBe('image/png')
+    })
+
+    it('should fall back to an owned input while the ref is still null', async () => {
+      const element = ref<HTMLInputElement | null>(null)
+      const provided = document.createElement('input')
+      provided.type = 'file'
+      const clicked: string[] = []
+      vi.spyOn(HTMLInputElement.prototype, 'click').mockImplementation(function (
+        this: HTMLInputElement
+      ) {
+        clicked.push(this === provided ? 'provided' : 'owned')
+      })
+      const { api } = mountWith({ onSelect: vi.fn(), element })
+
+      api.open()
+      expect(ownedInputs()).toHaveLength(1)
+      expect(clicked).toEqual(['owned'])
+
+      element.value = provided
+      await nextTick()
+      api.open()
+
+      expect(clicked).toEqual(['owned', 'provided'])
+    })
+  })
+
+  // ============================================
+  // CHANGE HANDLING
+  // ============================================
+  describe('onChange', () => {
+    it('should call onSelect with the selected files', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+      const input = document.createElement('input')
+      input.type = 'file'
+      const picked = [file('a.txt'), file('b.txt')]
+      Object.defineProperty(input, 'files', { value: picked, writable: false })
+
+      api.onChange({ target: input } as unknown as Event)
+
+      expect(onSelect).toHaveBeenCalledWith(picked)
+    })
+
+    it('should reset the input value so the same file can be picked twice', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+      const input = document.createElement('input')
+      input.type = 'file'
+      Object.defineProperty(input, 'files', { value: [file()], writable: false })
+
+      api.onChange({ target: input } as unknown as Event)
+
+      expect(input.value).toBe('')
+    })
+
+    it('should not call onSelect when the selection is empty', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+      const input = document.createElement('input')
+      input.type = 'file'
+      Object.defineProperty(input, 'files', { value: [], writable: false })
+
+      api.onChange({ target: input } as unknown as Event)
+
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it('should ignore an event with no file input behind it', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+
+      expect(() => api.onChange({ target: null } as unknown as Event)).not.toThrow()
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+  })
+
+  // ============================================
+  // DROP HANDLING
+  // ============================================
+  describe('onDrop', () => {
+    it('should call onSelect with the dropped files', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+      const dropped = file('dropped.txt')
+
+      api.onDrop(dragEvent([{ kind: 'file', file: dropped }]))
+
+      expect(onSelect).toHaveBeenCalledWith([dropped])
+    })
+
+    it('should prevent the default so the browser does not navigate', () => {
+      const { api } = mountWith({ onSelect: vi.fn() })
+      const event = dragEvent([{ kind: 'file', file: file() }])
+
+      api.onDrop(event)
+
+      expect(event.preventDefault).toHaveBeenCalled()
+    })
+
+    it('should keep only items of kind file', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+      const dropped = file('kept.txt')
+
+      api.onDrop(
+        dragEvent([
+          { kind: 'string' },
+          { kind: 'file', file: dropped },
+          { kind: 'string' }
+        ])
+      )
+
+      expect(onSelect).toHaveBeenCalledWith([dropped])
+    })
+
+    it('should drop items that resolve to no file', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+
+      api.onDrop(dragEvent([{ kind: 'file' }]))
+
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it('should not call onSelect when nothing was dropped', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+
+      api.onDrop(dragEvent([]))
+
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+
+    it('should ignore a drag event with no dataTransfer', () => {
+      const onSelect = vi.fn()
+      const { api } = mountWith({ onSelect })
+      const event = { preventDefault: vi.fn(), dataTransfer: null } as unknown as DragEvent
+
+      expect(() => api.onDrop(event)).not.toThrow()
+      expect(onSelect).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/upload/src/index.ts
+++ b/packages/upload/src/index.ts
@@ -1,2 +1,3 @@
 export { default as FzUpload } from "./FzUpload.vue";
+export { useFileSelect } from "./useFileSelect";
 export type * from "./types";

--- a/packages/upload/src/types.ts
+++ b/packages/upload/src/types.ts
@@ -1,3 +1,5 @@
+import type { MaybeRefOrGetter, VNode } from "vue";
+
 type FzUploadProps = {
   /** Unique identifier of the input */
   id?: string;
@@ -19,4 +21,54 @@ type FzUploadProps = {
   isScrollable?: boolean;
 };
 
-export { FzUploadProps };
+type FzUploadSlots = {
+  /**
+   * Use this to replace the button that opens the file picker. Call `open` to
+   * open it; the drop zone around the slot keeps working either way.
+   *
+   * When the trigger cannot live inside the component at all — an icon-only
+   * control elsewhere in a toolbar, say — reach for `useFileSelect` instead of
+   * rendering a hidden `FzUpload`.
+   */
+  opener(props: { open: () => void }): VNode | VNode[];
+};
+
+type UseFileSelectOptions = {
+  /**
+   * Called with the files the user picked or dropped. Never called with an
+   * empty list.
+   */
+  onSelect: (files: File[]) => void;
+  /** Whether the picker accepts more than one file. Re-read on every `open()`. */
+  multiple?: MaybeRefOrGetter<boolean | undefined>;
+  /**
+   * Pattern that dictates what files the picker accepts. Re-read on every
+   * `open()`.
+   */
+  accept?: MaybeRefOrGetter<string | undefined>;
+  /**
+   * An `input type="file"` the caller already renders, if there is one. Leave it
+   * out and the composable creates and owns a detached input, which is what lets
+   * `open()` work with no visible affordance at all.
+   *
+   * When it is provided, `multiple` and `accept` are the caller's business —
+   * they are bound in the caller's template, so `open()` does not touch them.
+   */
+  element?: MaybeRefOrGetter<HTMLInputElement | null | undefined>;
+};
+
+type UseFileSelectReturn = {
+  /** Opens the operating system file picker. */
+  open: () => void;
+  /** `change` handler for a caller-rendered input: `@change="onChange"`. */
+  onChange: (event: Event) => void;
+  /** `drop` handler for a drop target. Pair it with `@dragover.prevent`. */
+  onDrop: (event: DragEvent) => void;
+};
+
+export {
+  FzUploadProps,
+  FzUploadSlots,
+  UseFileSelectOptions,
+  UseFileSelectReturn,
+};

--- a/packages/upload/src/useFileSelect.ts
+++ b/packages/upload/src/useFileSelect.ts
@@ -1,0 +1,94 @@
+import { getCurrentScope, onScopeDispose, toValue } from "vue";
+import { UseFileSelectOptions, UseFileSelectReturn } from "./types";
+
+/**
+ * File selection without the widget.
+ *
+ * `open()` shows the operating system file picker, `onDrop()` reads files off a
+ * drag event, and both hand what they got to `onSelect`. `FzUpload` is built on
+ * this; so is any control that needs to pick files without the dashed drop zone
+ * — an icon-only clip in a chat composer, say.
+ *
+ * Nothing has to be rendered for `open()` to work. With no `element` passed the
+ * composable creates and owns its own input, so a caller needs neither a hidden
+ * `FzUpload` to host the behaviour nor a template ref to reach into it.
+ *
+ * @example An icon-only trigger, no upload widget in sight.
+ * ```ts
+ * const { open } = useFileSelect({
+ *   multiple: true,
+ *   accept: () => props.accept,
+ *   onSelect: (files) => emit('attach', files)
+ * })
+ * ```
+ * ```vue
+ * <FzIconButton icon-name="paperclip" @click="open" />
+ * ```
+ */
+function useFileSelect(options: UseFileSelectOptions): UseFileSelectReturn {
+  /** Created by the first `open()` that needs it, never before. */
+  let ownedInput: HTMLInputElement | null = null;
+
+  function onChange(event: Event) {
+    const input = event.target as HTMLInputElement | null;
+    if (!input?.files) return;
+    const files = [...input.files];
+    // Reset before handing the files on: without this, picking the same file
+    // twice in a row fires no second `change`.
+    input.value = "";
+    if (files.length) options.onSelect(files);
+  }
+
+  function ownInput() {
+    if (ownedInput) return ownedInput;
+    if (typeof document === "undefined") return null;
+    const input = document.createElement("input");
+    input.type = "file";
+    input.hidden = true;
+    input.addEventListener("change", onChange);
+    // Appended rather than left detached: Safari will not open the picker for an
+    // input that is not connected to the document. This is the only place in the
+    // package that touches the DOM directly, and it is undone on scope dispose.
+    document.body.appendChild(input);
+    ownedInput = input;
+    return ownedInput;
+  }
+
+  function open() {
+    const provided = toValue(options.element);
+    if (provided) {
+      // The caller renders it, so the caller binds `multiple` and `accept` too.
+      provided.click();
+      return;
+    }
+    const input = ownInput();
+    if (!input) return;
+    // Re-read on every open, so a picker configured from props or a ref stays
+    // in step with them.
+    input.multiple = Boolean(toValue(options.multiple));
+    input.accept = toValue(options.accept) ?? "";
+    input.click();
+  }
+
+  function onDrop(event: DragEvent) {
+    event.preventDefault();
+    if (!event.dataTransfer) return;
+    const files = [...event.dataTransfer.items]
+      .filter((item) => item.kind === "file")
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => Boolean(file));
+    if (files.length) options.onSelect(files);
+  }
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      ownedInput?.removeEventListener("change", onChange);
+      ownedInput?.remove();
+      ownedInput = null;
+    });
+  }
+
+  return { open, onChange, onDrop };
+}
+
+export { useFileSelect };


### PR DESCRIPTION
Jira: [LIB-2926](https://fiscozen.atlassian.net/browse/LIB-2926)

> **Stacked on #439.** Base is `fix/LIB-2929-tooltip-top-headroom`, so the diff here is only the upload work. GitHub will retarget this PR to `main` automatically once #439 merges. #439 is a one-line Storybook fix that unblocks the pre-push gate for the whole repo.

## The problem

`FzUpload` welded the *behaviour* of picking files to the *presentation* of picking files: a hidden `input type="file"` and its own `FzButton` inside a dashed drop zone, neither exposed.

A control that needed the picker without the widget had exactly one road — the one `FzpChatComposerBar` in `@fzp/customers` takes today:

```vue
<FzUpload ref="upload" v-model="picked" multiple :accept class="hidden" @fzupload:add="onFiles" />
```

Render it hidden, bind a `v-model` only to drain it (otherwise the hidden `<ul>` mints object URLs for files nobody will see), and reach the input through the component's root element. That is a dependency on private DOM.

The card originally proposed `defineExpose({ open })`. That legalises the reach-in but leaves the smell: a `display: none` component rendered purely to host a behaviour, plus a model that has to be manually drained. So this goes a layer down instead.

## `useFileSelect`

The file-selection behaviour on its own — `open()`, `onChange`, `onDrop`:

```ts
const { open } = useFileSelect({
  multiple: true,
  accept: () => props.accept,
  onSelect: (files) => emit('attach', files)
})
```
```vue
<FzIconButton icon-name="paperclip" @click="open" />
```

**Nothing has to be rendered for that to work.** With no `element` passed, the composable creates and owns its own input, so there is no hidden component to mount, no model to drain, and no template ref to null-check. Consequences worth naming:

- The card's "must work while the component is `display: none`" constraint **disappears** rather than being tested around.
- Because the input comes from design-system code, a consumer bound by a lint rule against raw `<input>` stays inside it.
- Any layer that needs "pick files" gets it without rendering an upload widget.

`document.body.appendChild` is confined to `useFileSelect.ts` (`hidden`, removed on `onScopeDispose`). It is appended rather than left detached because Safari will not open the picker for an input that is not connected to the document.

`FzUpload` is now built on the same composable, so the widget and a bare `useFileSelect` call cannot drift apart.

## Two smaller additions, for when the widget itself is still right

- **`opener` slot**, receiving `open` — the same shape as `FzDropdown`'s. The drop zone, the file list and the model keep working around it.
- **`defineExpose({ open })`** — the imperative way in, matching `FzDialog`/`FzDropdown` house style.

## One behaviour changes

An empty selection no longer reaches the model. Dropping a drag event carrying no files used to emit `fzupload:add`/`fzupload:change`, and with `multiple: false` it pushed `[undefined]` into the model — a limitation the spec documented rather than fixed. The existing test accepts either behaviour and passes unchanged. It is called out in the changeset.

## Verification

- **86 unit tests** pass (79 → 86): new `useFileSelect.spec.ts` with 21 cases, plus 7 covering the `opener` slot and the exposed API including the `display: none` case.
- **Both snapshots untouched** — that is the evidence `FzUpload`'s rendered output is byte-identical.
- **Coverage:** `useFileSelect.ts` 95/90/100/100, `FzUpload.vue` 92/82/85/94 — both over threshold.
- **Two new stories** exercised in a real browser: `ComposableTrigger` (paperclip + composable, no widget) and `CustomOpener` (widget kept, button swapped). Full Storybook suite 746 passed, 0 failed.
- Pushed through the complete pre-push gate, no checks skipped.

## Follow-up, not in this PR

Removing the workaround in `fiscozen-frontend-library` — drop the hidden `FzUpload`, the `picked` model and the 20-line module comment in favour of three lines of `useFileSelect`. It needs its own card there, and it is not urgent: `defineExpose` narrows the exposed proxy but `$el` stays reachable, so the current workaround does not break when 1.1.0 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-2926]: https://fiscozen.atlassian.net/browse/LIB-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ