### PR TITLE
feat(navbar): LIB-2951 elevation prop, so the shadow can actually be switched off

### DIFF
--- a/.changeset/navbar-elevation.md
+++ b/.changeset/navbar-elevation.md
@@ -1,0 +1,11 @@
+---
+"@fiscozen/navbar": minor
+---
+
+`FzNavbar`: new `elevation` prop (`'raised' | 'flat'`, default `'raised'`) to switch the elevation shadow off — for a navbar that sits _on_ the page background rather than above it, like the backoffice rail inside `FzFrameTemplate`, where a shadow draws a fake edge along a surface with nothing behind it.
+
+It has to be a prop. The shadow is declared by this package's own `.fz-navbar` rule, at the same specificity as any Tailwind utility, so whether a `shadow-none` added at the call site wins comes down to stylesheet order rather than intent; and the documented escape hatch, `--fz-navbar-shadow`, needs `style`, which consuming repos block under their compose-only styling policy exactly as they block `class`. Deciding it inside the component is the only way the capability exists for them. `elevation` takes precedence over `--fz-navbar-shadow` on purpose.
+
+The redundant Tailwind `shadow` utility is gone from the root's class list: the package's stylesheet already declared the same value, and leaving the utility in place is what made the shadow unswitchable. **No visual change at the default** — the rendered shadow is identical, and it now has exactly one source. Consumers whose build skips this package's CSS would lose the shadow, but they already lose padding, height, z-index and background, which have only ever lived there.
+
+Not coupled to `variant`: the frontoffice renders a vertical rail with a shadow today, and inferring elevation from the variant would change that silently.

--- a/apps/storybook/src/stories/navigation/Navbar.stories.ts
+++ b/apps/storybook/src/stories/navigation/Navbar.stories.ts
@@ -33,6 +33,12 @@ const meta = {
       description:
         'When `true`, the navbar adds `env(safe-area-inset-*)` to top/left/right padding for devices with a notch / dynamic island.'
     },
+    elevation: {
+      control: 'radio',
+      options: ['raised', 'flat'],
+      description:
+        'Whether the navbar casts its elevation shadow. `flat` is for a navbar that sits *on* the page background rather than above it.'
+    },
     isMenuOpen: {
       control: 'boolean',
       description: 'Mobile menu open state. Supports `v-model:isMenuOpen` for two-way binding.'
@@ -43,6 +49,7 @@ const meta = {
     variant: 'horizontal',
     position: 'static',
     respectSafeArea: false,
+    elevation: 'raised',
     isMenuOpen: false,
     onFznavbarMenuButtonClick: fn()
   }
@@ -205,7 +212,7 @@ export const Customized: Story = {
     docs: {
       description: {
         story:
-          'Layout values are exposed as CSS custom properties on the root (`--fz-navbar-padding`, `--fz-navbar-shadow`, `--fz-navbar-height`, `--fz-navbar-bg`, …). Override per-instance via inline `style` to slim the navbar without `!important` resets.'
+          'Layout values are exposed as CSS custom properties on the root (`--fz-navbar-padding`, `--fz-navbar-shadow`, `--fz-navbar-height`, `--fz-navbar-bg`, …). Override per-instance via inline `style` to slim the navbar without `!important` resets. Note that a repo under a compose-only styling policy cannot set these — setting a custom property needs `style` — so anything a consumer must be able to reach belongs behind a prop instead; the shadow now is (`elevation`).'
       }
     }
   },
@@ -341,6 +348,67 @@ export const BootstrapInterop: Story = {
     await step('Verify navbar renders inside a .twp wrapper', async () => {
       const header = canvas.getByRole('banner')
       await expect(header.closest('.twp')).not.toBeNull()
+    })
+  }
+}
+
+/**
+ * `elevation="flat"` — no shadow, for a navbar that sits **on** the page
+ * background rather than above it. The backoffice rail inside `FzFrameTemplate`
+ * is the case it was added for: with nothing behind the rail, a shadow draws a
+ * fake edge along a seamless surface.
+ *
+ * It is a prop rather than something the call site switches off because the
+ * shadow is declared by `@fiscozen/navbar`'s own `.fz-navbar` rule, at the same
+ * specificity as any Tailwind utility — so whether a `shadow-none` added at the
+ * call site wins depends on stylesheet order — and the `--fz-navbar-shadow`
+ * custom property needs `style`, which consuming repos block under their
+ * compose-only policy just as they block `class`.
+ *
+ * The prop also beats that custom property, deliberately: an explicit API should
+ * win over a property a host set further up.
+ */
+export const Flat: Story = {
+  args: { variant: 'vertical', elevation: 'flat' },
+  render: (args) => ({
+    setup() {
+      return { args }
+    },
+    components: { FzNavbar, FzIcon, FzNavlink, FzIconButton, FzAvatar },
+    template: FULL_NAVBAR_TEMPLATE
+  }),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Casts no shadow', async () => {
+      // Measured, not asserted through classes: the point of the prop is that it
+      // wins the cascade, and a class assertion says nothing about who wins.
+      // Only a real browser resolves this — jsdom applies no stylesheet.
+      const navbar = canvas.getByRole('banner')
+      await expect(getComputedStyle(navbar).boxShadow).toBe('none')
+    })
+  }
+}
+
+/**
+ * The default for comparison. Every version before the prop existed rendered
+ * this, and it stays the default so no existing consumer changes.
+ */
+export const Raised: Story = {
+  args: { variant: 'vertical', elevation: 'raised' },
+  render: (args) => ({
+    setup() {
+      return { args }
+    },
+    components: { FzNavbar, FzIcon, FzNavlink, FzIconButton, FzAvatar },
+    template: FULL_NAVBAR_TEMPLATE
+  }),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step('Casts the elevation shadow', async () => {
+      const navbar = canvas.getByRole('banner')
+      await expect(getComputedStyle(navbar).boxShadow).not.toBe('none')
     })
   }
 }

--- a/packages/navbar/README.md
+++ b/packages/navbar/README.md
@@ -2,3 +2,34 @@
 RFC: https://github.com/fiscozen/knowledge-base/pull/91
 
 Navbar skeleton component meant for primary navigation.
+
+## Elevation (`elevation`)
+
+`FzNavbar` casts an elevation shadow by default. Pass `elevation="flat"` for a
+navbar that sits **on** the page background rather than above it — the backoffice
+rail inside `FzFrameTemplate` is the case it exists for: with nothing behind the
+rail, a shadow draws a fake edge along a seamless surface.
+
+```vue
+<FzNavbar variant="vertical" elevation="flat" />
+```
+
+| Value | |
+| --- | --- |
+| `raised` *(default)* | the elevation shadow — unchanged from every version before the prop existed |
+| `flat` | no shadow |
+
+**Why a prop and not a class at the call site.** The shadow is declared by this
+package's own `.fz-navbar` rule, which sits at the same specificity as a Tailwind
+utility — so whether a `shadow-none` added at the call site wins comes down to
+stylesheet order, not intent. The `--fz-navbar-shadow` custom property is not an
+answer either: setting it needs `style`, which consuming repos block under their
+compose-only styling policy exactly as they block `class`. Deciding it inside the
+component is the only way the capability exists for them at all. `elevation` also
+takes precedence over `--fz-navbar-shadow`, deliberately — an explicit API should
+beat a property set further up.
+
+The other layout values (`--fz-navbar-padding`, `--fz-navbar-height`,
+`--fz-navbar-bg`, …) are still custom properties, with the same caveat: they are
+out of reach for a compose-only consumer. Promote one to a prop when a consumer
+actually needs it.

--- a/packages/navbar/src/FzNavbar.vue
+++ b/packages/navbar/src/FzNavbar.vue
@@ -11,7 +11,8 @@ const props = withDefaults(defineProps<FzNavbarProps>(), {
   mobileBreakpoint: undefined,
   position: 'static',
   respectSafeArea: false,
-  environment: 'frontoffice'
+  environment: 'frontoffice',
+  elevation: 'raised'
 })
 
 const emit = defineEmits<FzNavbarEmits>()
@@ -56,11 +57,12 @@ function handleMenuButtonClick() {
 
 <template>
   <header
-    class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow"
+    class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12"
     :class="{
       'fz-navbar--fixed': position === 'fixed',
       'fz-navbar--sticky': position === 'sticky',
       'fz-navbar--safe-area': respectSafeArea,
+      'fz-navbar--flat': elevation === 'flat',
       'justify-between': isMobile,
       'h-full w-56 flex-col': isVertical && !isMobile,
       'h-56 w-full': isHorizontal || isMobile
@@ -117,6 +119,15 @@ function handleMenuButtonClick() {
  * larger than intended.
  *
  * Consumers can still override per-instance via inline style or scoped CSS.
+ *
+ * THE SHADOW IS DECLARED HERE AND NOWHERE ELSE. The root used to carry
+ * Tailwind's `shadow` utility as well, which was redundant — this rule already
+ * declares the same value — and actively harmful: both are single-class
+ * selectors, so with the utility present whether anything can switch the shadow
+ * off depends on stylesheet order rather than on intent. It was removed together
+ * with the `elevation` prop (LIB-2951); do not add it back. Anything that needs
+ * to change the shadow belongs in this block, keyed to a modifier class, so the
+ * cascade stays inside the package.
  */
 
 .fz-navbar {
@@ -128,6 +139,13 @@ function handleMenuButtonClick() {
     0 1px 2px -1px rgb(0 0 0 / 0.1)
   );
   background: var(--fz-navbar-bg, transparent);
+}
+
+/* `elevation="flat"`. Declared after `.fz-navbar` and at the same specificity,
+   so it wins on order — and it wins over `--fz-navbar-shadow` too, deliberately:
+   an explicit prop should beat a custom property a host set further up. */
+.fz-navbar--flat {
+  box-shadow: none;
 }
 
 .fz-navbar.h-56 {

--- a/packages/navbar/src/__tests__/FzNavbar.spec.ts
+++ b/packages/navbar/src/__tests__/FzNavbar.spec.ts
@@ -98,7 +98,6 @@ describe('FzNavbar', () => {
       expect(header.classes()).toContain('z-10')
       expect(header.classes()).toContain('flex')
       expect(header.classes()).toContain('p-12')
-      expect(header.classes()).toContain('shadow')
     })
 
     it('should render brand-logo slot', () => {
@@ -471,7 +470,16 @@ describe('FzNavbar', () => {
         expect(header.classes()).toContain('z-10')
         expect(header.classes()).toContain('flex')
         expect(header.classes()).toContain('p-12')
-        expect(header.classes()).toContain('shadow')
+      })
+
+      it('should not carry the Tailwind shadow utility', () => {
+        // Regression guard for LIB-2951. The package's own `.fz-navbar` rule
+        // declares the shadow, so the utility was redundant — and, being a
+        // single-class selector like every other candidate, it made switching
+        // the shadow off a question of stylesheet order rather than of intent.
+        // The shadow now has exactly one source, inside the package.
+        wrapper = mount(FzNavbar, { props: { variant: 'horizontal' } })
+        expect(wrapper.find('header').classes()).not.toContain('shadow')
       })
     })
 
@@ -1119,6 +1127,39 @@ describe('FzNavbar', () => {
 
       expect(warnSpy).not.toHaveBeenCalled()
       warnSpy.mockRestore()
+    })
+  })
+  describe('elevation prop', () => {
+    it('casts the shadow by default', () => {
+      // `raised` is the behaviour every version before the prop had; the default
+      // must not change, or every existing consumer's navbar changes with it.
+      wrapper = mount(FzNavbar, { props: { variant: 'horizontal' } })
+      expect(wrapper.find('header').classes()).not.toContain('fz-navbar--flat')
+    })
+
+    it('adds the flat modifier when elevation is flat', () => {
+      // The modifier is the hook for the `box-shadow: none` rule in the
+      // package's own stylesheet — which is where the decision has to live, since
+      // a consuming repo can reach neither `class` nor `style` (nor, therefore,
+      // `--fz-navbar-shadow`) under its compose-only policy. That the rule
+      // actually wins the cascade is asserted in the Storybook play function,
+      // which runs in a real browser; jsdom applies no stylesheet here.
+      wrapper = mount(FzNavbar, { props: { variant: 'horizontal', elevation: 'flat' } })
+      expect(wrapper.find('header').classes()).toContain('fz-navbar--flat')
+    })
+
+    it('is explicit about raised', () => {
+      wrapper = mount(FzNavbar, { props: { variant: 'horizontal', elevation: 'raised' } })
+      expect(wrapper.find('header').classes()).not.toContain('fz-navbar--flat')
+    })
+
+    it('applies to the vertical rail too', () => {
+      // The flat rail is what the backoffice design needs, but the prop is not
+      // coupled to `variant`: the frontoffice uses a vertical rail *with* a
+      // shadow today, and inferring elevation from the variant would change that
+      // silently.
+      wrapper = mount(FzNavbar, { props: { variant: 'vertical', elevation: 'flat' } })
+      expect(wrapper.find('header').classes()).toContain('fz-navbar--flat')
     })
   })
 })

--- a/packages/navbar/src/__tests__/__snapshots__/FzNavbar.spec.ts.snap
+++ b/packages/navbar/src/__tests__/__snapshots__/FzNavbar.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`FzNavbar > Snapshots > should match snapshot - default state 1`] = `
-"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-56 w-full">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 h-56 w-full">
   <div class="mr-32"></div>
   <div class="flex items-center gap-8 flex-row"></div>
   <div class="flex items-center gap-16 ml-auto flex-row"></div>
@@ -9,7 +9,7 @@ exports[`FzNavbar > Snapshots > should match snapshot - default state 1`] = `
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - horizontal layout large screen 1`] = `
-"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-56 w-full">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 h-56 w-full">
   <div class="mr-32">
     <div id="brandlogo" class="desktop"></div>
   </div>
@@ -26,7 +26,7 @@ exports[`FzNavbar > Snapshots > should match snapshot - horizontal layout large 
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - horizontal layout small screen 1`] = `
-"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-56 w-full">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 h-56 w-full">
   <div class="mr-32">
     <div id="brandlogo" class="desktop"></div>
   </div>
@@ -43,7 +43,7 @@ exports[`FzNavbar > Snapshots > should match snapshot - horizontal layout small 
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - vertical layout large screen 1`] = `
-"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-full w-56 flex-col">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 h-full w-56 flex-col">
   <div class="mb-32">
     <div id="brandlogo" class="desktop"></div>
   </div>
@@ -60,7 +60,7 @@ exports[`FzNavbar > Snapshots > should match snapshot - vertical layout large sc
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - vertical layout small screen 1`] = `
-"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-full w-56 flex-col">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 h-full w-56 flex-col">
   <div class="mb-32">
     <div id="brandlogo" class="desktop"></div>
   </div>
@@ -77,7 +77,7 @@ exports[`FzNavbar > Snapshots > should match snapshot - vertical layout small sc
 `;
 
 exports[`FzNavbar > Snapshots > should match snapshot - with menu open 1`] = `
-"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 shadow h-56 w-full">
+"<header class="fz-navbar z-10 m-0 box-border flex items-center border-0 p-12 h-56 w-full">
   <div class="mr-32">
     <div id="brandlogo" class="desktop"></div>
   </div>

--- a/packages/navbar/src/types.ts
+++ b/packages/navbar/src/types.ts
@@ -5,6 +5,17 @@ export type FzNavbarVariant = 'horizontal' | 'vertical'
 
 export type FzNavbarPosition = 'static' | 'fixed' | 'sticky'
 
+/**
+ * Whether the navbar casts a shadow.
+ *
+ * - `raised` (default): the elevation shadow — the navbar reads as floating
+ *   above the page. Unchanged from every version before the prop existed.
+ * - `flat`: no shadow. For a navbar that sits *on* the page background rather
+ *   than above it, e.g. the backoffice rail inside `FzFrameTemplate`, where a
+ *   shadow draws a fake edge along a surface that has nothing behind it.
+ */
+export type FzNavbarElevation = 'raised' | 'flat'
+
 interface FzNavbarProps {
   /**
    * The main direction of the navbar.
@@ -48,6 +59,21 @@ interface FzNavbarProps {
    * for consumers to add `class="fixed top-0 left-0"` (or similar) on the call site.
    */
   position?: FzNavbarPosition
+  /**
+   * Whether the navbar casts its elevation shadow.
+   *
+   * A prop rather than something the call site switches off, for the same reason
+   * `position` is one: the shadow is declared by this package's own `.fz-navbar`
+   * rule, which sits at the same specificity as a Tailwind utility, so whether a
+   * `shadow-none` added at the call site wins depends on stylesheet order — and
+   * the `--fz-navbar-shadow` custom property needs `style`, which consuming repos
+   * block under their compose-only policy just as they block `class`. Deciding it
+   * inside the component is the only way the capability actually exists for them.
+   *
+   * @default 'raised'
+   * @see FzNavbarElevation
+   */
+  elevation?: FzNavbarElevation
   /**
    * When `true`, the navbar adds `env(safe-area-inset-*)` to its top, left and right padding
    * so it renders correctly on devices with a notch / dynamic island.


### PR DESCRIPTION
Jira: [LIB-2951](https://fiscozen.atlassian.net/browse/LIB-2951)

Companion to #444 (`FzFrameTemplate`) — **M2** of [`docs/RFC/layout/frame-shell-promotion.md`](https://github.com/fiscozen/design_system/blob/feat/LIB-2950-frame-template/docs/RFC/layout/frame-shell-promotion.md). The shell merges without this, but the backoffice rail is not design-conformant until it lands.

## The problem is not the shadow, it's that it can't be switched off

The new backoffice design wants the navigation rail flat and seamless against the page background. There was no way to ask for that.

The shadow had **two** sources:

1. Tailwind's `shadow` utility in the root's class list, and
2. this package's own `.fz-navbar` rule, declaring the same `box-shadow`.

Both are single-class selectors, so whether anything added at the call site wins comes down to **stylesheet order rather than intent**. And the documented escape hatch — the `--fz-navbar-shadow` custom property — is not an answer either: setting it needs `style`, which consuming repos block under their compose-only styling policy exactly as they block `class`. (`packages/layout/CLAUDE.md` already spells this out: *"CSS custom properties count as inaccessible too, since setting them needs `style`."*)

The LIB-2939 spike ended up with `[&.fz-navbar]:!shadow-none` at the call site — which a consuming repo cannot write. So this was never a cosmetic gap: it was a capability that, by our own rules, **did not exist**.

## Fix

Move the decision inside the component, where the cascade is ours.

- **`elevation?: 'raised' | 'flat'`**, default `'raised'`. Adds a `fz-navbar--flat` modifier.
- **`.fz-navbar--flat { box-shadow: none }`**, declared after `.fz-navbar` in the same stylesheet — so it wins on order at equal specificity, with no `!important` anywhere. It also wins over `--fz-navbar-shadow`, deliberately: an explicit prop should beat a property a host set further up.
- **The redundant `shadow` utility is removed from the root.** The rendered default is byte-for-byte what it was — the package rule already declared the same value — but the shadow now has exactly one source, which is what makes it switchable at all. A comment in the stylesheet says so, so it doesn't get added back.

`elevation` follows the precedent `position` and `respectSafeArea` set in this package — both exist for the same reason, and `position`'s JSDoc says it outright: *"Replaces the need for consumers to add `class="fixed top-0 left-0"` on the call site."*

## Deliberate non-changes

- **Not coupled to `variant`.** The frontoffice renders a vertical rail *with* a shadow today; inferring elevation from the variant would change that silently.
- **Default unchanged.** Flat by default would be a visual change on every frontoffice page. Additive: new optional prop, previous behaviour as its default.

## Testing

The interesting assertion is not the class, it is **who wins the cascade** — and jsdom applies no stylesheet, so a class assertion there proves nothing about the actual box-shadow.

- **Storybook play functions in real Chromium** read `getComputedStyle().boxShadow`: `'none'` under `flat`, non-`'none'` under `raised`. Both directions, measured.
- **jsdom** covers the prop plumbing (default, both explicit values, and the vertical rail, since that is the variant the backoffice uses) plus a regression guard that the `shadow` utility stays gone.
- `FzNavbar.vue` at **100% statements / branches / functions / lines**. Six snapshots updated for the removed class — the only diff in each is `shadow` disappearing from the root class list.
- Full Storybook suite **760 passed, 0 failures**; `nx run-many -t build` across all 47 projects clean.

## Note for the reviewer

Two things I did *not* fold in, to keep this reviewable:

1. **The remaining custom properties** (`--fz-navbar-padding`, `--fz-navbar-height`, `--fz-navbar-bg`, …) have the same reachability problem and are still properties. I noted it in the README rather than promoting them speculatively — promote one when a consumer actually needs it.
2. **`types.ts` says passing `variant="horizontal"` emits a dev-mode warning; the component only warns for the deprecated `breakpoints` prop.** Pre-existing doc/behaviour drift, spotted while working here, left alone.

Minor → `@fiscozen/navbar@0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-2951]: https://fiscozen.atlassian.net/browse/LIB-2951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ