### PR TITLE
chore(icons): LIB-2983 upgrade Font Awesome kit to 1.0.430

### DIFF
--- a/.changeset/fontawesome-kit-430.md
+++ b/.changeset/fontawesome-kit-430.md
@@ -1,0 +1,5 @@
+---
+'@fiscozen/icons': patch
+---
+
+chore: upgrade Font Awesome kit `@awesome.me/kit-8137893ad3` to 1.0.430 (18 new icons, none removed)

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -22,7 +22,7 @@
     "postinstall": "node scripts/postinstall-playwright.cjs"
   },
   "dependencies": {
-    "@awesome.me/kit-8137893ad3": "^1.0.421",
+    "@awesome.me/kit-8137893ad3": "^1.0.430",
     "@fiscozen/action": "workspace:^",
     "@fiscozen/actionlist": "workspace:^",
     "@fiscozen/alert": "workspace:^",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -38,7 +38,7 @@
     "vue-tsc": "^2.2.12"
   },
   "dependencies": {
-    "@awesome.me/kit-8137893ad3": "^1.0.421",
+    "@awesome.me/kit-8137893ad3": "^1.0.430",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/vue-fontawesome": "^3.1.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
   apps/storybook:
     dependencies:
       '@awesome.me/kit-8137893ad3':
-        specifier: ^1.0.421
-        version: 1.0.421
+        specifier: ^1.0.430
+        version: 1.0.430
       '@fiscozen/action':
         specifier: workspace:^
         version: link:../../packages/action
@@ -1864,8 +1864,8 @@ importers:
   packages/icons:
     dependencies:
       '@awesome.me/kit-8137893ad3':
-        specifier: ^1.0.421
-        version: 1.0.421
+        specifier: ^1.0.430
+        version: 1.0.430
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.7.2
         version: 6.7.2
@@ -3703,8 +3703,8 @@ packages:
   '@asamuzakjp/dom-selector@2.0.2':
     resolution: {integrity: sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==}
 
-  '@awesome.me/kit-8137893ad3@1.0.421':
-    resolution: {integrity: sha512-b0xEES+tTFzzRBXpByPVt2+eVUJ5fpGIVeSTakBkm4YixUhESzdNjFIvwcSXUr93tBg22WuVDBT9BpgHp4/ZSQ==}
+  '@awesome.me/kit-8137893ad3@1.0.430':
+    resolution: {integrity: sha512-/1Ded0SozrTgXwi63iVMvb8GrRg3cwAbuuk1k+m8WkK12tmXhL1cvioA2HfiKIS1QMOSFCqYnZRO4ICK6/e3ZQ==}
     engines: {node: '>=16'}
 
   '@babel/code-frame@7.29.0':
@@ -8840,8 +8840,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.9:
-    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
+  vue-component-type-helpers@3.3.11:
+    resolution: {integrity: sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -9065,7 +9065,7 @@ snapshots:
       css-tree: 2.3.1
       is-potential-custom-element-name: 1.0.1
 
-  '@awesome.me/kit-8137893ad3@1.0.421':
+  '@awesome.me/kit-8137893ad3@1.0.430':
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
 
@@ -10117,7 +10117,7 @@ snapshots:
       storybook: 10.3.3(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@5.7.3)
-      vue-component-type-helpers: 3.3.9
+      vue-component-type-helpers: 3.3.11
 
   '@tato30/vue-pdf@2.0.2(vue@3.5.26(typescript@5.7.3))':
     dependencies:
@@ -14606,7 +14606,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.9: {}
+  vue-component-type-helpers@3.3.11: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@5.7.3)):
     dependencies:


### PR DESCRIPTION
Jira: [LIB-2983](https://fiscozen.atlassian.net/browse/LIB-2983)

Bumps `@awesome.me/kit-8137893ad3` from 1.0.421 to 1.0.430 in the two packages that declare it — `@fiscozen/icons` and `apps/storybook` — plus the lockfile.

## Why it is safe

Diffing the classic icon-name exports between the two kit versions: **449 → 467 names, 18 added, 0 removed**. No `FzIcon` call site anywhere can break on a name that disappeared.

## Verification

- `@fiscozen/icons` unit tests: 75 passed
- Pre-commit: `test:unit` across 43 affected projects + full build of all 47 packages, including the Storybook build
- Pre-push: Storybook play-function suite, 758 passed / 3 skipped

## Out of scope

`packages/dialog` still pins `@fortawesome/fontawesome-svg-core@^6.5.1` and `@fortawesome/vue-fontawesome@^3.0.6`, against `^6.7.2` / `^3.1.1` in `@fiscozen/icons`. Aligning those is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LIB-2983]: https://fiscozen.atlassian.net/browse/LIB-2983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ