### PR TITLE
feat(textarea): LIB-2932 delegate the bare variant's focus indicator to the container

### DIFF
--- a/.changeset/textarea-focus-affordance.md
+++ b/.changeset/textarea-focus-affordance.md
@@ -1,0 +1,25 @@
+---
+'@fiscozen/textarea': minor
+---
+
+feat(textarea): let the `bare` variant delegate its focus indicator to the container
+
+`variant="bare"` draws a `focus-visible` outline on the field, standing in for the
+border-colour cue it turns off. That outline is offset from the *field*, so inside a
+container with padding of its own it lands within the visible box and reads as a field
+inside a field.
+
+`focusAffordance` moves the indicator instead of removing it:
+
+- `'field'` (default) keeps today's behaviour exactly — existing callers are unaffected,
+  and a caller who never hears of the prop cannot lose its focus indicator.
+- `'container'` draws no indicator on the field and suppresses the browser's native ring
+  as well, on the condition that the caller draws one on its own box (`focus-within:`).
+
+The prop transfers a WCAG 2.4.7 (Focus Visible) obligation, it does not cancel it — the
+component cannot verify the caller honoured it, which is why the default does not change.
+It applies to `variant="bare"` only; setting it on the default variant, which recolours its
+own border, warns and does nothing.
+
+This replaces the `!focus-visible:outline-none` override that was previously the only way to
+get that shape from a call site.

--- a/apps/storybook/src/FzTextarea.mdx
+++ b/apps/storybook/src/FzTextarea.mdx
@@ -16,6 +16,8 @@ Multi-line text input component with label, validation states, resize control, a
 - Error and valid states with visual feedback
 - Error messages via FzAlert component (circle-xmark icon, consistent with FzInput)
 - Custom focus styling (blue border on focus, error border maintained on error+focus)
+- `focusAffordance`: in the `bare` variant, the focus indicator can be delegated to the container
+  that draws the field, for boxes with padding of their own
 - Help text and error messages with multiline wrapping support
 - Required, disabled, and readonly states with proper visual cues
 - Combined states support (error+disabled, required+help, disabled+compiled)
@@ -123,6 +125,12 @@ const notes = ref('')
       <td><code>'default' | 'bare'</code></td>
       <td><code>'default'</code></td>
       <td>Visual variant. <code>default</code> draws the field (border, background, padding, 77px minimum height); <code>bare</code> draws no box at all, leaving it to the surrounding container. See <a href="#bare-variant-composer-bars">Bare Variant</a>.</td>
+    </tr>
+    <tr>
+      <td><code>focusAffordance</code></td>
+      <td><code>'field' | 'container'</code></td>
+      <td><code>'field'</code></td>
+      <td><code>bare</code> only. Which element draws the focus indicator. <code>field</code> draws a 2px <code>blue-600</code> <code>focus-visible</code> outline on the textarea; <code>container</code> draws none and requires the caller to draw one on its own box — dropping it outright fails WCAG 2.4.7. See <a href="#focus-affordance-who-draws-the-ring">Focus Affordance</a>.</td>
     </tr>
     <tr>
       <td><code>resize</code></td>
@@ -507,14 +515,64 @@ Notes:
   `errorMessage` slot, and the text turns grey when disabled or readonly, but any visual error
   affordance on the box is the caller's to draw (the composer in the chat widget, for instance, puts
   the message above the bar).
-- **Focus stays visible.** See below.
+- **Focus stays visible.** Either on the field or on your box — see below.
+
+## Focus Affordance (who draws the ring)
+
+The bare variant strips the border, so the border-colour focus cue goes with it. What replaces it
+is a `focus-visible` outline on the field, and `focusAffordance` decides whether the component
+keeps drawing it or hands it to you.
+
+| Value | The component draws | You must draw |
+| --- | --- | --- |
+| `'field'` *(default)* | a 2px `blue-600` outline on the textarea, offset by 2px | nothing |
+| `'container'` | nothing — the browser's own ring is suppressed too | a focus indicator on your box |
+
+Reach for `'container'` when the box has padding of its own. An outline on the field is offset from
+the *field*, so inside a `px-10 py-8` container it lands **inside** the grey box and reads as a
+field within a field. Moving it to the box puts it where the visible field actually is:
+
+```vue
+<template>
+  <!-- The box is the visible field, so the box takes the focus ring. -->
+  <div
+    class="flex min-h-[44px] flex-col justify-end gap-4 rounded bg-grey-100 px-10 py-8 text-sm leading-5
+           focus-within:outline focus-within:outline-2 focus-within:outline-blue-600"
+  >
+    <FzTextarea
+      v-model="draft"
+      variant="bare"
+      focus-affordance="container"
+      auto-height
+      :max-rows="6"
+      aria-label="Scrivi un messaggio"
+    />
+  </div>
+</template>
+```
+
+Notes:
+
+- **The prop moves an obligation, it does not cancel one.** `'container'` suppresses every focus
+  ring on the field, the browser's included — otherwise the native ring would simply replace the
+  one the component stopped drawing. A field left with no visible indicator anywhere is a
+  **WCAG 2.4.7 (Focus Visible)** failure. The `focus-within:` treatment on your box is the other
+  half of the prop, not decoration.
+- **The component cannot check that you honoured it**, which is why the default stays on `'field'`:
+  a caller who has never heard of the prop keeps a visible focus indicator.
+- **Use the prop, not `!important`.** Suppressing the outline from the call site takes
+  `!focus-visible:outline-none` — an override of the component's own styling, and the shape the
+  bare variant exists to remove.
+- **`'field'` and unset are identical.** Passing `'field'` explicitly changes nothing.
+- **It only applies to `variant="bare"`.** The default variant recolours its own border; setting
+  `focusAffordance` there emits a runtime warning and has no effect.
 
 ## Accessibility
 
 FzTextarea meets WCAG 2.1 AA standards:
 
 - **Focus indicator**: Custom blue border (`blue-600`) on focus replaces browser default outline. Error state maintains error border color on focus (`semantic-error-300`).
-- **Focus indicator in the `bare` variant**: with no border to recolour, the cue is *replaced*, not removed — a 2px `blue-600` `focus-visible` outline is drawn on the field itself. If your container draws its own focus treatment (e.g. `focus-within:` on the box) you can suppress it with `!focus-visible:outline-none`, but only ever in exchange for another visible indicator: dropping it outright fails WCAG 2.4.7.
+- **Focus indicator in the `bare` variant**: with no border to recolour, the cue is *replaced*, not removed — by default a 2px `blue-600` `focus-visible` outline is drawn on the field itself. If your container draws its own focus treatment, use `focusAffordance="container"` rather than an `!important` override; either way the indicator has to exist somewhere, because dropping it outright fails WCAG 2.4.7. See <a href="#focus-affordance-who-draws-the-ring">Focus Affordance</a>.
 - **ARIA attributes**: `aria-required`, `aria-invalid`, `aria-disabled` always present with string values ("true"/"false") for screen reader compatibility
 - **aria-describedby**: Links textarea to error or help message when present
 - **role="alert"**: Error messages are announced immediately by screen readers

--- a/apps/storybook/src/stories/form/Textarea.stories.ts
+++ b/apps/storybook/src/stories/form/Textarea.stories.ts
@@ -23,6 +23,12 @@ const meta = {
     variant: {
       control: 'select',
       options: ['default', 'bare']
+    },
+    focusAffordance: {
+      control: 'select',
+      options: ['field', 'container'],
+      description:
+        'Which element draws the focus indicator in the bare variant. `container` requires the caller to draw one on its own box.'
     }
   },
   args: {
@@ -95,7 +101,9 @@ const Error: TextareaStory = {
   },
   render: (args) => ({
     components: { FzTextarea },
-    setup() { return { args } },
+    setup() {
+      return { args }
+    },
     template: `<FzTextarea v-bind="args"><template #errorMessage>This is an error message</template></FzTextarea>`
   }),
   play: async ({ canvasElement, step }: PlayFunctionContext) => {
@@ -138,7 +146,9 @@ const Help: TextareaStory = {
   },
   render: (args) => ({
     components: { FzTextarea },
-    setup() { return { args } },
+    setup() {
+      return { args }
+    },
     template: `<FzTextarea v-bind="args"><template #helpText>This is a long long long long long long long long long long help message</template></FzTextarea>`
   }),
   play: async ({ canvasElement, step }: PlayFunctionContext) => {
@@ -258,11 +268,14 @@ const Disabled: TextareaStory = {
       await expect(textarea).toHaveValue(initialValue)
     })
 
-    await step('Verify update:modelValue is NOT called when typing in disabled textarea', async () => {
-      const textarea = canvas.getByLabelText(/This is a label/i) as HTMLTextAreaElement
-      await userEvent.type(textarea, 'test')
-      await expect(args['onUpdate:modelValue']).not.toHaveBeenCalled()
-    })
+    await step(
+      'Verify update:modelValue is NOT called when typing in disabled textarea',
+      async () => {
+        const textarea = canvas.getByLabelText(/This is a label/i) as HTMLTextAreaElement
+        await userEvent.type(textarea, 'test')
+        await expect(args['onUpdate:modelValue']).not.toHaveBeenCalled()
+      }
+    )
   }
 }
 
@@ -427,7 +440,9 @@ const HelpDisabled: TextareaStory = {
   },
   render: (args) => ({
     components: { FzTextarea },
-    setup() { return { args } },
+    setup() {
+      return { args }
+    },
     template: `<FzTextarea v-bind="args"><template #helpText>This help text should be greyed out</template></FzTextarea>`
   }),
   play: async ({ canvasElement, step }: PlayFunctionContext) => {
@@ -463,7 +478,9 @@ const RequiredWithHelp: TextareaStory = {
   },
   render: (args) => ({
     components: { FzTextarea },
-    setup() { return { args } },
+    setup() {
+      return { args }
+    },
     template: `<FzTextarea v-bind="args"><template #helpText>This field is mandatory</template></FzTextarea>`
   }),
   play: async ({ canvasElement, step }: PlayFunctionContext) => {
@@ -498,7 +515,9 @@ const ErrorWithHelpOnly: TextareaStory = {
   },
   render: (args) => ({
     components: { FzTextarea },
-    setup() { return { args } },
+    setup() {
+      return { args }
+    },
     template: `<FzTextarea v-bind="args"><template #helpText>Please fill out this field</template></FzTextarea>`
   }),
   play: async ({ canvasElement, step }: PlayFunctionContext) => {
@@ -566,8 +585,11 @@ const AutoHeight: TextareaStory = {
     await step('Verify typing triggers height adjustment', async () => {
       const textarea = canvas.getByLabelText(/This is a label/i) as HTMLTextAreaElement
       const initialHeight = textarea.offsetHeight
-      await userEvent.type(textarea, 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8')
-      await new Promise(r => setTimeout(r, 100))
+      await userEvent.type(
+        textarea,
+        'Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7\nLine 8'
+      )
+      await new Promise((r) => setTimeout(r, 100))
       await expect(textarea.style.height).toBeTruthy()
     })
   }
@@ -605,7 +627,7 @@ const AutoHeightWithMaxRows: TextareaStory = {
       const textarea = canvas.getByLabelText(/This is a label/i) as HTMLTextAreaElement
       const manyLines = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`).join('\n')
       await userEvent.type(textarea, manyLines)
-      await new Promise(r => setTimeout(r, 100))
+      await new Promise((r) => setTimeout(r, 100))
       await expect(textarea.style.overflowY).toBe('auto')
     })
   }
@@ -644,15 +666,18 @@ const AutoHeightBottomAnchored: TextareaStory = {
 
     await step('Verify textarea grows upward when typing', async () => {
       const textarea = canvas.getByLabelText(/This is a label/i) as HTMLTextAreaElement
-      const containerBottom = canvasElement.querySelector('.flex.flex-col.justify-end')!.getBoundingClientRect().bottom
+      const containerBottom = canvasElement
+        .querySelector('.flex.flex-col.justify-end')!
+        .getBoundingClientRect().bottom
       await userEvent.type(textarea, 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5')
-      await new Promise(r => setTimeout(r, 100))
-      const newContainerBottom = canvasElement.querySelector('.flex.flex-col.justify-end')!.getBoundingClientRect().bottom
+      await new Promise((r) => setTimeout(r, 100))
+      const newContainerBottom = canvasElement
+        .querySelector('.flex.flex-col.justify-end')!
+        .getBoundingClientRect().bottom
       await expect(newContainerBottom).toBeCloseTo(containerBottom, 0)
     })
   }
 }
-
 
 /**
  * The bare variant in the shape it was asked for: a single-line composer bar
@@ -771,10 +796,132 @@ const BareComposerBar: TextareaStory = {
   }
 }
 
+/**
+ * The same composer bar, with the focus indicator moved onto the box.
+ *
+ * `BareComposerBar` above draws the outline on the field. Inside a container
+ * with `px-10 py-8` that outline falls *within* the grey box and reads as a
+ * field inside a field. `focusAffordance="container"` hands the indicator over:
+ * the component draws none, and the box takes it with `focus-within:`.
+ *
+ * The prop moves an obligation rather than cancelling one — a field with no
+ * visible focus indicator fails WCAG 2.4.7 — so the `focus-within:` treatment
+ * on the box is not decoration, it is the other half of the prop.
+ */
+const BareComposerBarContainerFocus: TextareaStory = {
+  args: {
+    id: 'bare-composer-container-focus',
+    label: '',
+    variant: 'bare',
+    focusAffordance: 'container',
+    autoHeight: true,
+    maxRows: 6,
+    maxlength: 200,
+    placeholder: 'Scrivi un messaggio...',
+    'onUpdate:modelValue': fn()
+  },
+  render: (args) => ({
+    components: { FzTextarea, FzContainer, FzIconButton },
+    setup() {
+      const value = ref('')
+      return { args, value }
+    },
+    template: `
+      <FzContainer horizontal gap="xs" align-items="end">
+        <FzIconButton
+          icon-name="paperclip"
+          variant="invisible"
+          environment="frontoffice"
+          aria-label="Allega un documento"
+        />
+        <FzContainer
+          gap="none"
+          align-items="stretch"
+          class="min-h-[44px] w-[420px] justify-end gap-4 rounded bg-grey-100 px-10 py-8 text-sm leading-5 focus-within:outline focus-within:outline-2 focus-within:outline-blue-600"
+        >
+          <FzTextarea
+            v-bind="args"
+            :modelValue="value"
+            aria-label="Scrivi un messaggio"
+            @update:modelValue="args['onUpdate:modelValue']($event); value = $event"
+          />
+          <p class="self-end text-grey-500">{{ value.length }}/{{ args.maxlength }}</p>
+        </FzContainer>
+        <FzIconButton
+          icon-name="paper-plane"
+          variant="primary"
+          environment="frontoffice"
+          aria-label="Invia il messaggio"
+          :disabled="!value.length"
+        />
+      </FzContainer>
+    `
+  }),
+  play: async ({ canvasElement, step }: PlayFunctionContext) => {
+    const canvas = within(canvasElement)
+
+    await step('Verify the field draws no focus ring of its own', async () => {
+      const textarea = canvas.getByLabelText(/Scrivi un messaggio/i)
+      await expect(textarea).not.toHaveClass('focus-visible:outline-blue-600')
+      await expect(textarea).toHaveClass('outline-none')
+    })
+
+    await step('Verify the box draws the indicator once the field is focused', async () => {
+      const textarea = canvas.getByLabelText(/Scrivi un messaggio/i) as HTMLTextAreaElement
+      const box = textarea.closest('.bg-grey-100') as HTMLElement
+
+      await expect(getComputedStyle(box).outlineStyle).toBe('none')
+
+      textarea.focus()
+      await waitFor(async () => {
+        await expect(document.activeElement).toBe(textarea)
+      })
+
+      // The indicator is on the box, and it is a real computed outline —
+      // the point of the prop is that focus stays visible somewhere.
+      await waitFor(async () => {
+        const boxOutline = getComputedStyle(box)
+        await expect(boxOutline.outlineStyle).toBe('solid')
+        await expect(boxOutline.outlineWidth).toBe('2px')
+        await expect(boxOutline.outlineColor).not.toBe('rgba(0, 0, 0, 0)')
+      })
+      const boxOutlineColor = getComputedStyle(box).outlineColor
+
+      // ...and it is not doubled by a visible one on the field itself.
+      // `outline-none` is Tailwind's `2px solid transparent` rather than
+      // `outline: none` — deliberately, so the ring reappears in forced-colours
+      // mode — so transparency is what "draws nothing" means here.
+      const fieldOutline = getComputedStyle(textarea)
+      await expect(fieldOutline.outlineColor).toBe('rgba(0, 0, 0, 0)')
+      await expect(fieldOutline.outlineColor).not.toBe(boxOutlineColor)
+    })
+
+    await step('Verify the field still behaves like a bare composer', async () => {
+      const textarea = canvas.getByLabelText(/Scrivi un messaggio/i)
+      await expect(textarea).toHaveAttribute('rows', '1')
+      await expect(textarea).toHaveClass('bg-transparent')
+      await expect(textarea).not.toHaveClass('border-1')
+    })
+  }
+}
+
 export {
-  Default, Error, Help, Valid, Required, Disabled, Readonly,
-  ErrorWithValue, ValidWithValue, DisabledWithValue,
-  HelpDisabled, RequiredWithHelp, ErrorWithHelpOnly,
-  AutoHeight, AutoHeightWithMaxRows, AutoHeightBottomAnchored,
-  BareComposerBar
+  Default,
+  Error,
+  Help,
+  Valid,
+  Required,
+  Disabled,
+  Readonly,
+  ErrorWithValue,
+  ValidWithValue,
+  DisabledWithValue,
+  HelpDisabled,
+  RequiredWithHelp,
+  ErrorWithHelpOnly,
+  AutoHeight,
+  AutoHeightWithMaxRows,
+  AutoHeightBottomAnchored,
+  BareComposerBar,
+  BareComposerBarContainerFocus
 }

--- a/packages/textarea/src/FzTextarea.vue
+++ b/packages/textarea/src/FzTextarea.vue
@@ -17,7 +17,9 @@
  *   the visible field and owns the type — the shape a single-line composer bar needs.
  *   It keeps a visible focus indicator (a focus-visible outline replaces the default
  *   variant's border-colour cue) and starts on one row, growing with `autoHeight` up
- *   to `maxRows`.
+ *   to `maxRows`. Inside an already-padded box that outline lands within the box, so
+ *   `focusAffordance="container"` hands the indicator to the caller — which must then
+ *   draw one, or the field fails WCAG 2.4.7.
  *
  * @component
  * @example
@@ -70,6 +72,23 @@ watch(
   (maxRows) => {
     if (maxRows !== undefined && !props.autoHeight) {
       console.warn(`[FzTextarea] "maxRows" has no effect without "autoHeight" enabled.`)
+    }
+  },
+  { immediate: true }
+)
+
+/**
+ * `focusAffordance` is deliberately absent from `withDefaults`: leaving it
+ * `undefined` when unset is what lets a value set on the wrong variant be told
+ * apart from no value at all. `undefined` and `'field'` behave identically.
+ */
+watch(
+  () => props.focusAffordance,
+  (focusAffordance) => {
+    if (focusAffordance !== undefined && !isBare.value) {
+      console.warn(
+        `[FzTextarea] "focusAffordance" only applies to variant="bare". The default variant draws its focus cue on its own border.`
+      )
     }
   },
   { immediate: true }
@@ -273,10 +292,9 @@ const evaluateBareStateClasses = () => {
 /**
  * Base chrome of the field. The bare variant switches every box-drawing
  * declaration off — including the browser's own border, padding and background,
- * which would otherwise show through — and keeps a visible focus indicator by
- * replacing the default variant's border-colour cue with a focus-visible
- * outline drawn on the field itself. Removing it entirely would be a WCAG 2.4.7
- * failure.
+ * which would otherwise show through. The focus indicator is not part of this
+ * string for the bare variant: which element carries it is the caller's choice,
+ * resolved in `bareFocusClasses` below.
  *
  * It also sets no font size, so type is inherited from the container the same
  * way the box is: Tailwind's preflight gives a textarea `font-size: 100%` and
@@ -287,11 +305,32 @@ const evaluateBareStateClasses = () => {
 const baseClasses =
   'border-1 rounded p-10 placeholder:text-grey-300 block w-full outline-none focus:ring-0 focus:outline-none text-base min-w-[96px] min-h-[77px]'
 
-const bareClasses =
-  'border-0 p-0 bg-transparent placeholder:text-grey-300 block w-full min-w-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 focus-visible:rounded'
+const bareClasses = 'border-0 p-0 bg-transparent placeholder:text-grey-300 block w-full min-w-0'
+
+/**
+ * The focus indicator of the bare variant — and the one declaration a caller
+ * cannot make from the outside without `!important`.
+ *
+ * `'field'` (the default) draws a focus-visible outline on the textarea itself,
+ * standing in for the border-colour cue the default variant uses. Removing it
+ * with nothing in its place would be a WCAG 2.4.7 failure.
+ *
+ * `'container'` does not merely *omit* that outline: the browser's own
+ * `:focus-visible` ring would take its place, so it has to be suppressed as
+ * actively as the default variant suppresses it. The caller is then obliged to
+ * draw the indicator on the box it owns. That obligation is documented on the
+ * prop; the component has no way to check it was honoured, which is why the
+ * default stays on `'field'`.
+ */
+const bareFocusClasses = computed(() =>
+  props.focusAffordance === 'container'
+    ? 'outline-none focus:ring-0 focus:outline-none'
+    : 'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 focus-visible:rounded'
+)
 
 const classes = computed(() => [
   isBare.value ? bareClasses : baseClasses,
+  isBare.value ? bareFocusClasses.value : '',
   isBare.value ? evaluateBareStateClasses() : evaluateStateClasses(),
   props.autoHeight
     ? autoHeightResizeMap[effectiveResize.value]

--- a/packages/textarea/src/__tests__/FzTextarea.spec.ts
+++ b/packages/textarea/src/__tests__/FzTextarea.spec.ts
@@ -7,8 +7,8 @@ describe('FzTextarea', () => {
     it('should render with default props', () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
-        },
+          label: 'Test Label'
+        }
       })
       expect(wrapper.exists()).toBe(true)
       expect(wrapper.find('textarea').exists()).toBe(true)
@@ -17,8 +17,8 @@ describe('FzTextarea', () => {
     it('should render label when provided', () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
-        },
+          label: 'Test Label'
+        }
       })
       expect(wrapper.text()).toContain('Test Label')
       expect(wrapper.find('label').text()).toContain('Test Label')
@@ -33,8 +33,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          required: true,
-        },
+          required: true
+        }
       })
       expect(wrapper.find('label').text()).toContain('*')
     })
@@ -43,8 +43,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          placeholder: 'Enter text here',
-        },
+          placeholder: 'Enter text here'
+        }
       })
       expect(wrapper.find('textarea').attributes('placeholder')).toBe('Enter text here')
     })
@@ -53,8 +53,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          valid: true,
-        },
+          valid: true
+        }
       })
       const icon = wrapper.findComponent({ name: 'FzIcon' })
       expect(icon.exists()).toBe(true)
@@ -65,8 +65,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          valid: false,
-        },
+          valid: false
+        }
       })
       const icon = wrapper.findComponent({ name: 'FzIcon' })
       expect(icon.exists()).toBe(false)
@@ -76,11 +76,11 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          error: true,
+          error: true
         },
         slots: {
-          errorMessage: 'This field is required',
-        },
+          errorMessage: 'This field is required'
+        }
       })
       await wrapper.vm.$nextTick()
       expect(wrapper.text()).toContain('This field is required')
@@ -93,11 +93,11 @@ describe('FzTextarea', () => {
     it('should render help text when helpText slot is provided', async () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
+          label: 'Test Label'
         },
         slots: {
-          helpText: 'This is helpful text',
-        },
+          helpText: 'This is helpful text'
+        }
       })
       await wrapper.vm.$nextTick()
       expect(wrapper.text()).toContain('This is helpful text')
@@ -107,11 +107,11 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          error: false,
+          error: false
         },
         slots: {
-          errorMessage: 'This field is required',
-        },
+          errorMessage: 'This field is required'
+        }
       })
       await wrapper.vm.$nextTick()
       expect(wrapper.text()).not.toContain('This field is required')
@@ -122,10 +122,10 @@ describe('FzTextarea', () => {
     describe('size prop (deprecated)', () => {
       it('should always use text-base regardless of size prop', () => {
         const smWrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', size: 'sm' },
+          props: { label: 'Test Label', size: 'sm' }
         })
         const lgWrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', size: 'lg' },
+          props: { label: 'Test Label', size: 'lg' }
         })
         expect(smWrapper.find('textarea').classes()).toContain('text-base')
         expect(smWrapper.find('textarea').classes()).not.toContain('text-sm')
@@ -135,7 +135,7 @@ describe('FzTextarea', () => {
 
       it('should use text-base by default', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label' },
+          props: { label: 'Test Label' }
         })
         expect(wrapper.find('textarea').classes()).toContain('text-base')
       })
@@ -143,29 +143,25 @@ describe('FzTextarea', () => {
       it('should emit console.warn when size is not md', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', size: 'sm' },
+          props: { label: 'Test Label', size: 'sm' }
         })
-        expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('"size" prop is deprecated')
-        )
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"size" prop is deprecated'))
         warnSpy.mockRestore()
       })
 
       it('should emit console.warn when size is md (any value triggers warning)', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', size: 'md' },
+          props: { label: 'Test Label', size: 'md' }
         })
-        expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('"size" prop is deprecated')
-        )
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"size" prop is deprecated'))
         warnSpy.mockRestore()
       })
 
       it('should not emit console.warn when size is not provided', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label' },
+          props: { label: 'Test Label' }
         })
         expect(warnSpy).not.toHaveBeenCalled()
         warnSpy.mockRestore()
@@ -177,13 +173,13 @@ describe('FzTextarea', () => {
         ['none', 'resize-none'],
         ['vertical', 'resize-y'],
         ['horizontal', 'resize-x'],
-        ['all', 'resize'],
+        ['all', 'resize']
       ])('should apply %s resize classes', (resize, expectedClass) => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            resize: resize as 'none' | 'vertical' | 'horizontal' | 'all',
-          },
+            resize: resize as 'none' | 'vertical' | 'horizontal' | 'all'
+          }
         })
         expect(wrapper.find('textarea').classes()).toContain(expectedClass)
       })
@@ -191,8 +187,8 @@ describe('FzTextarea', () => {
       it('should default to all resize', () => {
         const wrapper = mount(FzTextarea, {
           props: {
-            label: 'Test Label',
-          },
+            label: 'Test Label'
+          }
         })
         expect(wrapper.find('textarea').classes()).toContain('resize')
       })
@@ -203,8 +199,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            disabled: true,
-          },
+            disabled: true
+          }
         })
         expect(wrapper.find('textarea').attributes('disabled')).toBeDefined()
       })
@@ -213,8 +209,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            disabled: true,
-          },
+            disabled: true
+          }
         })
         expect(wrapper.find('.cursor-not-allowed').exists()).toBe(true)
         expect(wrapper.find('label').classes()).toContain('text-grey-300')
@@ -226,8 +222,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            readonly: true,
-          },
+            readonly: true
+          }
         })
         expect(wrapper.find('textarea').attributes('readonly')).toBeDefined()
       })
@@ -236,8 +232,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            readonly: true,
-          },
+            readonly: true
+          }
         })
         expect(wrapper.find('label').classes()).toContain('text-grey-300')
       })
@@ -246,8 +242,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            readonly: true,
-          },
+            readonly: true
+          }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.classes()).toContain('bg-grey-100')
@@ -260,8 +256,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            readonly: true,
-          },
+            readonly: true
+          }
         })
         expect(wrapper.find('.cursor-not-allowed').exists()).toBe(true)
       })
@@ -272,8 +268,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            required: true,
-          },
+            required: true
+          }
         })
         expect(wrapper.find('textarea').attributes('required')).toBeDefined()
       })
@@ -282,8 +278,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            required: true,
-          },
+            required: true
+          }
         })
         expect(wrapper.find('label').text()).toContain('*')
       })
@@ -294,8 +290,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            error: true,
-          },
+            error: true
+          }
         })
         expect(wrapper.find('textarea').classes()).toContain('border-semantic-error-200')
         expect(wrapper.find('textarea').classes()).toContain('focus:border-semantic-error-300')
@@ -305,8 +301,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            error: false,
-          },
+            error: false
+          }
         })
         expect(wrapper.find('textarea').classes()).toContain('border-grey-300')
         expect(wrapper.find('textarea').classes()).toContain('focus:border-blue-600')
@@ -318,8 +314,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            valid: true,
-          },
+            valid: true
+          }
         })
         const icon = wrapper.findComponent({ name: 'FzIcon' })
         expect(icon.exists()).toBe(true)
@@ -331,8 +327,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            valid: true,
-          },
+            valid: true
+          }
         })
         expect(wrapper.find('textarea').classes()).toContain('pr-[38px]')
       })
@@ -343,8 +339,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            rows: 5,
-          },
+            rows: 5
+          }
         })
         expect(wrapper.find('textarea').attributes('rows')).toBe('5')
       })
@@ -355,8 +351,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            cols: 50,
-          },
+            cols: 50
+          }
         })
         expect(wrapper.find('textarea').attributes('cols')).toBe('50')
       })
@@ -367,8 +363,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            minlength: 10,
-          },
+            minlength: 10
+          }
         })
         expect(wrapper.find('textarea').attributes('minlength')).toBe('10')
       })
@@ -379,8 +375,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            maxlength: 100,
-          },
+            maxlength: 100
+          }
         })
         expect(wrapper.find('textarea').attributes('maxlength')).toBe('100')
       })
@@ -391,8 +387,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            id: 'test-textarea-id',
-          },
+            id: 'test-textarea-id'
+          }
         })
         expect(wrapper.find('textarea').attributes('id')).toBe('test-textarea-id')
         expect(wrapper.find('label').attributes('for')).toBe('test-textarea-id')
@@ -401,8 +397,8 @@ describe('FzTextarea', () => {
       it('should auto-generate id when id prop is not provided', () => {
         const wrapper = mount(FzTextarea, {
           props: {
-            label: 'Test Label',
-          },
+            label: 'Test Label'
+          }
         })
         const textarea = wrapper.find('textarea')
         const label = wrapper.find('label')
@@ -418,8 +414,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            name: 'test-textarea',
-          },
+            name: 'test-textarea'
+          }
         })
         expect(wrapper.find('textarea').attributes('name')).toBe('test-textarea')
       })
@@ -431,7 +427,7 @@ describe('FzTextarea', () => {
       const onBlur = vi.fn()
       const wrapper = mount(FzTextarea, {
         props: { label: 'Test Label' },
-        attrs: { onBlur },
+        attrs: { onBlur }
       })
       await wrapper.find('textarea').trigger('blur')
       expect(onBlur).toHaveBeenCalledTimes(1)
@@ -441,7 +437,7 @@ describe('FzTextarea', () => {
       const onFocus = vi.fn()
       const wrapper = mount(FzTextarea, {
         props: { label: 'Test Label' },
-        attrs: { onFocus },
+        attrs: { onFocus }
       })
       await wrapper.find('textarea').trigger('focus')
       expect(onFocus).toHaveBeenCalledTimes(1)
@@ -451,7 +447,7 @@ describe('FzTextarea', () => {
       const onPaste = vi.fn()
       const wrapper = mount(FzTextarea, {
         props: { label: 'Test Label' },
-        attrs: { onPaste },
+        attrs: { onPaste }
       })
       await wrapper.find('textarea').trigger('paste')
       expect(onPaste).toHaveBeenCalledTimes(1)
@@ -461,7 +457,7 @@ describe('FzTextarea', () => {
       const onKeydown = vi.fn()
       const wrapper = mount(FzTextarea, {
         props: { label: 'Test Label' },
-        attrs: { onKeydown },
+        attrs: { onKeydown }
       })
       await wrapper.find('textarea').trigger('keydown')
       expect(onKeydown).toHaveBeenCalledTimes(1)
@@ -469,7 +465,7 @@ describe('FzTextarea', () => {
 
     it('should emit update:modelValue when textarea value changes', async () => {
       const wrapper = mount(FzTextarea, {
-        props: { label: 'Test Label' },
+        props: { label: 'Test Label' }
       })
       const textarea = wrapper.find('textarea')
       await textarea.setValue('New value')
@@ -480,7 +476,7 @@ describe('FzTextarea', () => {
     it('should not apply $attrs to root element (inheritAttrs: false)', () => {
       const wrapper = mount(FzTextarea, {
         props: { label: 'Test Label' },
-        attrs: { 'data-custom': 'value' },
+        attrs: { 'data-custom': 'value' }
       })
       const root = wrapper.find('.fz-textarea')
       const textarea = wrapper.find('textarea')
@@ -492,7 +488,7 @@ describe('FzTextarea', () => {
   describe('Expose', () => {
     it('should expose textareaRef for programmatic focus', () => {
       const wrapper = mount(FzTextarea, {
-        props: { label: 'Test Label' },
+        props: { label: 'Test Label' }
       })
       expect(wrapper.vm.textareaRef).toBeDefined()
       expect(wrapper.vm.textareaRef).toBeInstanceOf(HTMLTextAreaElement)
@@ -505,8 +501,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            id: 'test-id',
-          },
+            id: 'test-id'
+          }
         })
         const textarea = wrapper.find('textarea')
         const label = wrapper.find('label')
@@ -518,7 +514,7 @@ describe('FzTextarea', () => {
 
       it('should not have aria-labelledby when label is not provided', () => {
         const wrapper = mount(FzTextarea, {
-          props: { id: 'test-id' },
+          props: { id: 'test-id' }
         })
         expect(wrapper.find('textarea').attributes('aria-labelledby')).toBeUndefined()
       })
@@ -527,8 +523,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            required: true,
-          },
+            required: true
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-required')).toBe('true')
       })
@@ -536,8 +532,8 @@ describe('FzTextarea', () => {
       it('should have aria-required="false" when not required', () => {
         const wrapper = mount(FzTextarea, {
           props: {
-            label: 'Test Label',
-          },
+            label: 'Test Label'
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-required')).toBe('false')
       })
@@ -546,11 +542,11 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            error: true,
+            error: true
           },
           slots: {
-            errorMessage: 'Error message',
-          },
+            errorMessage: 'Error message'
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-invalid')).toBe('true')
       })
@@ -558,8 +554,8 @@ describe('FzTextarea', () => {
       it('should have aria-invalid="false" when no error', () => {
         const wrapper = mount(FzTextarea, {
           props: {
-            label: 'Test Label',
-          },
+            label: 'Test Label'
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-invalid')).toBe('false')
       })
@@ -568,8 +564,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            disabled: true,
-          },
+            disabled: true
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-disabled')).toBe('true')
       })
@@ -577,8 +573,8 @@ describe('FzTextarea', () => {
       it('should have aria-disabled="false" when not disabled', () => {
         const wrapper = mount(FzTextarea, {
           props: {
-            label: 'Test Label',
-          },
+            label: 'Test Label'
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-disabled')).toBe('false')
       })
@@ -588,11 +584,11 @@ describe('FzTextarea', () => {
           props: {
             label: 'Test Label',
             id: 'test-id',
-            error: true,
+            error: true
           },
           slots: {
-            errorMessage: 'Error message',
-          },
+            errorMessage: 'Error message'
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-describedby')).toBe('test-id-error')
       })
@@ -601,11 +597,11 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            id: 'test-id',
+            id: 'test-id'
           },
           slots: {
-            helpText: 'Help message',
-          },
+            helpText: 'Help message'
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-describedby')).toBe('test-id-help')
       })
@@ -615,11 +611,11 @@ describe('FzTextarea', () => {
           props: {
             label: 'Test Label',
             id: 'test-id',
-            error: true,
+            error: true
           },
           slots: {
-            helpText: 'Help message',
-          },
+            helpText: 'Help message'
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-describedby')).toBe('test-id-help')
         expect(wrapper.text()).toContain('Help message')
@@ -628,8 +624,8 @@ describe('FzTextarea', () => {
       it('should not have aria-describedby when no error or help message', () => {
         const wrapper = mount(FzTextarea, {
           props: {
-            label: 'Test Label',
-          },
+            label: 'Test Label'
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-describedby')).toBeUndefined()
       })
@@ -639,12 +635,12 @@ describe('FzTextarea', () => {
           props: {
             label: 'Test Label',
             id: 'test-id',
-            error: true,
+            error: true
           },
           slots: {
             errorMessage: 'Error message',
-            helpText: 'Help message',
-          },
+            helpText: 'Help message'
+          }
         })
         expect(wrapper.find('textarea').attributes('aria-describedby')).toBe('test-id-error')
       })
@@ -655,11 +651,11 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            error: true,
+            error: true
           },
           slots: {
-            errorMessage: 'Error message',
-          },
+            errorMessage: 'Error message'
+          }
         })
         await wrapper.vm.$nextTick()
         const errorContainer = wrapper.find('[role="alert"]')
@@ -672,11 +668,11 @@ describe('FzTextarea', () => {
           props: {
             label: 'Test Label',
             id: 'test-id',
-            error: true,
+            error: true
           },
           slots: {
-            errorMessage: 'Error message',
-          },
+            errorMessage: 'Error message'
+          }
         })
         const errorContainer = wrapper.find('[role="alert"]')
         expect(errorContainer.attributes('id')).toBe('test-id-error')
@@ -686,11 +682,11 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            id: 'test-id',
+            id: 'test-id'
           },
           slots: {
-            helpText: 'Help message',
-          },
+            helpText: 'Help message'
+          }
         })
         const helpSpan = wrapper.find(`#test-id-help`)
         expect(helpSpan.exists()).toBe(true)
@@ -703,8 +699,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            valid: true,
-          },
+            valid: true
+          }
         })
         const icon = wrapper.findComponent({ name: 'FzIcon' })
         expect(icon.exists()).toBe(true)
@@ -715,11 +711,11 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            error: true,
+            error: true
           },
           slots: {
-            errorMessage: 'Error message',
-          },
+            errorMessage: 'Error message'
+          }
         })
         const errorIcon = wrapper
           .findAllComponents({ name: 'FzIcon' })
@@ -733,8 +729,8 @@ describe('FzTextarea', () => {
       it('should be focusable when not disabled', () => {
         const wrapper = mount(FzTextarea, {
           props: {
-            label: 'Test Label',
-          },
+            label: 'Test Label'
+          }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.attributes('disabled')).toBeUndefined()
@@ -745,8 +741,8 @@ describe('FzTextarea', () => {
         const wrapper = mount(FzTextarea, {
           props: {
             label: 'Test Label',
-            disabled: true,
-          },
+            disabled: true
+          }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.attributes('disabled')).toBeDefined()
@@ -758,8 +754,8 @@ describe('FzTextarea', () => {
     it('should apply static base classes to textarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
-        },
+          label: 'Test Label'
+        }
       })
       const textarea = wrapper.find('textarea')
       expect(textarea.classes()).toContain('border-1')
@@ -781,8 +777,8 @@ describe('FzTextarea', () => {
     it('should apply container classes with fz-textarea identifier', () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
-        },
+          label: 'Test Label'
+        }
       })
       const container = wrapper.find('.fz-textarea')
       expect(container.exists()).toBe(true)
@@ -797,8 +793,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          disabled: true,
-        },
+          disabled: true
+        }
       })
       expect(wrapper.find('.cursor-not-allowed').exists()).toBe(true)
       expect(wrapper.find('textarea').classes()).toContain('bg-grey-100')
@@ -811,8 +807,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          error: true,
-        },
+          error: true
+        }
       })
       expect(wrapper.find('textarea').classes()).toContain('border-semantic-error-200')
       expect(wrapper.find('textarea').classes()).toContain('focus:border-semantic-error-300')
@@ -822,8 +818,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          error: false,
-        },
+          error: false
+        }
       })
       expect(wrapper.find('textarea').classes()).toContain('border-grey-300')
       expect(wrapper.find('textarea').classes()).toContain('focus:border-blue-600')
@@ -833,8 +829,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          valid: true,
-        },
+          valid: true
+        }
       })
       expect(wrapper.find('textarea').classes()).toContain('pr-[38px]')
     })
@@ -842,8 +838,8 @@ describe('FzTextarea', () => {
     it('should apply font-normal text-base mb-0 to label (aligned with FzInput/FzSelect)', () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
-        },
+          label: 'Test Label'
+        }
       })
       const label = wrapper.find('label')
       expect(label.classes()).toContain('font-normal')
@@ -854,13 +850,13 @@ describe('FzTextarea', () => {
 
     it('should apply grey label when disabled or readonly', () => {
       const disabledWrapper = mount(FzTextarea, {
-        props: { label: 'Test Label', disabled: true },
+        props: { label: 'Test Label', disabled: true }
       })
       expect(disabledWrapper.find('label').classes()).toContain('text-grey-300')
       expect(disabledWrapper.find('label').classes()).not.toContain('text-grey-500')
 
       const readonlyWrapper = mount(FzTextarea, {
-        props: { label: 'Test Label', readonly: true },
+        props: { label: 'Test Label', readonly: true }
       })
       expect(readonlyWrapper.find('label').classes()).toContain('text-grey-300')
       expect(readonlyWrapper.find('label').classes()).not.toContain('text-grey-500')
@@ -869,11 +865,11 @@ describe('FzTextarea', () => {
     it('should apply font-normal text-base to help text', () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
+          label: 'Test Label'
         },
         slots: {
-          helpText: 'Help text',
-        },
+          helpText: 'Help text'
+        }
       })
       const helpSpan = wrapper.find('span')
       expect(helpSpan.classes()).toContain('font-normal')
@@ -885,11 +881,11 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          disabled: true,
+          disabled: true
         },
         slots: {
-          helpText: 'Help text',
-        },
+          helpText: 'Help text'
+        }
       })
       const helpSpan = wrapper.find('span')
       expect(helpSpan.classes()).toContain('text-grey-300')
@@ -901,8 +897,8 @@ describe('FzTextarea', () => {
     it('should handle undefined modelValue gracefully', () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
-        },
+          label: 'Test Label'
+        }
       })
       expect(wrapper.exists()).toBe(true)
       const textarea = wrapper.find('textarea')
@@ -912,8 +908,8 @@ describe('FzTextarea', () => {
     it('should handle empty string modelValue', async () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
-        },
+          label: 'Test Label'
+        }
       })
       await wrapper.find('textarea').setValue('')
       expect(wrapper.emitted('update:modelValue')).toBeTruthy()
@@ -924,8 +920,8 @@ describe('FzTextarea', () => {
       const longText = 'a'.repeat(1000)
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test Label',
-        },
+          label: 'Test Label'
+        }
       })
       await wrapper.find('textarea').setValue(longText)
       expect(wrapper.emitted('update:modelValue')).toBeTruthy()
@@ -936,8 +932,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          error: true,
-        },
+          error: true
+        }
       })
       await wrapper.vm.$nextTick()
       const errorContainer = wrapper.find('[role="alert"]')
@@ -948,12 +944,12 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          error: true,
+          error: true
         },
         slots: {
           errorMessage: 'Error message',
-          helpText: 'Help message',
-        },
+          helpText: 'Help message'
+        }
       })
       await wrapper.vm.$nextTick()
       expect(wrapper.text()).toContain('Error message')
@@ -965,11 +961,11 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           error: true,
-          disabled: true,
+          disabled: true
         },
         slots: {
-          errorMessage: 'Error on disabled',
-        },
+          errorMessage: 'Error on disabled'
+        }
       })
       await wrapper.vm.$nextTick()
       expect(wrapper.text()).toContain('Error on disabled')
@@ -982,11 +978,11 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          disabled: true,
+          disabled: true
         },
         slots: {
-          helpText: 'Help text',
-        },
+          helpText: 'Help text'
+        }
       })
       const helpSpan = wrapper.find('span')
       expect(helpSpan.classes()).toContain('text-grey-300')
@@ -998,11 +994,11 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          required: true,
+          required: true
         },
         slots: {
-          helpText: 'This field is mandatory',
-        },
+          helpText: 'This field is mandatory'
+        }
       })
       expect(wrapper.find('label').text()).toContain('*')
       expect(wrapper.text()).toContain('This field is mandatory')
@@ -1012,8 +1008,8 @@ describe('FzTextarea', () => {
     it('should handle special characters in label', () => {
       const wrapper = mount(FzTextarea, {
         props: {
-          label: 'Test & Label <with> "special" chars',
-        },
+          label: 'Test & Label <with> "special" chars'
+        }
       })
       expect(wrapper.find('label').text()).toContain('Test & Label <with> "special" chars')
     })
@@ -1023,8 +1019,8 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           minlength: 10,
-          maxlength: 100,
-        },
+          maxlength: 100
+        }
       })
       expect(wrapper.find('textarea').attributes('minlength')).toBe('10')
       expect(wrapper.find('textarea').attributes('maxlength')).toBe('100')
@@ -1036,8 +1032,8 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          id: 'snapshot-default',
-        },
+          id: 'snapshot-default'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1047,8 +1043,8 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-required',
-          required: true,
-        },
+          required: true
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1058,8 +1054,8 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-disabled',
-          disabled: true,
-        },
+          disabled: true
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1069,11 +1065,11 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-error',
-          error: true,
+          error: true
         },
         slots: {
-          errorMessage: 'This field is required',
-        },
+          errorMessage: 'This field is required'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1083,8 +1079,8 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-valid',
-          valid: true,
-        },
+          valid: true
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1093,11 +1089,11 @@ describe('FzTextarea', () => {
       const wrapper = mount(FzTextarea, {
         props: {
           label: 'Test Label',
-          id: 'snapshot-help',
+          id: 'snapshot-help'
         },
         slots: {
-          helpText: 'This is helpful text',
-        },
+          helpText: 'This is helpful text'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1107,8 +1103,8 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-readonly',
-          readonly: true,
-        },
+          readonly: true
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1118,8 +1114,8 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-sm',
-          size: 'sm',
-        },
+          size: 'sm'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1129,8 +1125,8 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-lg',
-          size: 'lg',
-        },
+          size: 'lg'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1152,11 +1148,11 @@ describe('FzTextarea', () => {
           rows: 5,
           cols: 50,
           minlength: 10,
-          maxlength: 100,
+          maxlength: 100
         },
         slots: {
-          helpText: 'Help text',
-        },
+          helpText: 'Help text'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1167,11 +1163,11 @@ describe('FzTextarea', () => {
           label: 'Test Label',
           id: 'snapshot-error-disabled',
           error: true,
-          disabled: true,
+          disabled: true
         },
         slots: {
-          errorMessage: 'Error on disabled',
-        },
+          errorMessage: 'Error on disabled'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1181,11 +1177,11 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-help-disabled',
-          disabled: true,
+          disabled: true
         },
         slots: {
-          helpText: 'Help text',
-        },
+          helpText: 'Help text'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1195,11 +1191,11 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-required-help',
-          required: true,
+          required: true
         },
         slots: {
-          helpText: 'Mandatory field',
-        },
+          helpText: 'Mandatory field'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1209,8 +1205,8 @@ describe('FzTextarea', () => {
         props: {
           label: 'Test Label',
           id: 'snapshot-auto-height',
-          autoHeight: true,
-        },
+          autoHeight: true
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1220,8 +1216,8 @@ describe('FzTextarea', () => {
         props: {
           id: 'snapshot-bare',
           variant: 'bare',
-          placeholder: 'Scrivi un messaggio...',
-        },
+          placeholder: 'Scrivi un messaggio...'
+        }
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
@@ -1231,7 +1227,7 @@ describe('FzTextarea', () => {
     describe('autoHeight prop', () => {
       it('should apply resize-x instead of resize when autoHeight is true (default resize=all)', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', autoHeight: true },
+          props: { label: 'Test Label', autoHeight: true }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.classes()).toContain('resize-x')
@@ -1241,28 +1237,28 @@ describe('FzTextarea', () => {
 
       it('should apply resize-none when autoHeight is true and resize=vertical', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', autoHeight: true, resize: 'vertical' },
+          props: { label: 'Test Label', autoHeight: true, resize: 'vertical' }
         })
         expect(wrapper.find('textarea').classes()).toContain('resize-none')
       })
 
       it('should apply resize-x when autoHeight is true and resize=horizontal', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', autoHeight: true, resize: 'horizontal' },
+          props: { label: 'Test Label', autoHeight: true, resize: 'horizontal' }
         })
         expect(wrapper.find('textarea').classes()).toContain('resize-x')
       })
 
       it('should apply resize-none when autoHeight is true and resize=none', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', autoHeight: true, resize: 'none' },
+          props: { label: 'Test Label', autoHeight: true, resize: 'none' }
         })
         expect(wrapper.find('textarea').classes()).toContain('resize-none')
       })
 
       it('should not change resize classes when autoHeight is false', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', autoHeight: false, resize: 'all' },
+          props: { label: 'Test Label', autoHeight: false, resize: 'all' }
         })
         expect(wrapper.find('textarea').classes()).toContain('resize')
       })
@@ -1272,7 +1268,7 @@ describe('FzTextarea', () => {
       it('should warn when maxRows is set without autoHeight', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', maxRows: 5 },
+          props: { label: 'Test Label', maxRows: 5 }
         })
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('"maxRows" has no effect without "autoHeight"')
@@ -1283,18 +1279,16 @@ describe('FzTextarea', () => {
       it('should not warn when maxRows is set with autoHeight', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', maxRows: 5, autoHeight: true },
+          props: { label: 'Test Label', maxRows: 5, autoHeight: true }
         })
-        expect(warnSpy).not.toHaveBeenCalledWith(
-          expect.stringContaining('"maxRows" has no effect')
-        )
+        expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('"maxRows" has no effect'))
         warnSpy.mockRestore()
       })
 
       it('should warn when autoHeight is true and resize has vertical component (all)', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', autoHeight: true, resize: 'all' },
+          props: { label: 'Test Label', autoHeight: true, resize: 'all' }
         })
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('Vertical resize is disabled when "autoHeight" is enabled')
@@ -1305,7 +1299,7 @@ describe('FzTextarea', () => {
       it('should warn when autoHeight is true and resize=vertical', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', autoHeight: true, resize: 'vertical' },
+          props: { label: 'Test Label', autoHeight: true, resize: 'vertical' }
         })
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('Vertical resize is disabled when "autoHeight" is enabled')
@@ -1316,7 +1310,7 @@ describe('FzTextarea', () => {
       it('should not warn when autoHeight is true and resize=horizontal', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', autoHeight: true, resize: 'horizontal' },
+          props: { label: 'Test Label', autoHeight: true, resize: 'horizontal' }
         })
         expect(warnSpy).not.toHaveBeenCalledWith(
           expect.stringContaining('Vertical resize is disabled')
@@ -1327,7 +1321,7 @@ describe('FzTextarea', () => {
       it('should not warn when autoHeight is true and resize=none', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', autoHeight: true, resize: 'none' },
+          props: { label: 'Test Label', autoHeight: true, resize: 'none' }
         })
         expect(warnSpy).not.toHaveBeenCalledWith(
           expect.stringContaining('Vertical resize is disabled')
@@ -1340,7 +1334,7 @@ describe('FzTextarea', () => {
       it('should set overflow-y hidden when autoHeight is true and no maxRows', async () => {
         const wrapper = mount(FzTextarea, {
           props: { label: 'Test Label', autoHeight: true },
-          attachTo: document.body,
+          attachTo: document.body
         })
         await wrapper.vm.$nextTick()
         const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
@@ -1351,7 +1345,7 @@ describe('FzTextarea', () => {
       it('should set style.height when autoHeight is true', async () => {
         const wrapper = mount(FzTextarea, {
           props: { label: 'Test Label', autoHeight: true },
-          attachTo: document.body,
+          attachTo: document.body
         })
         await wrapper.vm.$nextTick()
         const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
@@ -1361,7 +1355,7 @@ describe('FzTextarea', () => {
 
       it('should not set style.height when autoHeight is false', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label' },
+          props: { label: 'Test Label' }
         })
         const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
         expect(textarea.style.height).toBe('')
@@ -1369,12 +1363,11 @@ describe('FzTextarea', () => {
     })
   })
 
-
   describe('Bare variant', () => {
     describe('box removal', () => {
       it('should default to the boxed variant when variant is not provided', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label' },
+          props: { label: 'Test Label' }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.classes()).toContain('min-h-[77px]')
@@ -1383,7 +1376,7 @@ describe('FzTextarea', () => {
 
       it('should drop min-height, border, background and padding when variant is bare', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare' },
+          props: { label: 'Test Label', variant: 'bare' }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.classes()).not.toContain('min-h-[77px]')
@@ -1400,7 +1393,7 @@ describe('FzTextarea', () => {
 
       it('should keep the shared field basics when variant is bare', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare' },
+          props: { label: 'Test Label', variant: 'bare' }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.classes()).toContain('block')
@@ -1410,7 +1403,7 @@ describe('FzTextarea', () => {
 
       it('should set no font size when variant is bare, so type is inherited', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare' },
+          props: { label: 'Test Label', variant: 'bare' }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.classes()).not.toContain('text-base')
@@ -1419,7 +1412,7 @@ describe('FzTextarea', () => {
 
       it('should keep the fixed font size in the default variant', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label' },
+          props: { label: 'Test Label' }
         })
         expect(wrapper.find('textarea').classes()).toContain('text-base')
       })
@@ -1428,7 +1421,7 @@ describe('FzTextarea', () => {
     describe('focus visibility', () => {
       it('should replace the border focus cue with a focus-visible outline', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare' },
+          props: { label: 'Test Label', variant: 'bare' }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.classes()).toContain('focus-visible:outline')
@@ -1437,33 +1430,130 @@ describe('FzTextarea', () => {
         expect(textarea.classes()).not.toContain('focus:outline-none')
         expect(textarea.classes()).not.toContain('focus:border-blue-600')
       })
+
+      it('should draw the outline on the field when focusAffordance is field', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', focusAffordance: 'field' }
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).toContain('focus-visible:outline')
+        expect(textarea.classes()).toContain('focus-visible:outline-2')
+        expect(textarea.classes()).toContain('focus-visible:outline-offset-2')
+        expect(textarea.classes()).toContain('focus-visible:outline-blue-600')
+      })
+
+      it('should behave identically whether focusAffordance is unset or field', () => {
+        const unset = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare' }
+        })
+        const explicit = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', focusAffordance: 'field' }
+        })
+        expect(unset.find('textarea').classes().sort()).toEqual(
+          explicit.find('textarea').classes().sort()
+        )
+      })
+
+      /**
+       * The point of `'container'` is not that the outline is absent but that
+       * the browser's own focus ring is suppressed too — otherwise it would
+       * simply replace the one the component stopped drawing.
+       */
+      it('should suppress every focus ring when focusAffordance is container', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', focusAffordance: 'container' }
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).not.toContain('focus-visible:outline')
+        expect(textarea.classes()).not.toContain('focus-visible:outline-2')
+        expect(textarea.classes()).not.toContain('focus-visible:outline-offset-2')
+        expect(textarea.classes()).not.toContain('focus-visible:outline-blue-600')
+        expect(textarea.classes()).not.toContain('focus-visible:rounded')
+        expect(textarea.classes()).toContain('outline-none')
+        expect(textarea.classes()).toContain('focus:outline-none')
+      })
+
+      it('should keep the box off when focus is delegated to the container', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', focusAffordance: 'container' }
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).toContain('border-0')
+        expect(textarea.classes()).toContain('p-0')
+        expect(textarea.classes()).toContain('bg-transparent')
+        expect(textarea.classes()).not.toContain('min-h-[77px]')
+      })
+
+      it('should not warn when focusAffordance is used on the bare variant', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        mount(FzTextarea, {
+          props: { label: 'Test Label', variant: 'bare', focusAffordance: 'container' }
+        })
+        expect(warnSpy).not.toHaveBeenCalled()
+        warnSpy.mockRestore()
+      })
+    })
+
+    /**
+     * The constraint on LIB-2932: adding the prop must leave the default
+     * variant untouched, so a caller who never heard of it cannot lose its
+     * focus indicator.
+     */
+    describe('focusAffordance on the default variant', () => {
+      it('should warn that focusAffordance does not apply to the default variant', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        mount(FzTextarea, {
+          props: { label: 'Test Label', focusAffordance: 'container' }
+        })
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('"focusAffordance" only applies to variant="bare"')
+        )
+        warnSpy.mockRestore()
+      })
+
+      it('should keep the default variant focus cue whatever focusAffordance says', () => {
+        const wrapper = mount(FzTextarea, {
+          props: { label: 'Test Label', focusAffordance: 'container' }
+        })
+        const textarea = wrapper.find('textarea')
+        expect(textarea.classes()).toContain('focus:border-blue-600')
+        expect(textarea.classes()).toContain('border-1')
+        expect(textarea.classes()).toContain('min-h-[77px]')
+      })
+
+      it('should not warn when focusAffordance is left unset', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        mount(FzTextarea, { props: { label: 'Test Label' } })
+        expect(warnSpy).not.toHaveBeenCalled()
+        warnSpy.mockRestore()
+      })
     })
 
     describe('variant-dependent defaults', () => {
       it('should start on a single row when variant is bare', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare' },
+          props: { label: 'Test Label', variant: 'bare' }
         })
         expect(wrapper.find('textarea').attributes('rows')).toBe('1')
       })
 
       it('should honour an explicit rows value when variant is bare', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare', rows: 3 },
+          props: { label: 'Test Label', variant: 'bare', rows: 3 }
         })
         expect(wrapper.find('textarea').attributes('rows')).toBe('3')
       })
 
       it('should disable resize by default when variant is bare', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare' },
+          props: { label: 'Test Label', variant: 'bare' }
         })
         expect(wrapper.find('textarea').classes()).toContain('resize-none')
       })
 
       it('should honour an explicit resize value when variant is bare', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare', resize: 'horizontal' },
+          props: { label: 'Test Label', variant: 'bare', resize: 'horizontal' }
         })
         expect(wrapper.find('textarea').classes()).toContain('resize-x')
       })
@@ -1471,7 +1561,7 @@ describe('FzTextarea', () => {
       it('should not warn about vertical resize when bare defaults are used with autoHeight', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare', autoHeight: true },
+          props: { label: 'Test Label', variant: 'bare', autoHeight: true }
         })
         expect(warnSpy).not.toHaveBeenCalled()
         warnSpy.mockRestore()
@@ -1480,7 +1570,7 @@ describe('FzTextarea', () => {
       it('should still warn about vertical resize when bare opts into it with autoHeight', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
         mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare', autoHeight: true, resize: 'vertical' },
+          props: { label: 'Test Label', variant: 'bare', autoHeight: true, resize: 'vertical' }
         })
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining('Vertical resize is disabled when "autoHeight" is enabled')
@@ -1492,7 +1582,7 @@ describe('FzTextarea', () => {
     describe('states', () => {
       it('should grey the text without a background when disabled', () => {
         const wrapper = mount(FzTextarea, {
-          props: { label: 'Test Label', variant: 'bare', disabled: true },
+          props: { label: 'Test Label', variant: 'bare', disabled: true }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.classes()).toContain('text-grey-300')
@@ -1503,7 +1593,7 @@ describe('FzTextarea', () => {
       it('should keep error semantics without an error border', () => {
         const wrapper = mount(FzTextarea, {
           props: { label: 'Test Label', variant: 'bare', error: true },
-          slots: { errorMessage: 'This is an error' },
+          slots: { errorMessage: 'This is an error' }
         })
         const textarea = wrapper.find('textarea')
         expect(textarea.attributes('aria-invalid')).toBe('true')
@@ -1514,7 +1604,7 @@ describe('FzTextarea', () => {
       it('should keep label association and help text', () => {
         const wrapper = mount(FzTextarea, {
           props: { label: 'Test Label', variant: 'bare', id: 'bare-field' },
-          slots: { helpText: 'Some help' },
+          slots: { helpText: 'Some help' }
         })
         expect(wrapper.find('label').attributes('for')).toBe('bare-field')
         expect(wrapper.find('textarea').attributes('aria-describedby')).toBe('bare-field-help')
@@ -1529,7 +1619,7 @@ describe('FzTextarea', () => {
           paddingTop: '0px',
           paddingBottom: '0px',
           borderTopWidth: '0px',
-          borderBottomWidth: '0px',
+          borderBottomWidth: '0px'
         } as unknown as CSSStyleDeclaration)
 
         const wrapper = mount(FzTextarea, {
@@ -1538,9 +1628,9 @@ describe('FzTextarea', () => {
             variant: 'bare',
             autoHeight: true,
             maxRows: 3,
-            modelValue: '',
+            modelValue: ''
           },
-          attachTo: document.body,
+          attachTo: document.body
         })
 
         const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
@@ -1564,7 +1654,7 @@ describe('FzTextarea', () => {
           paddingTop: '0px',
           paddingBottom: '0px',
           borderTopWidth: '0px',
-          borderBottomWidth: '0px',
+          borderBottomWidth: '0px'
         } as unknown as CSSStyleDeclaration)
 
         const wrapper = mount(FzTextarea, {
@@ -1573,9 +1663,9 @@ describe('FzTextarea', () => {
             variant: 'bare',
             autoHeight: true,
             maxRows: 3,
-            modelValue: '',
+            modelValue: ''
           },
-          attachTo: document.body,
+          attachTo: document.body
         })
 
         const textarea = wrapper.find('textarea').element as HTMLTextAreaElement
@@ -1594,5 +1684,4 @@ describe('FzTextarea', () => {
       })
     })
   })
-
 })

--- a/packages/textarea/src/types.ts
+++ b/packages/textarea/src/types.ts
@@ -10,7 +10,16 @@
  * `bare` strips the component's own box (border, background, padding, minimum
  * height) so that the container around it can be the visible field.
  */
-type FzTextareaVariant = "default" | "bare";
+type FzTextareaVariant = 'default' | 'bare'
+
+/**
+ * Which element is responsible for the focus indicator of the `bare` variant.
+ *
+ * `field` keeps the indicator on the textarea; `container` hands the obligation
+ * to the caller's box. It is a transfer of responsibility, never a removal —
+ * see the `focusAffordance` prop.
+ */
+type FzTextareaFocusAffordance = 'field' | 'container'
 
 /**
  * Props for the FzTextarea component.
@@ -29,40 +38,40 @@ type FzTextareaProps = {
   /**
    * HTML id attribute. Falls back to auto-generated ID for label association.
    */
-  id?: string;
+  id?: string
   /**
    * Form field name for submission and identification
    */
-  name?: string;
+  name?: string
   /**
    * @deprecated Not part of the Figma design. Will be removed in the next major version.
    * The textarea always uses text-base (16px). This prop is accepted but ignored.
    */
-  size?: "sm" | "md" | "lg";
+  size?: 'sm' | 'md' | 'lg'
   /**
    * Text label displayed above the textarea. When omitted, no label element is rendered.
    */
-  label?: string;
+  label?: string
   /**
    * Marks field as required. Adds asterisk to label and sets native required attribute.
    * @default false
    */
-  required?: boolean;
+  required?: boolean
   /**
    * Placeholder text shown when textarea is empty
    */
-  placeholder?: string;
+  placeholder?: string
   /**
    * Enables error state with red border. Paired with errorMessage slot
    * to display error via FzAlert. Works with disabled (both states reflected in ARIA).
    * @default false
    */
-  error?: boolean;
+  error?: boolean
   /**
    * Disables interaction and applies muted styling
    * @default false
    */
-  disabled?: boolean;
+  disabled?: boolean
   /**
    * Visual variant of the field.
    *
@@ -82,40 +91,63 @@ type FzTextareaProps = {
    *   affordance on its own container.
    * @default 'default'
    */
-  variant?: FzTextareaVariant;
+  variant?: FzTextareaVariant
+  /**
+   * Which element draws the focus indicator, in the `bare` variant only.
+   *
+   * - `field` — the component draws a 2px `blue-600` `focus-visible` outline on
+   *   the textarea itself, standing in for the border-colour cue the `default`
+   *   variant uses. Nothing is required of the caller.
+   * - `container` — the component draws no focus indicator, and the caller
+   *   **must** draw one on the box it owns (typically `focus-within:` on that
+   *   box). Use this when the field sits inside a padded container, where an
+   *   outline on the field falls *inside* the box and reads as a field within a
+   *   field.
+   *
+   * This prop **moves** the obligation, it does not cancel it: a field with no
+   * visible focus indicator is a WCAG 2.4.7 (Focus Visible) failure. Pass
+   * `container` only together with a focus treatment on your own box — the
+   * component cannot verify that you did, which is why the default stays on
+   * `field`.
+   *
+   * Has no effect in the `default` variant, which recolours its own border; a
+   * runtime warning is emitted if set there.
+   * @default 'field'
+   */
+  focusAffordance?: FzTextareaFocusAffordance
   /**
    * Controls resize behavior of the textarea
    * @default 'all' — `'none'` when `variant="bare"`, where a resize grabber would
    * break the container that draws the field
    */
-  resize?: "none" | "vertical" | "horizontal" | "all";
+  resize?: 'none' | 'vertical' | 'horizontal' | 'all'
   /**
    * Number of visible text rows
    * @default 2 — `1` when `variant="bare"`, so a composer bar starts on a single line
    */
-  rows?: number;
+  rows?: number
   /**
    * Visible width in average character widths
    */
-  cols?: number;
+  cols?: number
   /**
    * Shows success checkmark icon when true
    * @default false
    */
-  valid?: boolean;
+  valid?: boolean
   /**
    * Native minlength constraint
    */
-  minlength?: number;
+  minlength?: number
   /**
    * Native maxlength constraint
    */
-  maxlength?: number;
+  maxlength?: number
   /**
    * Prevents editing while keeping field focusable and selectable
    * @default false
    */
-  readonly?: boolean;
+  readonly?: boolean
   /**
    * Enables automatic height adjustment based on content.
    * The textarea grows as the user types and shrinks when content is removed.
@@ -125,13 +157,13 @@ type FzTextareaProps = {
    * Must be set at mount time — changing at runtime is not supported.
    * @default false
    */
-  autoHeight?: boolean;
+  autoHeight?: boolean
   /**
    * Maximum number of visible rows before scrollbar appears.
    * Only effective when `autoHeight` is true; a runtime warning is
    * emitted if set without `autoHeight`.
    */
-  maxRows?: number;
-};
+  maxRows?: number
+}
 
-export { FzTextareaProps, FzTextareaVariant };
+export { FzTextareaProps, FzTextareaVariant, FzTextareaFocusAffordance }


### PR DESCRIPTION
Jira: [LIB-2932](https://fiscozen.atlassian.net/browse/LIB-2932)

`variant="bare"` (LIB-2927, shipped in 3.2.0) turns off the field's border, and replaces the
border-colour focus cue with a `focus-visible` outline drawn on the field itself. That outline
is offset from the **field**, so inside a container with padding of its own it lands *within*
the visible box — a field inside a field. The chat composer bar hits this with its `px-10 py-8`.

`focusAffordance` moves the indicator rather than removing it.

| Value | The component draws | The caller must draw |
|---|---|---|
| `'field'` *(default)* | a 2px `blue-600` outline on the textarea, offset 2px | nothing |
| `'container'` | nothing — the browser's native ring is suppressed too | a focus indicator on its own box |

## Why this needs a prop and not a class at the call site

`'container'` does not merely *omit* the outline. Drop the `focus-visible:outline-*` utilities
and the browser's own `:focus-visible` ring takes their place, so the outline has to be
suppressed as actively as the `default` variant suppresses it. From outside the component that
takes `!focus-visible:outline-none` — which is simultaneously the `!`-override the bare variant
exists to remove, and, as the previous code shipped it, the complete absence of a focus
indicator.

## The default does not move

The card's binding constraint. `'field'` is today's behaviour byte for byte, and a locked-in
test asserts that unset and `'field'` produce identical class lists. A caller who has never
heard of the prop cannot lose its focus indicator.

The prop **transfers a WCAG 2.4.7 (Focus Visible) obligation, it does not cancel it**, and the
component has no way to verify the caller honoured it — which is precisely why the default stays
where it is. The prop's own JSDoc, the MDX and the changeset all say plainly that removing the
indicator without replacing it is a violation.

It applies to `variant="bare"` only; on the `default` variant, which recolours its own border, it
warns and does nothing — the same idiom as the existing `maxRows`/`size` warnings.

## Verified in a browser, not assumed

The new `BareComposerBarContainerFocus` story asserts computed styles, and I looked at the pixels:

| | field outline | box outline |
|---|---|---|
| `'field'` (existing story) | `2px solid rgb(72, 88, 204)` | `none` |
| `'container'` (new story) | `2px solid rgba(0, 0, 0, 0)` | `2px solid rgb(72, 88, 204)` |

One ring, on the grey box, enclosing the field *and* the character counter — instead of a rounded
ring inside the box with the counter outside it.

Note the field's outline computes **transparent** rather than `none`: Tailwind's `outline-none` is
`2px solid transparent`, deliberately, so the ring returns in forced-colours mode. That is a
feature here, and it is why the story asserts on `outlineColor` rather than `outlineStyle` — my
first version of that assertion was wrong and the browser caught it.

## On the accessibility framing in the card

The card is right that this is **not** an accessibility defect today. I recomputed the contrast
from the real tokens rather than trusting it: `blue-600` `#4858cc` on `grey-100` `#e9edf0` is
**5.03:1**, so 2.4.7 and 1.4.11 both pass. What ships here is a coherence fix that makes the
correct accessible outcome reachable without an override.

## Checks

- `@fiscozen/textarea` unit tests: **140 pass** (9 new, covering both values, the unset/`'field'`
  equivalence, native-ring suppression, and the default-variant warning)
- Storybook play functions: **759 pass** across 68 files, in a real browser (pre-push)
- `vue-tsc --noEmit` clean
- Changeset present — minor bump of `@fiscozen/textarea`
- No existing variant, default or snapshot changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LIB-2932]: https://fiscozen.atlassian.net/browse/LIB-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ