### PR TITLE
feat(textarea): bare variant for single-line composer bars (LIB-2927)

### DIFF
--- a/.changeset/nine-mice-compose.md
+++ b/.changeset/nine-mice-compose.md
@@ -5,9 +5,14 @@
 feat(textarea): add a `bare` variant for single-line composer bars (LIB-2927)
 
 `variant="bare"` turns off every box-drawing declaration the component owns — border, background,
-padding, radius, minimum height and minimum width — so the container around the field becomes the
-visible field. Everything else is unchanged: label, help text, error ARIA, `autoHeight` and
-`maxRows`, which now also hold with zero padding.
+padding, radius, minimum height and minimum width — and declares no font size, so the container
+around the field becomes the visible field and owns the type: a `text-sm` on the box carries the
+field and anything else inside it on one scale. Everything else is unchanged: label, help text,
+error ARIA, `autoHeight` and `maxRows`, which now also hold with zero padding.
+
+`maxRows` also gained a fallback for a line height that computes to `normal` (possible now that the
+bare field inherits its type): the ceiling uses the browser's ~1.2 ratio instead of going unbounded.
+The default variant, with its fixed `text-base`, was never exposed to that.
 
 Two defaults shift with the variant so a composer bar starts in the right shape: `rows` is `1` and
 `resize` is `'none'`. The focus cue is replaced rather than removed — with no border to recolour, the

--- a/.changeset/nine-mice-compose.md
+++ b/.changeset/nine-mice-compose.md
@@ -1,0 +1,16 @@
+---
+'@fiscozen/textarea': minor
+---
+
+feat(textarea): add a `bare` variant for single-line composer bars (LIB-2927)
+
+`variant="bare"` turns off every box-drawing declaration the component owns — border, background,
+padding, radius, minimum height and minimum width — so the container around the field becomes the
+visible field. Everything else is unchanged: label, help text, error ARIA, `autoHeight` and
+`maxRows`, which now also hold with zero padding.
+
+Two defaults shift with the variant so a composer bar starts in the right shape: `rows` is `1` and
+`resize` is `'none'`. The focus cue is replaced rather than removed — with no border to recolour, the
+bare field draws a 2px `blue-600` `focus-visible` outline on itself.
+
+The default variant is untouched, visually and behaviourally.

--- a/apps/storybook/src/FzTextarea.mdx
+++ b/apps/storybook/src/FzTextarea.mdx
@@ -9,8 +9,9 @@ Multi-line text input component with label, validation states, resize control, a
 ## Features
 
 - Resize control (none, vertical, horizontal, all)
-- `bare` variant: no box of its own (no border, background, padding or minimum height), so a
-  container drawn by the caller becomes the visible field — the shape a single-line composer bar needs
+- `bare` variant: no box of its own (no border, background, padding or minimum height) and no font
+  size, so a container drawn by the caller becomes the visible field and owns the type — the shape a
+  single-line composer bar needs
 - Auto-height mode: textarea grows/shrinks with content, optional max-row cap
 - Error and valid states with visual feedback
 - Error messages via FzAlert component (circle-xmark icon, consistent with FzInput)
@@ -454,9 +455,9 @@ With `flex-col justify-end`, the textarea sits at the bottom of the container. A
 ## Bare Variant (composer bars)
 
 `variant="bare"` turns off everything the component draws around the text: border, background,
-padding, corner radius, minimum height and minimum width. What stays is the field itself — the
-label, the help text, the error ARIA, `autoHeight`, `maxRows` and every native attribute forwarded
-through `$attrs`.
+padding, corner radius, minimum height, minimum width — and the font size. What stays is the field
+itself — the label, the help text, the error ARIA, `autoHeight`, `maxRows` and every native
+attribute forwarded through `$attrs`.
 
 Use it whenever the box is already drawn by something else: a composer bar, a toolbar, a cell, an
 inline editor. Before this variant existed, the only way to get that shape was to re-declare the
@@ -471,10 +472,10 @@ const draft = ref('')
 </script>
 
 <template>
-  <!-- The container is the visible field: it owns the background, the padding
-       and the radius. The textarea only carries the text, and the counter can
-       sit inside the same box. -->
-  <div class="flex min-h-[44px] flex-col justify-end gap-4 rounded bg-grey-100 px-10 py-8">
+  <!-- The container is the visible field: it owns the background, the padding,
+       the radius and the type. The textarea only carries the text, and the
+       counter sits inside the same box on the same scale. -->
+  <div class="flex min-h-[44px] flex-col justify-end gap-4 rounded bg-grey-100 px-10 py-8 text-sm leading-5">
     <FzTextarea
       v-model="draft"
       variant="bare"
@@ -484,7 +485,7 @@ const draft = ref('')
       placeholder="Scrivi un messaggio..."
       aria-label="Scrivi un messaggio"
     />
-    <p class="self-end text-sm text-grey-500">{{ draft.length }}/200</p>
+    <p class="self-end text-grey-500">{{ draft.length }}/200</p>
   </div>
 </template>
 ```
@@ -494,9 +495,14 @@ Notes:
 - **Defaults shift with the variant.** `rows` defaults to `1` and `resize` to `'none'`, so the field
   starts on a single line and no resize grabber breaks the container's shape. Both can still be set
   explicitly.
+- **Type is inherited, not declared.** The bare field sets no font size, so `text-sm leading-5` on
+  the box carries the field and everything else in it on one scale. (Tailwind's preflight gives a
+  `textarea` `font-size: 100%` and `line-height: inherit`, which is what makes this work.) The
+  default variant keeps its fixed `text-base`.
 - **`autoHeight` + `maxRows` work unchanged.** The ceiling is measured from the live line height and
   padding, which is simply zero here: with `maxRows="6"` and a 20px line height the field stops at
-  120px and starts scrolling.
+  120px and starts scrolling. If the inherited line height computes to `normal`, the ceiling falls
+  back to the browser's ~1.2 ratio rather than going unbounded.
 - **The error state has no border to colour.** `error` still drives `aria-invalid` and the
   `errorMessage` slot, and the text turns grey when disabled or readonly, but any visual error
   affordance on the box is the caller's to draw (the composer in the chat widget, for instance, puts
@@ -529,7 +535,7 @@ FzTextarea meets WCAG 2.1 AA standards:
 - Use `autoHeight` with `maxRows` when the textarea should grow with content but stay bounded
 - Prefer `autoHeight` over manual resize for a smoother user experience in forms
 - Use `maxlength` to enforce content limits
-- Reach for `variant="bare"` instead of overriding the component's box from the outside; keep the label or an `aria-label` even when the design has no visible label
+- Reach for `variant="bare"` instead of overriding the component's box from the outside; set the type on the container rather than on the field, and keep the label or an `aria-label` even when the design has no visible label
 - When showing pre-filled disabled fields, ensure the value conveys why the field is locked
 
 ## Related Components

--- a/apps/storybook/src/FzTextarea.mdx
+++ b/apps/storybook/src/FzTextarea.mdx
@@ -9,6 +9,8 @@ Multi-line text input component with label, validation states, resize control, a
 ## Features
 
 - Resize control (none, vertical, horizontal, all)
+- `bare` variant: no box of its own (no border, background, padding or minimum height), so a
+  container drawn by the caller becomes the visible field — the shape a single-line composer bar needs
 - Auto-height mode: textarea grows/shrinks with content, optional max-row cap
 - Error and valid states with visual feedback
 - Error messages via FzAlert component (circle-xmark icon, consistent with FzInput)
@@ -116,15 +118,21 @@ const notes = ref('')
       <td>Shows success checkmark icon</td>
     </tr>
     <tr>
+      <td><code>variant</code></td>
+      <td><code>'default' | 'bare'</code></td>
+      <td><code>'default'</code></td>
+      <td>Visual variant. <code>default</code> draws the field (border, background, padding, 77px minimum height); <code>bare</code> draws no box at all, leaving it to the surrounding container. See <a href="#bare-variant-composer-bars">Bare Variant</a>.</td>
+    </tr>
+    <tr>
       <td><code>resize</code></td>
       <td><code>'none' | 'vertical' | 'horizontal' | 'all'</code></td>
-      <td><code>'all'</code></td>
+      <td><code>'all'</code> (<code>'none'</code> when <code>variant="bare"</code>)</td>
       <td>Controls resize behavior of the textarea</td>
     </tr>
     <tr>
       <td><code>rows</code></td>
       <td><code>number</code></td>
-      <td><code>2</code></td>
+      <td><code>2</code> (<code>1</code> when <code>variant="bare"</code>)</td>
       <td>Number of visible text rows</td>
     </tr>
     <tr>
@@ -443,11 +451,64 @@ With `flex-col justify-end`, the textarea sits at the bottom of the container. A
 - `autoHeight` must be set at mount time. Changing it at runtime is not supported.
 - When `autoHeight` is enabled and the textarea has pre-filled content (via `v-model`), the height is adjusted on mount.
 
+## Bare Variant (composer bars)
+
+`variant="bare"` turns off everything the component draws around the text: border, background,
+padding, corner radius, minimum height and minimum width. What stays is the field itself — the
+label, the help text, the error ARIA, `autoHeight`, `maxRows` and every native attribute forwarded
+through `$attrs`.
+
+Use it whenever the box is already drawn by something else: a composer bar, a toolbar, a cell, an
+inline editor. Before this variant existed, the only way to get that shape was to re-declare the
+component's own styling from the outside with `!`-important utilities.
+
+```vue
+<script setup>
+import { FzTextarea } from '@fiscozen/textarea'
+import { ref } from 'vue'
+
+const draft = ref('')
+</script>
+
+<template>
+  <!-- The container is the visible field: it owns the background, the padding
+       and the radius. The textarea only carries the text, and the counter can
+       sit inside the same box. -->
+  <div class="flex min-h-[44px] flex-col justify-end gap-4 rounded bg-grey-100 px-10 py-8">
+    <FzTextarea
+      v-model="draft"
+      variant="bare"
+      auto-height
+      :max-rows="6"
+      :maxlength="200"
+      placeholder="Scrivi un messaggio..."
+      aria-label="Scrivi un messaggio"
+    />
+    <p class="self-end text-sm text-grey-500">{{ draft.length }}/200</p>
+  </div>
+</template>
+```
+
+Notes:
+
+- **Defaults shift with the variant.** `rows` defaults to `1` and `resize` to `'none'`, so the field
+  starts on a single line and no resize grabber breaks the container's shape. Both can still be set
+  explicitly.
+- **`autoHeight` + `maxRows` work unchanged.** The ceiling is measured from the live line height and
+  padding, which is simply zero here: with `maxRows="6"` and a 20px line height the field stops at
+  120px and starts scrolling.
+- **The error state has no border to colour.** `error` still drives `aria-invalid` and the
+  `errorMessage` slot, and the text turns grey when disabled or readonly, but any visual error
+  affordance on the box is the caller's to draw (the composer in the chat widget, for instance, puts
+  the message above the bar).
+- **Focus stays visible.** See below.
+
 ## Accessibility
 
 FzTextarea meets WCAG 2.1 AA standards:
 
 - **Focus indicator**: Custom blue border (`blue-600`) on focus replaces browser default outline. Error state maintains error border color on focus (`semantic-error-300`).
+- **Focus indicator in the `bare` variant**: with no border to recolour, the cue is *replaced*, not removed — a 2px `blue-600` `focus-visible` outline is drawn on the field itself. If your container draws its own focus treatment (e.g. `focus-within:` on the box) you can suppress it with `!focus-visible:outline-none`, but only ever in exchange for another visible indicator: dropping it outright fails WCAG 2.4.7.
 - **ARIA attributes**: `aria-required`, `aria-invalid`, `aria-disabled` always present with string values ("true"/"false") for screen reader compatibility
 - **aria-describedby**: Links textarea to error or help message when present
 - **role="alert"**: Error messages are announced immediately by screen readers
@@ -468,6 +529,7 @@ FzTextarea meets WCAG 2.1 AA standards:
 - Use `autoHeight` with `maxRows` when the textarea should grow with content but stay bounded
 - Prefer `autoHeight` over manual resize for a smoother user experience in forms
 - Use `maxlength` to enforce content limits
+- Reach for `variant="bare"` instead of overriding the component's box from the outside; keep the label or an `aria-label` even when the design has no visible label
 - When showing pre-filled disabled fields, ensure the value conveys why the field is locked
 
 ## Related Components

--- a/apps/storybook/src/stories/form/Textarea.stories.ts
+++ b/apps/storybook/src/stories/form/Textarea.stories.ts
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite'
-import { expect, fn, userEvent, within } from 'storybook/test'
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test'
+import { FzIconButton } from '@fiscozen/button'
+import { FzContainer } from '@fiscozen/container'
 import { FzTextarea } from '@fiscozen/textarea'
 import { ref } from 'vue'
 
@@ -17,6 +19,10 @@ const meta = {
     resize: {
       control: 'select',
       options: ['none', 'vertical', 'horizontal', 'all']
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'bare']
     }
   },
   args: {
@@ -647,9 +653,117 @@ const AutoHeightBottomAnchored: TextareaStory = {
   }
 }
 
+
+/**
+ * The bare variant in the shape it was asked for: a single-line composer bar
+ * where the visible field is the box around the textarea, and the character
+ * counter lives inside that same box.
+ *
+ * The box carries Tailwind classes deliberately. In the consuming apps a
+ * composer bar is a molecule — the layer where `class` is allowed — and
+ * FzContainer has no props for background, padding or radius. That is the whole
+ * point of the variant: the field brings no box of its own, so the caller draws
+ * one and the field only carries the text.
+ */
+const BareComposerBar: TextareaStory = {
+  args: {
+    id: 'bare-composer',
+    label: '',
+    variant: 'bare',
+    autoHeight: true,
+    maxRows: 6,
+    maxlength: 200,
+    placeholder: 'Scrivi un messaggio...',
+    'onUpdate:modelValue': fn()
+  },
+  render: (args) => ({
+    components: { FzTextarea, FzContainer, FzIconButton },
+    setup() {
+      const value = ref('')
+      return { args, value }
+    },
+    template: `
+      <FzContainer horizontal gap="xs" align-items="end">
+        <FzIconButton
+          icon-name="paperclip"
+          variant="invisible"
+          environment="frontoffice"
+          aria-label="Allega un documento"
+        />
+        <FzContainer
+          gap="none"
+          align-items="stretch"
+          class="min-h-[44px] w-[420px] justify-end gap-4 rounded bg-grey-100 px-10 py-8"
+        >
+          <FzTextarea
+            v-bind="args"
+            :modelValue="value"
+            aria-label="Scrivi un messaggio"
+            @update:modelValue="args['onUpdate:modelValue']($event); value = $event"
+          />
+          <p class="self-end text-sm text-grey-500">{{ value.length }}/{{ args.maxlength }}</p>
+        </FzContainer>
+        <FzIconButton
+          icon-name="paper-plane"
+          variant="primary"
+          environment="frontoffice"
+          aria-label="Invia il messaggio"
+          :disabled="!value.length"
+        />
+      </FzContainer>
+    `
+  }),
+  play: async ({ args, canvasElement, step }: PlayFunctionContext) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify the field starts on a single line with no box of its own', async () => {
+      const textarea = canvas.getByLabelText(/Scrivi un messaggio/i)
+      await expect(textarea).toBeVisible()
+      await expect(textarea).toHaveAttribute('rows', '1')
+      await expect(textarea).not.toHaveClass('min-h-[77px]')
+      await expect(textarea).not.toHaveClass('border-1')
+      await expect(textarea).toHaveClass('bg-transparent')
+    })
+
+    await step('Verify focus stays visible without a border to recolour', async () => {
+      const textarea = canvas.getByLabelText(/Scrivi un messaggio/i)
+      await expect(textarea).toHaveClass('focus-visible:outline')
+      await expect(textarea).toHaveClass('focus-visible:outline-blue-600')
+    })
+
+    await step('Verify no label is rendered inside the composer', async () => {
+      await expect(canvasElement.querySelector('label')).toBeNull()
+    })
+
+    await step('Verify typing updates the model and the counter in the same box', async () => {
+      const textarea = canvas.getByLabelText(/Scrivi un messaggio/i) as HTMLTextAreaElement
+      await userEvent.type(textarea, 'Ciao')
+      await expect(args['onUpdate:modelValue']).toHaveBeenCalled()
+      await waitFor(async () => {
+        await expect(canvas.getByText('4/200')).toBeVisible()
+      })
+    })
+
+    await step('Verify the field grows with its content up to maxRows', async () => {
+      const textarea = canvas.getByLabelText(/Scrivi un messaggio/i) as HTMLTextAreaElement
+      const singleLineHeight = textarea.offsetHeight
+      await userEvent.type(textarea, '{Enter}Seconda riga')
+      await waitFor(async () => {
+        await expect(textarea.offsetHeight).toBeGreaterThan(singleLineHeight)
+      })
+    })
+
+    await step('Verify the send control unlocks once there is a draft', async () => {
+      const send = canvas.getByRole('button', { name: /Invia il messaggio/i })
+      await expect(send).toBeEnabled()
+    })
+  }
+}
+
 export {
   Default, Error, Help, Valid, Required, Disabled, Readonly,
   ErrorWithValue, ValidWithValue, DisabledWithValue,
   HelpDisabled, RequiredWithHelp, ErrorWithHelpOnly,
-  AutoHeight, AutoHeightWithMaxRows, AutoHeightBottomAnchored
+  AutoHeight, AutoHeightWithMaxRows, AutoHeightBottomAnchored,
+  BareComposerBar
 }

--- a/apps/storybook/src/stories/form/Textarea.stories.ts
+++ b/apps/storybook/src/stories/form/Textarea.stories.ts
@@ -664,6 +664,9 @@ const AutoHeightBottomAnchored: TextareaStory = {
  * FzContainer has no props for background, padding or radius. That is the whole
  * point of the variant: the field brings no box of its own, so the caller draws
  * one and the field only carries the text.
+ *
+ * Type is set once, on the box (`text-sm leading-5`), and both the field and the
+ * counter inherit it — the bare variant declares no font size of its own.
  */
 const BareComposerBar: TextareaStory = {
   args: {
@@ -693,7 +696,7 @@ const BareComposerBar: TextareaStory = {
         <FzContainer
           gap="none"
           align-items="stretch"
-          class="min-h-[44px] w-[420px] justify-end gap-4 rounded bg-grey-100 px-10 py-8"
+          class="min-h-[44px] w-[420px] justify-end gap-4 rounded bg-grey-100 px-10 py-8 text-sm leading-5"
         >
           <FzTextarea
             v-bind="args"
@@ -701,7 +704,7 @@ const BareComposerBar: TextareaStory = {
             aria-label="Scrivi un messaggio"
             @update:modelValue="args['onUpdate:modelValue']($event); value = $event"
           />
-          <p class="self-end text-sm text-grey-500">{{ value.length }}/{{ args.maxlength }}</p>
+          <p class="self-end text-grey-500">{{ value.length }}/{{ args.maxlength }}</p>
         </FzContainer>
         <FzIconButton
           icon-name="paper-plane"
@@ -723,6 +726,14 @@ const BareComposerBar: TextareaStory = {
       await expect(textarea).not.toHaveClass('min-h-[77px]')
       await expect(textarea).not.toHaveClass('border-1')
       await expect(textarea).toHaveClass('bg-transparent')
+    })
+
+    await step('Verify the field inherits the type set on the box', async () => {
+      const textarea = canvas.getByLabelText(/Scrivi un messaggio/i)
+      await expect(textarea).not.toHaveClass('text-base')
+      const styles = getComputedStyle(textarea)
+      await expect(styles.fontSize).toBe('14px')
+      await expect(styles.lineHeight).toBe('20px')
     })
 
     await step('Verify focus stays visible without a border to recolour', async () => {

--- a/packages/textarea/src/FzTextarea.vue
+++ b/packages/textarea/src/FzTextarea.vue
@@ -11,9 +11,21 @@
  * listeners (blur, focus, paste, keydown, etc.) are forwarded directly
  * to the native textarea element via v-bind="$attrs", not the root div.
  *
+ * Two variants:
+ * - `default` draws the field itself (border, background, padding, 77px minimum height);
+ * - `bare` draws no box at all, so the container around it is the visible field —
+ *   the shape a single-line composer bar needs. It keeps a visible focus indicator
+ *   (a focus-visible outline replaces the default variant's border-colour cue) and
+ *   starts on one row, growing with `autoHeight` up to `maxRows`.
+ *
  * @component
  * @example
  * <FzTextarea label="Description" v-model="text" @blur="onBlur" />
+ * @example
+ * <!-- composer bar: the caller draws the box, the field only carries the text -->
+ * <div class="flex items-end rounded bg-grey-100 px-10 py-8">
+ *   <FzTextarea v-model="draft" variant="bare" auto-height :max-rows="6" aria-label="Message" />
+ * </div>
  */
 import { computed, ref, watch, onMounted, onBeforeUnmount, nextTick, useSlots } from 'vue'
 import { FzTextareaProps } from './types'
@@ -24,9 +36,20 @@ import { generateTextareaId } from './utils'
 defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<FzTextareaProps>(), {
-  resize: 'all',
-  rows: 2
+  variant: 'default'
 })
+
+const isBare = computed(() => props.variant === 'bare')
+
+/**
+ * `resize` and `rows` have variant-dependent defaults, so they are resolved here
+ * instead of in `withDefaults`: the bare field lives inside a box drawn by the
+ * caller, where a resize grabber is out of place and the natural starting height
+ * is a single line.
+ */
+const effectiveResize = computed(() => props.resize ?? (isBare.value ? 'none' : 'all'))
+
+const effectiveRows = computed(() => props.rows ?? (isBare.value ? 1 : 2))
 
 watch(
   () => props.size,
@@ -53,7 +76,7 @@ watch(
 watch(
   () => props.autoHeight,
   (autoHeight) => {
-    if (autoHeight && (props.resize === 'all' || props.resize === 'vertical')) {
+    if (autoHeight && (effectiveResize.value === 'all' || effectiveResize.value === 'vertical')) {
       console.warn(
         `[FzTextarea] Vertical resize is disabled when "autoHeight" is enabled. Only horizontal resize is preserved.`
       )
@@ -123,7 +146,10 @@ let resizeObserver: ResizeObserver | null = null
 
 /**
  * Reads font metrics once from the DOM. These values are stable because
- * font-size (text-base), padding (p-10), and border (border-1) are fixed.
+ * font-size (text-base), padding and border are fixed per variant — p-10 and
+ * border-1 in the default variant, both zero in the bare one, where the
+ * measurement still holds: padding and border simply contribute 0 to the
+ * maxRows ceiling.
  */
 function measureMetrics() {
   const el = textareaRef.value
@@ -220,10 +246,41 @@ const evaluateStateClasses = () => {
   }
 }
 
+/**
+ * The bare variant has no box to recolour, so only the text colour reacts to
+ * state. `error` keeps driving `aria-invalid` and the errorMessage slot; the
+ * visual error affordance belongs to the container the caller draws.
+ */
+const evaluateBareStateClasses = () => {
+  switch (true) {
+    case isReadonlyOrDisabled.value:
+      return 'text-grey-300 cursor-not-allowed'
+
+    default:
+      return 'text-core-black cursor-text'
+  }
+}
+
+/**
+ * Base chrome of the field. The bare variant switches every box-drawing
+ * declaration off — including the browser's own border, padding and background,
+ * which would otherwise show through — and keeps a visible focus indicator by
+ * replacing the default variant's border-colour cue with a focus-visible
+ * outline drawn on the field itself. Removing it entirely would be a WCAG 2.4.7
+ * failure.
+ */
+const baseClasses =
+  'border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px]'
+
+const bareClasses =
+  'border-0 p-0 bg-transparent placeholder:text-grey-300 block w-full text-base min-w-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 focus-visible:rounded'
+
 const classes = computed(() => [
-  'border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px]',
-  evaluateStateClasses(),
-  props.autoHeight ? autoHeightResizeMap[props.resize] : mapResizeToClass[props.resize],
+  isBare.value ? bareClasses : baseClasses,
+  isBare.value ? evaluateBareStateClasses() : evaluateStateClasses(),
+  props.autoHeight
+    ? autoHeightResizeMap[effectiveResize.value]
+    : mapResizeToClass[effectiveResize.value],
   {
     'pr-[38px]': props.valid
   }
@@ -249,7 +306,7 @@ const helpClasses = computed(() => [
         :placeholder
         :disabled
         :required
-        :rows
+        :rows="effectiveRows"
         :cols
         :minlength
         :maxlength

--- a/packages/textarea/src/FzTextarea.vue
+++ b/packages/textarea/src/FzTextarea.vue
@@ -13,17 +13,19 @@
  *
  * Two variants:
  * - `default` draws the field itself (border, background, padding, 77px minimum height);
- * - `bare` draws no box at all, so the container around it is the visible field —
- *   the shape a single-line composer bar needs. It keeps a visible focus indicator
- *   (a focus-visible outline replaces the default variant's border-colour cue) and
- *   starts on one row, growing with `autoHeight` up to `maxRows`.
+ * - `bare` draws no box at all and sets no font size, so the container around it is
+ *   the visible field and owns the type — the shape a single-line composer bar needs.
+ *   It keeps a visible focus indicator (a focus-visible outline replaces the default
+ *   variant's border-colour cue) and starts on one row, growing with `autoHeight` up
+ *   to `maxRows`.
  *
  * @component
  * @example
  * <FzTextarea label="Description" v-model="text" @blur="onBlur" />
  * @example
- * <!-- composer bar: the caller draws the box, the field only carries the text -->
- * <div class="flex items-end rounded bg-grey-100 px-10 py-8">
+ * <!-- composer bar: the caller draws the box and sets the type, the field
+ *      only carries the text -->
+ * <div class="flex items-end rounded bg-grey-100 px-10 py-8 text-sm">
  *   <FzTextarea v-model="draft" variant="bare" auto-height :max-rows="6" aria-label="Message" />
  * </div>
  */
@@ -155,7 +157,14 @@ function measureMetrics() {
   const el = textareaRef.value
   if (!el) return
   const styles = getComputedStyle(el)
-  cachedLineHeight = parseFloat(styles.lineHeight)
+  const lineHeight = parseFloat(styles.lineHeight)
+  /**
+   * `line-height: normal` computes to the keyword, not to a pixel value, which
+   * would leave the maxRows ceiling unset. It cannot happen with the fixed
+   * text-base of the default variant, but the bare one inherits its type from
+   * the container, so the browser's own ~1.2 ratio is the fallback.
+   */
+  cachedLineHeight = Number.isFinite(lineHeight) ? lineHeight : parseFloat(styles.fontSize) * 1.2
   cachedPaddingY = parseFloat(styles.paddingTop) + parseFloat(styles.paddingBottom)
   cachedBorderY = parseFloat(styles.borderTopWidth) + parseFloat(styles.borderBottomWidth)
 }
@@ -268,12 +277,18 @@ const evaluateBareStateClasses = () => {
  * replacing the default variant's border-colour cue with a focus-visible
  * outline drawn on the field itself. Removing it entirely would be a WCAG 2.4.7
  * failure.
+ *
+ * It also sets no font size, so type is inherited from the container the same
+ * way the box is: Tailwind's preflight gives a textarea `font-size: 100%` and
+ * `line-height: inherit`, so a `text-sm` on the box carries the field and
+ * anything else in it (a character counter, say) on one scale. The default
+ * variant keeps its fixed `text-base`.
  */
 const baseClasses =
   'border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px]'
 
 const bareClasses =
-  'border-0 p-0 bg-transparent placeholder:text-grey-300 block w-full text-base min-w-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 focus-visible:rounded'
+  'border-0 p-0 bg-transparent placeholder:text-grey-300 block w-full min-w-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 focus-visible:rounded'
 
 const classes = computed(() => [
   isBare.value ? bareClasses : baseClasses,

--- a/packages/textarea/src/__tests__/FzTextarea.spec.ts
+++ b/packages/textarea/src/__tests__/FzTextarea.spec.ts
@@ -1405,8 +1405,23 @@ describe('FzTextarea', () => {
         const textarea = wrapper.find('textarea')
         expect(textarea.classes()).toContain('block')
         expect(textarea.classes()).toContain('w-full')
-        expect(textarea.classes()).toContain('text-base')
         expect(textarea.classes()).toContain('placeholder:text-grey-300')
+      })
+
+      it('should set no font size when variant is bare, so type is inherited', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare' },
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).not.toContain('text-base')
+        expect(textarea.classes().some((c) => /^text-(xs|sm|base|lg|xl)$/.test(c))).toBe(false)
+      })
+
+      it('should keep the fixed font size in the default variant', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label' },
+        })
+        expect(wrapper.find('textarea').classes()).toContain('text-base')
       })
     })
 
@@ -1536,6 +1551,42 @@ describe('FzTextarea', () => {
         await wrapper.vm.$nextTick()
 
         expect(textarea.style.height).toBe('60px')
+        expect(textarea.style.overflowY).toBe('auto')
+
+        styleSpy.mockRestore()
+        wrapper.unmount()
+      })
+
+      it('should fall back to the browser ratio when the inherited line height is normal', async () => {
+        const styleSpy = vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+          lineHeight: 'normal',
+          fontSize: '20px',
+          paddingTop: '0px',
+          paddingBottom: '0px',
+          borderTopWidth: '0px',
+          borderBottomWidth: '0px',
+        } as unknown as CSSStyleDeclaration)
+
+        const wrapper = mount(FzTextarea, {
+          props: {
+            label: 'Test Label',
+            variant: 'bare',
+            autoHeight: true,
+            maxRows: 3,
+            modelValue: '',
+          },
+          attachTo: document.body,
+        })
+
+        const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
+        Object.defineProperty(textarea, 'scrollHeight', { configurable: true, value: 200 })
+
+        await wrapper.setProps({ modelValue: 'a\nb\nc\nd\ne' })
+        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick()
+
+        // 3 rows * (20px * 1.2)
+        expect(textarea.style.height).toBe('72px')
         expect(textarea.style.overflowY).toBe('auto')
 
         styleSpy.mockRestore()

--- a/packages/textarea/src/__tests__/FzTextarea.spec.ts
+++ b/packages/textarea/src/__tests__/FzTextarea.spec.ts
@@ -1214,6 +1214,17 @@ describe('FzTextarea', () => {
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
+
+    it('should match snapshot - bare variant', () => {
+      const wrapper = mount(FzTextarea, {
+        props: {
+          id: 'snapshot-bare',
+          variant: 'bare',
+          placeholder: 'Scrivi un messaggio...',
+        },
+      })
+      expect(wrapper.html()).toMatchSnapshot()
+    })
   })
 
   describe('Auto Height', () => {
@@ -1354,6 +1365,181 @@ describe('FzTextarea', () => {
         })
         const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
         expect(textarea.style.height).toBe('')
+      })
+    })
+  })
+
+
+  describe('Bare variant', () => {
+    describe('box removal', () => {
+      it('should default to the boxed variant when variant is not provided', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label' },
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).toContain('min-h-[77px]')
+        expect(textarea.classes()).toContain('border-1')
+      })
+
+      it('should drop min-height, border, background and padding when variant is bare', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare' },
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).not.toContain('min-h-[77px]')
+        expect(textarea.classes()).not.toContain('border-1')
+        expect(textarea.classes()).not.toContain('rounded')
+        expect(textarea.classes()).not.toContain('p-10')
+        expect(textarea.classes()).not.toContain('bg-core-white')
+        expect(textarea.classes()).not.toContain('min-w-[96px]')
+        expect(textarea.classes()).toContain('border-0')
+        expect(textarea.classes()).toContain('p-0')
+        expect(textarea.classes()).toContain('bg-transparent')
+        expect(textarea.classes()).toContain('min-w-0')
+      })
+
+      it('should keep the shared field basics when variant is bare', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare' },
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).toContain('block')
+        expect(textarea.classes()).toContain('w-full')
+        expect(textarea.classes()).toContain('text-base')
+        expect(textarea.classes()).toContain('placeholder:text-grey-300')
+      })
+    })
+
+    describe('focus visibility', () => {
+      it('should replace the border focus cue with a focus-visible outline', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare' },
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).toContain('focus-visible:outline')
+        expect(textarea.classes()).toContain('focus-visible:outline-2')
+        expect(textarea.classes()).toContain('focus-visible:outline-blue-600')
+        expect(textarea.classes()).not.toContain('focus:outline-none')
+        expect(textarea.classes()).not.toContain('focus:border-blue-600')
+      })
+    })
+
+    describe('variant-dependent defaults', () => {
+      it('should start on a single row when variant is bare', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare' },
+        })
+        expect(wrapper.find('textarea').attributes('rows')).toBe('1')
+      })
+
+      it('should honour an explicit rows value when variant is bare', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', rows: 3 },
+        })
+        expect(wrapper.find('textarea').attributes('rows')).toBe('3')
+      })
+
+      it('should disable resize by default when variant is bare', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare' },
+        })
+        expect(wrapper.find('textarea').classes()).toContain('resize-none')
+      })
+
+      it('should honour an explicit resize value when variant is bare', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', resize: 'horizontal' },
+        })
+        expect(wrapper.find('textarea').classes()).toContain('resize-x')
+      })
+
+      it('should not warn about vertical resize when bare defaults are used with autoHeight', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', autoHeight: true },
+        })
+        expect(warnSpy).not.toHaveBeenCalled()
+        warnSpy.mockRestore()
+      })
+
+      it('should still warn about vertical resize when bare opts into it with autoHeight', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', autoHeight: true, resize: 'vertical' },
+        })
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Vertical resize is disabled when "autoHeight" is enabled')
+        )
+        warnSpy.mockRestore()
+      })
+    })
+
+    describe('states', () => {
+      it('should grey the text without a background when disabled', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', disabled: true },
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).toContain('text-grey-300')
+        expect(textarea.classes()).toContain('cursor-not-allowed')
+        expect(textarea.classes()).not.toContain('bg-grey-100')
+      })
+
+      it('should keep error semantics without an error border', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', error: true },
+          slots: { errorMessage: 'This is an error' },
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.attributes('aria-invalid')).toBe('true')
+        expect(textarea.classes()).not.toContain('border-semantic-error-200')
+        expect(wrapper.text()).toContain('This is an error')
+      })
+
+      it('should keep label association and help text', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', id: 'bare-field' },
+          slots: { helpText: 'Some help' },
+        })
+        expect(wrapper.find('label').attributes('for')).toBe('bare-field')
+        expect(wrapper.find('textarea').attributes('aria-describedby')).toBe('bare-field-help')
+        expect(wrapper.text()).toContain('Some help')
+      })
+    })
+
+    describe('auto height with zero padding', () => {
+      it('should cap the height at maxRows when there is no padding or border', async () => {
+        const styleSpy = vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+          lineHeight: '20px',
+          paddingTop: '0px',
+          paddingBottom: '0px',
+          borderTopWidth: '0px',
+          borderBottomWidth: '0px',
+        } as unknown as CSSStyleDeclaration)
+
+        const wrapper = mount(FzTextarea, {
+          props: {
+            label: 'Test Label',
+            variant: 'bare',
+            autoHeight: true,
+            maxRows: 3,
+            modelValue: '',
+          },
+          attachTo: document.body,
+        })
+
+        const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
+        Object.defineProperty(textarea, 'scrollHeight', { configurable: true, value: 200 })
+
+        await wrapper.setProps({ modelValue: 'a\nb\nc\nd\ne' })
+        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick()
+
+        expect(textarea.style.height).toBe('60px')
+        expect(textarea.style.overflowY).toBe('auto')
+
+        styleSpy.mockRestore()
+        wrapper.unmount()
       })
     })
   })

--- a/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
+++ b/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
@@ -12,7 +12,7 @@ exports[`FzTextarea > Snapshots > should match snapshot - autoHeight 1`] = `
 exports[`FzTextarea > Snapshots > should match snapshot - bare variant 1`] = `
 "<div class="fz-textarea flex flex-col gap-8 items-start w-full">
   <!--v-if-->
-  <div class="relative w-full"><textarea id="snapshot-bare" class="border-0 p-0 bg-transparent placeholder:text-grey-300 block w-full text-base min-w-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 focus-visible:rounded text-core-black cursor-text resize-none" placeholder="Scrivi un messaggio..." rows="1" aria-required="false" aria-invalid="false" aria-disabled="false"></textarea>
+  <div class="relative w-full"><textarea id="snapshot-bare" class="border-0 p-0 bg-transparent placeholder:text-grey-300 block w-full min-w-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 focus-visible:rounded text-core-black cursor-text resize-none" placeholder="Scrivi un messaggio..." rows="1" aria-required="false" aria-invalid="false" aria-disabled="false"></textarea>
     <!--v-if-->
   </div>
   <!--v-if-->

--- a/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
+++ b/packages/textarea/src/__tests__/__snapshots__/FzTextarea.spec.ts.snap
@@ -9,6 +9,16 @@ exports[`FzTextarea > Snapshots > should match snapshot - autoHeight 1`] = `
 </div>"
 `;
 
+exports[`FzTextarea > Snapshots > should match snapshot - bare variant 1`] = `
+"<div class="fz-textarea flex flex-col gap-8 items-start w-full">
+  <!--v-if-->
+  <div class="relative w-full"><textarea id="snapshot-bare" class="border-0 p-0 bg-transparent placeholder:text-grey-300 block w-full text-base min-w-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 focus-visible:rounded text-core-black cursor-text resize-none" placeholder="Scrivi un messaggio..." rows="1" aria-required="false" aria-invalid="false" aria-disabled="false"></textarea>
+    <!--v-if-->
+  </div>
+  <!--v-if-->
+</div>"
+`;
+
 exports[`FzTextarea > Snapshots > should match snapshot - default state 1`] = `
 "<div class="fz-textarea flex flex-col gap-8 items-start w-full"><label id="snapshot-default-label" class="font-normal text-base mb-0 text-grey-500" for="snapshot-default">Test Label</label>
   <div class="relative w-full"><textarea id="snapshot-default" class="border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px] border-grey-300 focus:border-blue-600 bg-core-white text-core-black cursor-text resize" rows="2" aria-required="false" aria-invalid="false" aria-disabled="false" aria-labelledby="snapshot-default-label"></textarea>

--- a/packages/textarea/src/types.ts
+++ b/packages/textarea/src/types.ts
@@ -69,11 +69,12 @@ type FzTextareaProps = {
    * - `default`: the component draws the field — 1px border, white background,
    *   10px padding, rounded corners and a 77px minimum height.
    * - `bare`: the component draws no box of its own — no border, no background,
-   *   no padding, no minimum height and no minimum width. The surrounding
-   *   container becomes the visible field, which is what a single-line
-   *   composer bar needs. Everything else (label, help text, error ARIA,
-   *   `autoHeight`, `maxRows`) is unchanged, and focus stays visible through a
-   *   `focus-visible` outline drawn on the field itself.
+   *   no padding, no minimum height and no minimum width — and sets no font
+   *   size, so type is inherited from the container along with the box. The
+   *   surrounding container becomes the visible field, which is what a
+   *   single-line composer bar needs. Everything else (label, help text, error
+   *   ARIA, `autoHeight`, `maxRows`) is unchanged, and focus stays visible
+   *   through a `focus-visible` outline drawn on the field itself.
    *
    *   Because the box belongs to the caller in this variant, the error state has
    *   no border to colour: `error` still drives `aria-invalid` and the

--- a/packages/textarea/src/types.ts
+++ b/packages/textarea/src/types.ts
@@ -5,6 +5,14 @@
  */
 
 /**
+ * Visual variants of the FzTextarea field.
+ *
+ * `bare` strips the component's own box (border, background, padding, minimum
+ * height) so that the container around it can be the visible field.
+ */
+type FzTextareaVariant = "default" | "bare";
+
+/**
  * Props for the FzTextarea component.
  *
  * Multi-line text input with label, validation states, resize control,
@@ -56,13 +64,33 @@ type FzTextareaProps = {
    */
   disabled?: boolean;
   /**
+   * Visual variant of the field.
+   *
+   * - `default`: the component draws the field — 1px border, white background,
+   *   10px padding, rounded corners and a 77px minimum height.
+   * - `bare`: the component draws no box of its own — no border, no background,
+   *   no padding, no minimum height and no minimum width. The surrounding
+   *   container becomes the visible field, which is what a single-line
+   *   composer bar needs. Everything else (label, help text, error ARIA,
+   *   `autoHeight`, `maxRows`) is unchanged, and focus stays visible through a
+   *   `focus-visible` outline drawn on the field itself.
+   *
+   *   Because the box belongs to the caller in this variant, the error state has
+   *   no border to colour: `error` still drives `aria-invalid` and the
+   *   `errorMessage` slot, but the caller is responsible for any visual error
+   *   affordance on its own container.
+   * @default 'default'
+   */
+  variant?: FzTextareaVariant;
+  /**
    * Controls resize behavior of the textarea
-   * @default 'all'
+   * @default 'all' — `'none'` when `variant="bare"`, where a resize grabber would
+   * break the container that draws the field
    */
   resize?: "none" | "vertical" | "horizontal" | "all";
   /**
    * Number of visible text rows
-   * @default 2
+   * @default 2 — `1` when `variant="bare"`, so a composer bar starts on a single line
    */
   rows?: number;
   /**
@@ -105,4 +133,4 @@ type FzTextareaProps = {
   maxRows?: number;
 };
 
-export { FzTextareaProps };
+export { FzTextareaProps, FzTextareaVariant };


### PR DESCRIPTION
Jira: [LIB-2927](https://fiscozen.atlassian.net/browse/LIB-2927)

`FzTextarea` hard-coded its own box — `border-1 rounded p-10 bg-core-white min-h-[77px]` — plus a
fixed `text-base`, so a single-line composer bar was only reachable by re-declaring all of it from
the outside. The chat widget in `fiscozen-frontend-library` pays for that with nine `!`-important
utilities on one element (`FzpChatComposerBar.vue`).

## What this adds

`variant="bare"` turns every box-drawing declaration off — including the browser's own border,
padding and background, which would otherwise show through — and declares no font size either. What
stays is the field itself: label, help text, error ARIA, `autoHeight` and `maxRows` are untouched.
The container around the field becomes the visible field, and owns the type along with the box.

Two defaults follow the variant, resolved in computeds instead of `withDefaults`:

- `rows` → `1`, so a composer starts on one line;
- `resize` → `'none'`, because a grabber would break the container's shape.

Both stay overridable, and the `autoHeight`/`resize` warning now reads the resolved value, so the
default variant warns exactly as it did before.

**Type is inherited, not declared.** Tailwind's preflight gives a `textarea` `font-size: 100%` and
`line-height: inherit`, so `text-sm leading-5` on the composer box carries the field *and* the
character counter on one scale. That is what closes the last two overrides in the consumer's list;
the default variant keeps its fixed `text-base`, so the `size` deprecation note stays true.

**Focus is replaced, not removed.** With no border to recolour, the bare field draws a 2px
`blue-600` `focus-visible` outline on itself; dropping it would be a WCAG 2.4.7 failure. A caller
whose box owns the focus treatment can suppress it with `!focus-visible:outline-none`, and the MDX
says so — in exchange for another visible indicator, never for nothing.

**The error state has no border to colour** in this variant: `error` still drives `aria-invalid` and
the `errorMessage` slot, but the visual affordance on the box belongs to the caller (the chat
composer already puts the message above the bar).

**One robustness fix that inheritance made necessary.** An inherited line height can compute to
`normal`, which parses to `NaN` and would leave the `maxRows` ceiling unset — the field would grow
without a cap. `measureMetrics` now falls back to the browser's ~1.2 ratio. The default variant,
with its fixed `text-base`, could never reach that path.

## What it does to the consumer's override list

```
!min-h-[24px] !max-h-[128px] !rounded-none !border-0 !bg-transparent !p-0 !text-sm !leading-5 !outline-none
```

All nine go: six are the bare box, `!max-h-[128px]` is `:max-rows="6"`, `!text-sm !leading-5` move
onto the box that already draws the field, and `!outline-none` is dropped in favour of the visible
focus ring.

## Verified

- 132 unit tests (18 new): box removal, no font size in bare / fixed `text-base` in default, focus
  classes, variant-dependent defaults, states, label and help association, the `maxRows` ceiling
  with zero padding, and the `line-height: normal` fallback.
- New `BareComposerBar` story with a play function; full storybook suite green (745 tests).
- In a real browser, on the story: `border 0px`, `padding 0px`, `background rgba(0,0,0,0)`,
  `min-height 0px`, `outline rgb(72,88,204) 2px solid` while focused, and `14px / 20px` inherited
  from the box. The field is 20px on one line, 40px on two, and stops at 120px with `maxRows="6"` —
  so the ceiling still measures correctly with zero padding, which was the card's second constraint.
- The default variant's class list is byte-identical; the existing snapshots lock that in and did
  not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2927]: https://fiscozen.atlassian.net/browse/LIB-2927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ